### PR TITLE
Graphsync user can make request to the network

### DIFF
--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -9,6 +9,7 @@ package "go-ipld-prime" {
   }
   interface Path {
   }
+  interface Link
   package traversal {
     package selector {
       interface Selector {
@@ -28,32 +29,27 @@ package "go-ipld-prime" {
     TraversalProgress *-- TraversalConfig
   }
 
-  package repose {
-    interface RawLoader {
-    }
-
-    interface MulticodecDecodeTable {
-    }
-
-    interface NodeBuilderChooser {
-    }
-
-    interface LinkLoader {
-    }
-
-    object "Package Public Functions" as goIPLDReposePf {
-      ComposeLinkLoader(RawLoader, NodeBuilderChooser, MulticodecDecodeTable)
-      EncoderDagCbor(Node, io.Writer)
-      DecodeDagCbor(NodeBuilder, io.Writer)
-    }  
-  }
+  interface Loader {}
 }
 
 package "go-graphsync" {
   
+    class ResponseProgress {
+      Node ipld.Node
+      Path ipld.Path
+      LastBlock struct {
+        ipld.Node
+        ipld.Link
+      }
+    }
+    
+    interface Cid2BlockFn {
+
+    }
     class GraphSync {
-      Request(ctx context.Context, p peer.ID, cidRootedSelector Node) (chan ResponseProgress, chan ResponseError)
-      ReceiveMessage(ctx context.Context, sender peer.ID, incoming GraphSyncMessage)
+      Request(ctx context.Context, p peer.ID, rootedSelector Node) (chan ResponseProgress, chan error)
+      GetBlocks(ctx context.Context, p peer.ID, rootedSelector Node) (chan blocks.Block, chan error)
+      ReceiveMessage(ctx context.Context, sender peer.ID, incoming GraphSyncMessage)     
       ReceiveError(error)
     }
 
@@ -186,12 +182,11 @@ package "go-graphsync" {
 
   package ipldbridge {
     interface IPLDBridge {
-      ComposeLinkLoader(actualLoader RawLoader) LinkLoader
-	    ValidateSelectorSpec(cidRootedSelector ipld.Node) []error
+	    ValidateSelectorSpec(rootedSelector ipld.Node) []error
 	    EncodeNode(ipld.Node) ([]byte, error)
 	    DecodeNode([]byte) (ipld.Node, error)
 	    DecodeSelectorSpec(cidRootedSelector ipld.Node) (ipld.Node, Selector, error)
-	    Traverse(ctx context.Context, loader LinkLoader, root ipld.Node, s Selector, fn AdvVisitFn) error
+	    Traverse(ctx context.Context, loader Loader, root ipld.Node, s Selector, fn AdvVisitFn) error
     }
 
     GraphSync *-- IPLDBridge
@@ -202,7 +197,7 @@ package "go-graphsync" {
     }
 
     object "PackagePublicFunctions" as goIPLDBridge {
-      NewIPLDBridge(nodeBuilderChooser NodeBuilderChooser, multicodecTable MulticodecDecodeTable) IPLDBridge
+      NewIPLDBridge() IPLDBridge
     }
 
     IPLDBridge <|-- ipldBridge
@@ -214,7 +209,9 @@ package "go-graphsync" {
     ipldBridge .. goIPLDReposePf
   }
   object "PackagePublicFunctions" as goGraphsyncPf {
-    New(ctx context.Context, network GraphSyncNetwork, rawLoader RawLoader, multicodecDecodeTable MulticodecDecodeTable, nodeBuilderChooser NodeBuilderChooser) GraphSync
+    New(ctx context.Context, network GraphSyncNetwork, loader Loader) GraphSync
+    LoaderFromCid2BlockFn(cid2BlockFn Cid2BlockFn) Loader
+    SelectorSpecFromCidAndPath(lnk cid.Cid, pathSegments []string) (ipld.Node, error) 
   }
 }
 

--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -209,7 +209,7 @@ package "go-graphsync" {
     ipldBridge .. goIPLDReposePf
   }
   object "PackagePublicFunctions" as goGraphsyncPf {
-    New(ctx context.Context, network GraphSyncNetwork, loader Loader) GraphSync
+    New(ctx context.Context, network GraphSyncNetwork, ipldBridge IPLDBridge, loader Loader) GraphSync
     LoaderFromCid2BlockFn(cid2BlockFn Cid2BlockFn) Loader
     SelectorSpecFromCidAndPath(lnk cid.Cid, pathSegments []string) (ipld.Node, error) 
   }

--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -29,7 +29,9 @@ package "go-ipld-prime" {
     TraversalProgress *-- TraversalConfig
   }
 
-  interface Loader {}
+  interface Loader {
+
+  }
 }
 
 package "go-graphsync" {
@@ -39,8 +41,7 @@ package "go-graphsync" {
       Path ipld.Path
       LastBlock struct {
         ipld.Node
-        ipld.Link
-      }
+        ipld.Link }
     }
     
     interface Cid2BlockFn {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/ipfs/go-cid v0.0.1
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/ipld/go-ipld-prime v0.0.0-20190306022502-066284669cf6
+	github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-host v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,10 @@ github.com/ipld/go-ipld-prime v0.0.0-20190227132703-aaea73ad73c5 h1:Fm+tk5iaitTL
 github.com/ipld/go-ipld-prime v0.0.0-20190227132703-aaea73ad73c5/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
 github.com/ipld/go-ipld-prime v0.0.0-20190306022502-066284669cf6 h1:FJW7rDl8g/580E6ZuR5rXzDT/9SsJvCuAEQCq8cbdPQ=
 github.com/ipld/go-ipld-prime v0.0.0-20190306022502-066284669cf6/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
+github.com/ipld/go-ipld-prime v0.0.0-20190316215235-adc089c2d3fb h1:pBiRTPGX6V8HXQYbKMCuetYgnALxdVZLeBzImJbErbk=
+github.com/ipld/go-ipld-prime v0.0.0-20190316215235-adc089c2d3fb/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
+github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db h1:/6+Pat3+xFjSaBHudbUm+KFyf/11JLuMHGM2dGVNkHc=
+github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
 github.com/jackpal/gateway v1.0.4 h1:LS5EHkLuQ6jzaHwULi0vL+JO0mU/n4yUtK8oUjHHOlM=
 github.com/jackpal/gateway v1.0.4/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=

--- a/graphsync.go
+++ b/graphsync.go
@@ -1,0 +1,65 @@
+package graphsync
+
+import (
+	"context"
+
+	"github.com/ipfs/go-graphsync/messagequeue"
+	"github.com/ipfs/go-graphsync/peermanager"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/requestmanager"
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+// ResponseProgress is the fundamental unit of responses making progress in
+// Graphsync.
+type ResponseProgress = requestmanager.ResponseProgress
+
+// ResponseError is an error that occurred during a traversal.
+type ResponseError = requestmanager.ResponseError
+
+// GraphSync is an instance of a GraphSync exchange that implements
+// the graphsync protocol.
+type GraphSync struct {
+	ipldBridge     ipldbridge.IPLDBridge
+	network        gsnet.GraphSyncNetwork
+	loader         ipldbridge.Loader
+	requestManager *requestmanager.RequestManager
+	peerManager    *peermanager.PeerManager
+	ctx            context.Context
+	cancel         context.CancelFunc
+}
+
+// New creates a new GraphSync Exchange on the given network,
+// using the given bridge to IPLD and the given link loader.
+func New(parent context.Context, network gsnet.GraphSyncNetwork,
+	ipldBridge ipldbridge.IPLDBridge, loader ipldbridge.Loader) *GraphSync {
+	ctx, cancel := context.WithCancel(parent)
+
+	createMessageQueue := func(ctx context.Context, p peer.ID) peermanager.PeerQueue {
+		return messagequeue.New(ctx, p, network)
+	}
+	peerManager := peermanager.New(ctx, createMessageQueue)
+	requestManager := requestmanager.New(ctx, ipldBridge)
+	graphSync := &GraphSync{
+		ipldBridge:     ipldBridge,
+		network:        network,
+		loader:         loader,
+		requestManager: requestManager,
+		peerManager:    peerManager,
+		ctx:            ctx,
+		cancel:         cancel,
+	}
+
+	requestManager.SetDelegate(peerManager)
+	requestManager.Startup()
+
+	return graphSync
+}
+
+// Request initiates a new GraphSync request to the given peer using the given selector spec.
+func (gs *GraphSync) Request(ctx context.Context, p peer.ID, rootedSelector ipld.Node) (<-chan ResponseProgress, <-chan ResponseError) {
+	return gs.requestManager.SendRequest(ctx, p, rootedSelector)
+}

--- a/graphsync_test.go
+++ b/graphsync_test.go
@@ -1,0 +1,109 @@
+package graphsync
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/testbridge"
+	"github.com/ipfs/go-graphsync/testutil"
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-peer"
+	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+)
+
+// Receiver is an interface for receiving messages from the GraphSyncNetwork.
+type receiver struct {
+	messageReceived chan struct{}
+	lastMessage     gsmsg.GraphSyncMessage
+	lastSender      peer.ID
+}
+
+func (r *receiver) ReceiveMessage(
+	ctx context.Context,
+	sender peer.ID,
+	incoming gsmsg.GraphSyncMessage) {
+	r.lastSender = sender
+	r.lastMessage = incoming
+	select {
+	case <-ctx.Done():
+	case r.messageReceived <- struct{}{}:
+	}
+}
+
+func (r *receiver) ReceiveError(err error) {
+}
+
+func TestMakeRequestToNetwork(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	mn := mocknet.New(ctx)
+
+	// setup network
+	host1, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	host2, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	err = mn.LinkAll()
+	if err != nil {
+		t.Fatal("error linking hosts")
+	}
+
+	gsnet1 := gsnet.NewFromLibp2pHost(host1)
+
+	// setup receiving peer to just record message coming in
+	gsnet2 := gsnet.NewFromLibp2pHost(host2)
+	r := &receiver{
+		messageReceived: make(chan struct{}),
+	}
+	gsnet2.SetDelegate(r)
+
+	loader := func(ipldLink ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
+		return nil, fmt.Errorf("unable to load block")
+	}
+	bridge := testbridge.NewMockIPLDBridge()
+	graphSync := New(ctx, gsnet1, bridge, loader)
+
+	cids := testutil.GenerateCids(5)
+	spec := testbridge.NewMockSelectorSpec(cids)
+	requestCtx, requestCancel := context.WithCancel(ctx)
+	defer requestCancel()
+	graphSync.Request(requestCtx, host2.ID(), spec)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("did not receive message sent")
+	case <-r.messageReceived:
+	}
+
+	sender := r.lastSender
+	if sender != host1.ID() {
+		t.Fatal("received message from wrong node")
+	}
+
+	received := r.lastMessage
+	receivedRequests := received.Requests()
+	if len(receivedRequests) != 1 {
+		t.Fatal("Did not add request to received message")
+	}
+	receivedRequest := receivedRequests[0]
+	receivedSpec, err := bridge.DecodeNode(receivedRequest.Selector())
+	if err != nil {
+		t.Fatal("unable to decode transmitted selector")
+	}
+	if !reflect.DeepEqual(spec, receivedSpec) {
+		t.Fatal("did not transmit selector spec correctly")
+	}
+}

--- a/ipldbridge/ipldbridge.go
+++ b/ipldbridge/ipldbridge.go
@@ -4,22 +4,12 @@ import (
 	"context"
 
 	ipld "github.com/ipld/go-ipld-prime"
-	ipldrepose "github.com/ipld/go-ipld-prime/repose"
 	ipldtraversal "github.com/ipld/go-ipld-prime/traversal"
 	ipldselector "github.com/ipld/go-ipld-prime/traversal/selector"
 )
 
-// MulticodecDecodeTable is an alias from ipld, in case it's renamed/moved.
-type MulticodecDecodeTable = ipldrepose.MulticodecDecodeTable
-
-// NodeBuilderChooser is an an alias from ipld, in case it's renamed/moved.
-type NodeBuilderChooser = ipldrepose.NodeBuilderChooser
-
-// LinkLoader is alias from ipld, in case it.s renamed/moved.
-type LinkLoader = ipldtraversal.LinkLoader
-
-// RawLoader is an alias from ipld, in case it's renamed/moved.
-type RawLoader = ipldrepose.ActualLoader
+// Loader is an alias from ipld, in case it's renamed/moved.
+type Loader = ipld.Loader
 
 // AdvVisitFn is an alias from ipld, in case it's renamed/moved.
 type AdvVisitFn = ipldtraversal.AdvVisitFn
@@ -28,7 +18,7 @@ type AdvVisitFn = ipldtraversal.AdvVisitFn
 type Selector = ipldselector.Selector
 
 // LinkContext is an alias from ipld, in case it's renamed/moved.
-type LinkContext = ipldtraversal.LinkContext
+type LinkContext = ipld.LinkContext
 
 // TraversalProgress is an alias from ipld, in case it's renamed/moved.
 type TraversalProgress = ipldtraversal.TraversalProgress
@@ -39,11 +29,9 @@ type TraversalReason = ipldtraversal.TraversalReason
 // IPLDBridge is an interface for making calls to IPLD, which can be
 // replaced with alternative implementations
 type IPLDBridge interface {
-	// ComposeLinkLoader converts a raw block loader into an IPLD node loader.
-	ComposeLinkLoader(actualLoader RawLoader) LinkLoader
 
 	// ValidateSelectorSpec verifies if a node matches the selector spec.
-	ValidateSelectorSpec(cidRootedSelector ipld.Node) []error
+	ValidateSelectorSpec(rootedSelector ipld.Node) []error
 
 	// EncodeNode encodes an IPLD Node to bytes for network transfer.
 	EncodeNode(ipld.Node) ([]byte, error)
@@ -53,10 +41,10 @@ type IPLDBridge interface {
 
 	// DecodeSelectorSpec checks if a generic IPLD node is a selector spec,
 	// and if so, converts it to a root node and a go-ipld-prime Selector.
-	DecodeSelectorSpec(cidRootedSelector ipld.Node) (ipld.Node, Selector, error)
+	DecodeSelectorSpec(rootedSelector ipld.Node) (ipld.Node, Selector, error)
 
 	// Traverse performs a selector traversal, starting at a given root, using the given selector,
 	// and the given link loader. The given visit function will be called for each node
 	// visited.
-	Traverse(ctx context.Context, loader LinkLoader, root ipld.Node, s Selector, fn AdvVisitFn) error
+	Traverse(ctx context.Context, loader Loader, root ipld.Node, s Selector, fn AdvVisitFn) error
 }

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -20,14 +20,7 @@ import (
 type ResponseProgress = blocks.Block
 
 // ResponseError is an error that occurred during a traversal.
-// It can be either a "non-terminal" error -- meaning progress will
-// continue to happen in the future.
-// or it can be a terminal error, meaning no further progress or errors
-// will emit.
-type ResponseError struct {
-	IsTerminal bool
-	Error      error
-}
+type ResponseError error
 
 const (
 	// maxPriority is the max priority as defined by the bitswap protocol
@@ -155,7 +148,7 @@ func (rm *RequestManager) singleErrorResponse(err error) (chan ResponseProgress,
 	ch := make(chan ResponseProgress)
 	close(ch)
 	errCh := make(chan ResponseError, 1)
-	errCh <- ResponseError{true, err}
+	errCh <- err
 	close(errCh)
 	return ch, errCh
 }
@@ -317,14 +310,14 @@ func (prm *processResponseMessage) handle(rm *RequestManager) {
 func (rm *RequestManager) generateResponseErrorFromStatus(status gsmsg.GraphSyncResponseStatusCode) ResponseError {
 	switch status {
 	case gsmsg.RequestFailedBusy:
-		return ResponseError{true, fmt.Errorf("Request Failed - Peer Is Busy")}
+		return fmt.Errorf("Request Failed - Peer Is Busy")
 	case gsmsg.RequestFailedContentNotFound:
-		return ResponseError{true, fmt.Errorf("Request Failed - Content Not Found")}
+		return fmt.Errorf("Request Failed - Content Not Found")
 	case gsmsg.RequestFailedLegal:
-		return ResponseError{true, fmt.Errorf("Request Failed - For Legal Reasons")}
+		return fmt.Errorf("Request Failed - For Legal Reasons")
 	case gsmsg.RequestFailedUnknown:
-		return ResponseError{true, fmt.Errorf("Request Failed - Unknown Reason")}
+		return fmt.Errorf("Request Failed - Unknown Reason")
 	default:
-		return ResponseError{}
+		return fmt.Errorf("Unknown")
 	}
 }

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -79,7 +79,7 @@ func readNBlocks(ctx context.Context, t *testing.T, blocksChan <-chan ResponsePr
 func verifySingleTerminalError(ctx context.Context, t *testing.T, errChan <-chan ResponseError) {
 	select {
 	case err := <-errChan:
-		if err.Error == nil || err.IsTerminal != true {
+		if err == nil {
 			t.Fatal("should have sent a erminal error but did not")
 		}
 	case <-ctx.Done():

--- a/requestmanager/responsecollector.go
+++ b/requestmanager/responsecollector.go
@@ -44,7 +44,7 @@ func (rc *responseCollector) collectResponses(
 		}
 		nextError := func() ResponseError {
 			if len(receivedErrors) == 0 {
-				return ResponseError{}
+				return nil
 			}
 			return receivedErrors[0]
 		}

--- a/requestmanager/responsecollector_test.go
+++ b/requestmanager/responsecollector_test.go
@@ -34,8 +34,8 @@ func TestBufferingResponseProgress(t *testing.T) {
 		}
 	}
 
-	interimError := ResponseError{false, fmt.Errorf("A block was missing")}
-	terminalError := ResponseError{true, fmt.Errorf("Something terrible happened")}
+	interimError := fmt.Errorf("A block was missing")
+	terminalError := fmt.Errorf("Something terrible happened")
 	select {
 	case <-ctx.Done():
 		t.Fatal("should have written error to channel but didn't")

--- a/testbridge/mockbuilder.go
+++ b/testbridge/mockbuilder.go
@@ -1,0 +1,21 @@
+package testbridge
+
+import (
+	"fmt"
+
+	ipld "github.com/ipld/go-ipld-prime"
+)
+
+type mockBuilder struct{}
+
+func (m *mockBuilder) CreateMap() (ipld.MapBuilder, error)     { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) AmendMap() (ipld.MapBuilder, error)      { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateList() (ipld.ListBuilder, error)   { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) AmendList() (ipld.ListBuilder, error)    { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateNull() (ipld.Node, error)          { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateBool(bool) (ipld.Node, error)      { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateInt(int) (ipld.Node, error)        { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateFloat(float64) (ipld.Node, error)  { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateString(string) (ipld.Node, error)  { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateBytes([]byte) (ipld.Node, error)   { return nil, fmt.Errorf("Invalid") }
+func (m *mockBuilder) CreateLink(ipld.Link) (ipld.Node, error) { return nil, fmt.Errorf("Invalid") }

--- a/testbridge/mocknodes.go
+++ b/testbridge/mocknodes.go
@@ -42,14 +42,15 @@ func (mss *mockSelectorSpec) Keys() ipld.KeyIterator { return &mockKeyIterator{}
 func (mss *mockSelectorSpec) KeysImmediate() ([]string, error) {
 	return nil, fmt.Errorf("404")
 }
-func (mss *mockSelectorSpec) Length() int               { return 0 }
-func (mss *mockSelectorSpec) IsNull() bool              { return true }
-func (mss *mockSelectorSpec) AsBool() (bool, error)     { return false, fmt.Errorf("404") }
-func (mss *mockSelectorSpec) AsInt() (int, error)       { return 0, fmt.Errorf("404") }
-func (mss *mockSelectorSpec) AsFloat() (float64, error) { return 0.0, fmt.Errorf("404") }
-func (mss *mockSelectorSpec) AsString() (string, error) { return "", fmt.Errorf("404") }
-func (mss *mockSelectorSpec) AsBytes() ([]byte, error)  { return nil, fmt.Errorf("404") }
-func (mss *mockSelectorSpec) AsLink() (cid.Cid, error)  { return cid.Cid{}, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) Length() int                   { return 0 }
+func (mss *mockSelectorSpec) IsNull() bool                  { return true }
+func (mss *mockSelectorSpec) AsBool() (bool, error)         { return false, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) AsInt() (int, error)           { return 0, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) AsFloat() (float64, error)     { return 0.0, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) AsString() (string, error)     { return "", fmt.Errorf("404") }
+func (mss *mockSelectorSpec) AsBytes() ([]byte, error)      { return nil, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) AsLink() (ipld.Link, error)    { return nil, fmt.Errorf("404") }
+func (mss *mockSelectorSpec) NodeBuilder() ipld.NodeBuilder { return &mockBuilder{} }
 
 type mockKeyIterator struct {
 }
@@ -77,11 +78,12 @@ func (mbn *mockBlockNode) Keys() ipld.KeyIterator { return &mockKeyIterator{} }
 func (mbn *mockBlockNode) KeysImmediate() ([]string, error) {
 	return nil, fmt.Errorf("404")
 }
-func (mbn *mockBlockNode) Length() int               { return 0 }
-func (mbn *mockBlockNode) IsNull() bool              { return false }
-func (mbn *mockBlockNode) AsBool() (bool, error)     { return false, fmt.Errorf("404") }
-func (mbn *mockBlockNode) AsInt() (int, error)       { return 0, fmt.Errorf("404") }
-func (mbn *mockBlockNode) AsFloat() (float64, error) { return 0.0, fmt.Errorf("404") }
-func (mbn *mockBlockNode) AsString() (string, error) { return "", fmt.Errorf("404") }
-func (mbn *mockBlockNode) AsBytes() ([]byte, error)  { return mbn.data, nil }
-func (mbn *mockBlockNode) AsLink() (cid.Cid, error)  { return cid.Cid{}, fmt.Errorf("404") }
+func (mbn *mockBlockNode) Length() int                   { return 0 }
+func (mbn *mockBlockNode) IsNull() bool                  { return false }
+func (mbn *mockBlockNode) AsBool() (bool, error)         { return false, fmt.Errorf("404") }
+func (mbn *mockBlockNode) AsInt() (int, error)           { return 0, fmt.Errorf("404") }
+func (mbn *mockBlockNode) AsFloat() (float64, error)     { return 0.0, fmt.Errorf("404") }
+func (mbn *mockBlockNode) AsString() (string, error)     { return "", fmt.Errorf("404") }
+func (mbn *mockBlockNode) AsBytes() ([]byte, error)      { return mbn.data, nil }
+func (mbn *mockBlockNode) AsLink() (ipld.Link, error)    { return nil, fmt.Errorf("404") }
+func (mbn *mockBlockNode) NodeBuilder() ipld.NodeBuilder { return &mockBuilder{} }


### PR DESCRIPTION
# Goals

Integrate features written so far to actually have the top level interface send a request across the network. No processing on the other side, no response.

# Implementation

- update all the IPLD code to match changing interfaces in go-ipld-prime
- remove special error type used in request manager
- build the top level exchange interface - GraphSync - to setup dependencies, and call the code to make a request to the network
- test that:
   1. Sets up to mocknet hosts & GraphSync network for each one
   2. Sets up a GraphSync exchange on one while manually reading incoming messages for the other
   3. Makes a mock selector spec and initiates a request on the exchange to the other peer for that selector
   4. Verifies the second peer received the message, and the selector was correctly encoded in it.

# For Discussion

fix #6