### PR TITLE
Graphsync responds to incoming requests

### DIFF
--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -91,7 +91,7 @@ package "go-graphsync" {
 
   package messagequeue {
     class MessageQueue {
-      AddRequest(GraphSyncRequestID, selector []byte, GraphSyncPriority)
+      AddRequest(GraphSyncRequest)
       Cancel(GraphSyncRequestID)
       Startup()
       Shutdown()
@@ -109,8 +109,7 @@ package "go-graphsync" {
       Connected(p peer.ID)
       Disconnected(p peer.ID)
       ConnectedPeers() []peer.ID
-      SendRequest(peer.ID, GraphSyncRequestID, selector []byte, priority)
-      CancelRequest(peer.ID, GraphSyncRequestID)
+      SendRequest(peer.ID, GraphSyncRequest)
     }
 
     object "Package Public Functions" as goPeerManagerPF {

--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -54,7 +54,7 @@ package "go-graphsync" {
       ReceiveError(error)
     }
 
-    GraphSync *-- RawLoader
+    GraphSync *-- Loader
 
   package network {
     
@@ -92,7 +92,7 @@ package "go-graphsync" {
   package messagequeue {
     class MessageQueue {
       AddRequest(GraphSyncRequest)
-      Cancel(GraphSyncRequestID)
+      AddResponses([]GraphSyncResponse, []Block) <-chan struct{}
       Startup()
       Shutdown()
     }
@@ -104,19 +104,26 @@ package "go-graphsync" {
     MessageQueue *-- GraphSyncNetwork
   }
 
-  package peerhandler {
+  package peermanager {
     class PeerManager {
       Connected(p peer.ID)
       Disconnected(p peer.ID)
       ConnectedPeers() []peer.ID
+      GetProcess(peer.ID) PeerProcess
+    }
+
+    class PeerMessageManager {
       SendRequest(peer.ID, GraphSyncRequest)
+      SendResponses(peer.ID, []GraphSyncResponse, []Block)
     }
 
     object "Package Public Functions" as goPeerManagerPF {
-      New(ctx context.Context, createPeerQueue func(context, peer.ID) MessageQueue)
+      New(ctx context.Context, createPeerProcess func(context, peer.ID) PeerProcess)
+      NewMessageManager(ctx context.Context, createPeerQueue func(context, peer.ID) MessageQueue)
     }
     GraphSync .. goPeerManagerPF
-    PeerManager *-- MessageQueue
+    PeerManager <|-- PeerMessageManager
+    PeerMessageManager *-- MessageQueue
   }
 
   package requestmanager {
@@ -126,38 +133,167 @@ package "go-graphsync" {
     interface ResponseError {
 
     }
-  class RequestManager {
-    SetDelegate(peerHandler PeerManager)
-    SendRequest(ctx context.Context, p peer.ID, cidRootedSelector Node) chan Block
-    ProcessResponses(message GraphSyncMessage)
-  }
-  RequestManager *-- PeerManager
-  GraphSync *-- RequestManager
+    class RequestManager {
+      SetDelegate(peerHandler PeerMessageManager)
+      SendRequest(ctx context.Context, p peer.ID, cidRootedSelector Node) chan Block
+      ProcessResponses(message GraphSyncMessage)
+    }
+    RequestManager *-- PeerMessageManager
+    GraphSync *-- RequestManager
   }
 
+  
   package responsemanager {
-  class ResponseManager {
-    ProcessRequests(p peer.ID, requests []GraphSyncRequests)
+    package peertaskqueue {
+      package peertask {
+        class Task {
+        }
+        class TaskBlock {
+          MarkPrunable(Identifier)
+          PruneTasks()
+          Index()
+          SetIndex(int)
+        }
+
+        interface Identifier {
+        }
+        object "Package Public Functions" as goPeerTaskPF {
+          FIFOCompare(a, b *TaskBlock) bool
+          PriorityCompare(a, b *TaskBlock) bool
+          WrapCompare(func(a, b *TaskBlock) bool) func(a, b pq.Elem) bool
+          NewTaskBlock([]Task, int, peer.ID, func([]Task)) *TaskBlock
+        }
+      }
+
+      package peertracker {
+        class PeerTracker {
+          StartTask(Identifier)
+          TaskDone(Identifier)
+          Index()
+          SetIndex(int)
+          PushBlock(peer.ID, []Task, func([]Task))
+          PopBlock() *TaskBlock
+          Remove(Identifier)
+          Freeze()
+          Thaw() bool
+          FullThaw()
+          IsFrozen() bool
+        }
+        object "Package Public Functions" as goPeerTrackerPF {
+          New() *PeerTracker
+          PeerCompare(a, b pq.Elem) bool
+        }
+        PeerTracker *-- TaskBlock
+        PeerTracker .. goPeerTaskPF
+      }
+
+      class PeerTaskQueue {
+        PushBlock(to peer.ID, tasks ...Task)
+	      PopBlock() *TaskBlock
+	      Remove(identifier Identifier, p peer.ID)
+	      ThawRound()
+        FullThaw()
+      }
+      PeerTaskQueue *-- PeerTracker
+      PeerTaskQueue .. goPeerTrackerPF
+
+      object "Package Public Functions" as goPeerTaskQueuePF {
+        New() *PeerTaskQueue
+      }
+      GraphSync .. goPeerTaskQueuePF     
+    }
+
+    package loader {
+      object "Package Public Functions" as goResponseLoaderPF {
+        WrapLoader(Loader,GraphSyncRequestID, PeerResponseSender) Loader
+      }
+    }
+    package linktracker {
+      class LinkTracker {
+        ShouldSendBlockFor(Link) bool
+        RecordLinkTraversal(GraphSyncRequestID, Link, bool)
+        FinishRequest(GraphSyncRequestID) bool
+      }
+      object "Package Public Functions" as goLinkTrackerPF {
+        New() *LinkTracker
+      }
+    }
+
+    package responsebuilder {
+      class ResponseBuilder {
+        AddBlock(Block)
+        AddLink(GraphSyncRequestID, Link, bool)
+        AddCompletedRequest(GraphSyncRequestID, GraphSyncResponseStatusCode)
+        Empty() bool
+        Build(IPLDBridge) ([]GraphSyncResponse, []Block, error)    
+      }
+      object "Package Public Functions" as goResponseBuilderPF {
+        New() *ResponseBuilder
+      }
+    }
+    
+    package peerresponsemanager {
+      class PeerResponseManager {
+        SenderForPeer(p peer.ID) PeerResponseSender
+      }
+      class PeerResponseSender {
+        Startup()
+        Shutdown()
+        SendResponse(GraphSyncRequestID,Link,[]byte)
+	      FinishRequest(GraphSyncRequestID)
+	      FinishWithError(GraphSyncRequestID, GraphSyncResponseStatusCode)
+      }
+
+      object "Package Public Functions" as goPeerResponseManagerPF {
+        New(Context, func(Context, peer.ID) PeerResponseSender) *PeerResponseManager
+        NewResponseSender(Context, peer.ID, PeerMessageManager, IPLDBridge) PeerResponseSender  
+      }
+
+      PeerResponseManager *-- PeerResponseSender
+      PeerResponseSender *-- LinkTracker
+      PeerResponseSender *-- ResponseBuilder
+      PeerResponseSender *-- PeerMessageManager
+      PeerResponseSender *-- IPLDBridge
+      PeerResponseSender .. goLinkTrackerPF
+      PeerResponseSender .. goResponseBuilderPF
+      GraphSync .. goPeerResponseManagerPF     
+    }
+
+    class ResponseManager {
+      ProcessRequests(context, peer.ID, []GraphSyncRequests)
+    }
+
+    object "Package Public Functions" as goResponseManagerPF {
+      New(Context, Loader, IPLDBridge, PeerResponseManager, PeerTaskQueue) *ResponseManager
+    }
+    GraphSync *-- ResponseManager
+    ResponseManager *-- Loader
+    ResponseManager *-- IPLDBridge
+    ResponseManager *-- PeerResponseManager
+    ResponseManager *-- PeerTaskQueue
+    ResponseManager .. goResponseLoaderPF
+    GraphSync .. goResponseManagerPF
   }
-  ResponseManager *-- GraphSyncNetwork
-  GraphSync *-- ResponseManager
-  ResponseManager *-- RawLoader
-  }
+
   package message {
     object "Package Public Functions" as goGraphSyncMessagePF {
       func FromPBReader(pbr ggio.Reader) (GraphSyncMessage, error)
       func FromNet(r io.Reader) (GraphSyncMessage, error)
+      func New() GraphSyncMessage
+      func NewRequest(GraphSyncRequestID, []byte, GraphSyncPriority) GraphSyncRequest
+      func CancelRequest(GraphSyncRequestID) GraphSyncRequest
+      func NewResponse(GraphSyncRequestID, GraphSyncResponseStatusCode, []byte) GraphSyncResponse
     }
     goGraphSyncMessagePF .. libP2PGraphSyncNetwork
 
-    interface GraphSyncRequest {
+    class GraphSyncRequest {
       Selector() []bytes
       Priority() Priority
       ID()       int
       IsCancel() bool
     }
 
-    interface GraphSyncResponse {
+    class GraphSyncResponse {
       RequestID() int
       Status() GraphSyncStatus
       Extra() []bytes
@@ -167,6 +303,9 @@ package "go-graphsync" {
       Requests() : []GraphSyncRequest
       Responses() : []GraphSyncResponse
       Blocks() : []Blocks
+      AddRequest(GraphSyncRequest)
+      AddResponse(GraphSyncResponse)
+      AddBlock(Block)
     }
 
     interface Exportable {
@@ -182,6 +321,7 @@ package "go-graphsync" {
 
   package ipldbridge {
     interface IPLDBridge {
+      BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
 	    ValidateSelectorSpec(rootedSelector ipld.Node) []error
 	    EncodeNode(ipld.Node) ([]byte, error)
 	    DecodeNode([]byte) (ipld.Node, error)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.1
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
+	github.com/ipfs/go-ipfs-pq v0.0.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/ipfs/go-ipfs-blocksutil v0.0.1
 	github.com/ipfs/go-ipfs-pq v0.0.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db
+	github.com/ipld/go-ipld-prime v0.0.0-20190329013432-23c6f913c975
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-libp2p v0.0.2
 	github.com/libp2p/go-libp2p-host v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/ipld/go-ipld-prime v0.0.0-20190316215235-adc089c2d3fb h1:pBiRTPGX6V8H
 github.com/ipld/go-ipld-prime v0.0.0-20190316215235-adc089c2d3fb/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
 github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db h1:/6+Pat3+xFjSaBHudbUm+KFyf/11JLuMHGM2dGVNkHc=
 github.com/ipld/go-ipld-prime v0.0.0-20190320000329-46ca29fe25db/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
+github.com/ipld/go-ipld-prime v0.0.0-20190329013432-23c6f913c975 h1:rwQVBxB/muR+Og3iu8ypYp6Rerkcp5pi2j0qfAtqQeI=
+github.com/ipld/go-ipld-prime v0.0.0-20190329013432-23c6f913c975/go.mod h1:hSGXgXt4BSdqvjA3Kkxhzcg4Rsk9yvIeEuEVCPCi7/A=
 github.com/jackpal/gateway v1.0.4 h1:LS5EHkLuQ6jzaHwULi0vL+JO0mU/n4yUtK8oUjHHOlM=
 github.com/jackpal/gateway v1.0.4/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1 h1:i0LektDkO1QlrTm/cSuP+PyBCDnYvjPLGl4LdWEMiaA=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/ipfs/go-ds-leveldb v0.0.1/go.mod h1:feO8V3kubwsEF22n0YRQCffeb79OOYIyk
 github.com/ipfs/go-ipfs-blocksutil v0.0.1 h1:Eh/H4pc1hsvhzsQoMEP3Bke/aW5P5rVM1IWFJMcGIPQ=
 github.com/ipfs/go-ipfs-blocksutil v0.0.1/go.mod h1:Yq4M86uIOmxmGPUHv/uI7uKqZNtLb449gwKqXjIsnRk=
 github.com/ipfs/go-ipfs-delay v0.0.0-20181109222059-70721b86a9a8/go.mod h1:8SP1YXK1M1kXuc4KJZINY3TQQ03J2rwBG9QfXmbRPrw=
+github.com/ipfs/go-ipfs-pq v0.0.1 h1:zgUotX8dcAB/w/HidJh1zzc1yFq6Vm8J7T2F4itj/RU=
+github.com/ipfs/go-ipfs-pq v0.0.1/go.mod h1:LWIqQpqfRG3fNc5XsnIhz/wQ2XXGyugQwls7BgUmUfY=
 github.com/ipfs/go-ipfs-util v0.0.1 h1:Wz9bL2wB2YBJqggkA4dD7oSmqB4cAnpNbGrlHJulv50=
 github.com/ipfs/go-ipfs-util v0.0.1/go.mod h1:spsl5z8KUnrve+73pOhSVZND1SIxPW5RyBCNzQxlJBc=
 github.com/ipfs/go-log v0.0.1 h1:9XTUN/rW64BCG1YhPK9Hoy3q8nr4gOmHHBpgFdfw6Lc=

--- a/graphsync.go
+++ b/graphsync.go
@@ -3,15 +3,21 @@ package graphsync
 import (
 	"context"
 
-	"github.com/ipfs/go-graphsync/messagequeue"
-	"github.com/ipfs/go-graphsync/peermanager"
-
 	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/messagequeue"
 	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/peermanager"
 	"github.com/ipfs/go-graphsync/requestmanager"
+	"github.com/ipfs/go-graphsync/responsemanager"
+	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue"
+	logging "github.com/ipfs/go-log"
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-peer"
 )
+
+var log = logging.Logger("graphsync")
 
 // ResponseProgress is the fundamental unit of responses making progress in
 // Graphsync.
@@ -23,13 +29,16 @@ type ResponseError = requestmanager.ResponseError
 // GraphSync is an instance of a GraphSync exchange that implements
 // the graphsync protocol.
 type GraphSync struct {
-	ipldBridge     ipldbridge.IPLDBridge
-	network        gsnet.GraphSyncNetwork
-	loader         ipldbridge.Loader
-	requestManager *requestmanager.RequestManager
-	peerManager    *peermanager.PeerMessageManager
-	ctx            context.Context
-	cancel         context.CancelFunc
+	ipldBridge          ipldbridge.IPLDBridge
+	network             gsnet.GraphSyncNetwork
+	loader              ipldbridge.Loader
+	requestManager      *requestmanager.RequestManager
+	responseManager     *responsemanager.ResponseManager
+	peerResponseManager *peerresponsemanager.PeerResponseManager
+	peerTaskQueue       *peertaskqueue.PeerTaskQueue
+	peerManager         *peermanager.PeerMessageManager
+	ctx                 context.Context
+	cancel              context.CancelFunc
 }
 
 // New creates a new GraphSync Exchange on the given network,
@@ -43,23 +52,48 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	}
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	requestManager := requestmanager.New(ctx, ipldBridge)
+	peerTaskQueue := peertaskqueue.New()
+	createdResponseQueue := func(ctx context.Context, p peer.ID) peerresponsemanager.PeerResponseSender {
+		return peerresponsemanager.NewResponseSender(ctx, p, peerManager, ipldBridge)
+	}
+	peerResponseManager := peerresponsemanager.New(ctx, createdResponseQueue)
+	responseManager := responsemanager.New(ctx, loader, ipldBridge, peerResponseManager, peerTaskQueue)
 	graphSync := &GraphSync{
-		ipldBridge:     ipldBridge,
-		network:        network,
-		loader:         loader,
-		requestManager: requestManager,
-		peerManager:    peerManager,
-		ctx:            ctx,
-		cancel:         cancel,
+		ipldBridge:          ipldBridge,
+		network:             network,
+		loader:              loader,
+		requestManager:      requestManager,
+		peerManager:         peerManager,
+		peerTaskQueue:       peerTaskQueue,
+		peerResponseManager: peerResponseManager,
+		responseManager:     responseManager,
+		ctx:                 ctx,
+		cancel:              cancel,
 	}
 
 	requestManager.SetDelegate(peerManager)
 	requestManager.Startup()
-
+	responseManager.Startup()
+	network.SetDelegate(graphSync)
 	return graphSync
 }
 
 // Request initiates a new GraphSync request to the given peer using the given selector spec.
 func (gs *GraphSync) Request(ctx context.Context, p peer.ID, rootedSelector ipld.Node) (<-chan ResponseProgress, <-chan ResponseError) {
 	return gs.requestManager.SendRequest(ctx, p, rootedSelector)
+}
+
+// ReceiveMessage is part of the networks Receiver interface and receives
+// incoming messages from the network
+func (gs *GraphSync) ReceiveMessage(
+	ctx context.Context,
+	sender peer.ID,
+	incoming gsmsg.GraphSyncMessage) {
+	gs.responseManager.ProcessRequests(ctx, sender, incoming.Requests())
+}
+
+// ReceiveError is part of the network's Receiver interface and handles incoming
+// errors from the network.
+func (gs *GraphSync) ReceiveError(err error) {
+	log.Errorf("Error: %s", err.Error())
 }

--- a/graphsync.go
+++ b/graphsync.go
@@ -27,7 +27,7 @@ type GraphSync struct {
 	network        gsnet.GraphSyncNetwork
 	loader         ipldbridge.Loader
 	requestManager *requestmanager.RequestManager
-	peerManager    *peermanager.PeerManager
+	peerManager    *peermanager.PeerMessageManager
 	ctx            context.Context
 	cancel         context.CancelFunc
 }
@@ -41,7 +41,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	createMessageQueue := func(ctx context.Context, p peer.ID) peermanager.PeerQueue {
 		return messagequeue.New(ctx, p, network)
 	}
-	peerManager := peermanager.New(ctx, createMessageQueue)
+	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	requestManager := requestmanager.New(ctx, ipldBridge)
 	graphSync := &GraphSync{
 		ipldBridge:     ipldBridge,

--- a/graphsync_test.go
+++ b/graphsync_test.go
@@ -4,9 +4,14 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
+	"math/rand"
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-block-format"
+	cid "github.com/ipfs/go-cid"
 
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsmsg "github.com/ipfs/go-graphsync/message"
@@ -18,22 +23,24 @@ import (
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 )
 
+type receivedMessage struct {
+	message gsmsg.GraphSyncMessage
+	sender  peer.ID
+}
+
 // Receiver is an interface for receiving messages from the GraphSyncNetwork.
 type receiver struct {
-	messageReceived chan struct{}
-	lastMessage     gsmsg.GraphSyncMessage
-	lastSender      peer.ID
+	messageReceived chan receivedMessage
 }
 
 func (r *receiver) ReceiveMessage(
 	ctx context.Context,
 	sender peer.ID,
 	incoming gsmsg.GraphSyncMessage) {
-	r.lastSender = sender
-	r.lastMessage = incoming
+
 	select {
 	case <-ctx.Done():
-	case r.messageReceived <- struct{}{}:
+	case r.messageReceived <- receivedMessage{incoming, sender}:
 	}
 }
 
@@ -66,7 +73,7 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	// setup receiving peer to just record message coming in
 	gsnet2 := gsnet.NewFromLibp2pHost(host2)
 	r := &receiver{
-		messageReceived: make(chan struct{}),
+		messageReceived: make(chan receivedMessage),
 	}
 	gsnet2.SetDelegate(r)
 
@@ -82,18 +89,19 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	defer requestCancel()
 	graphSync.Request(requestCtx, host2.ID(), spec)
 
+	var message receivedMessage
 	select {
 	case <-ctx.Done():
 		t.Fatal("did not receive message sent")
-	case <-r.messageReceived:
+	case message = <-r.messageReceived:
 	}
 
-	sender := r.lastSender
+	sender := message.sender
 	if sender != host1.ID() {
 		t.Fatal("received message from wrong node")
 	}
 
-	received := r.lastMessage
+	received := message.message
 	receivedRequests := received.Requests()
 	if len(receivedRequests) != 1 {
 		t.Fatal("Did not add request to received message")
@@ -105,5 +113,103 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	}
 	if !reflect.DeepEqual(spec, receivedSpec) {
 		t.Fatal("did not transmit selector spec correctly")
+	}
+}
+
+func TestSendResponseToIncomingRequest(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	mn := mocknet.New(ctx)
+
+	// setup network
+	host1, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	host2, err := mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	err = mn.LinkAll()
+	if err != nil {
+		t.Fatal("error linking hosts")
+	}
+
+	gsnet1 := gsnet.NewFromLibp2pHost(host1)
+	r := &receiver{
+		messageReceived: make(chan receivedMessage),
+	}
+	gsnet1.SetDelegate(r)
+
+	// setup receiving peer to just record message coming in
+	gsnet2 := gsnet.NewFromLibp2pHost(host2)
+
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+
+	loader := testbridge.NewMockLoader(blks)
+	bridge := testbridge.NewMockIPLDBridge()
+
+	// initialize graphsync on second node to response to requests
+	New(ctx, gsnet2, bridge, loader)
+
+	cids := make([]cid.Cid, 0, 7)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	// append block that should be deduped
+	cids = append(cids, blks[0].Cid())
+
+	unknownCid := testutil.GenerateCids(1)[0]
+	cids = append(cids, unknownCid)
+
+	spec := testbridge.NewMockSelectorSpec(cids)
+	selectorData, err := bridge.EncodeNode(spec)
+	if err != nil {
+		t.Fatal("could not encode selector spec")
+	}
+	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+
+	message := gsmsg.New()
+	message.AddRequest(gsmsg.NewRequest(requestID, selectorData, gsmsg.GraphSyncPriority(math.MaxInt32)))
+	// send request across network
+	gsnet1.SendMessage(ctx, host2.ID(), message)
+	// read the values sent back to requestor
+	var received gsmsg.GraphSyncMessage
+	var receivedBlocks []blocks.Block
+readAllMessages:
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive complete response")
+		case message := <-r.messageReceived:
+			sender := message.sender
+			if sender != host2.ID() {
+				t.Fatal("received message from wrong node")
+			}
+
+			received = message.message
+			receivedBlocks = append(receivedBlocks, received.Blocks()...)
+			receivedResponses := received.Responses()
+			if len(receivedResponses) != 1 {
+				t.Fatal("Did not receive response")
+			}
+			if receivedResponses[0].RequestID() != requestID {
+				t.Fatal("Sent response for incorrect request id")
+			}
+			if receivedResponses[0].Status() != gsmsg.PartialResponse {
+				break readAllMessages
+			}
+		}
+	}
+
+	if len(receivedBlocks) != len(blks) {
+		t.Fatal("Send incorrect number of blocks or there were duplicate blocks")
+	}
+
+	// there should have been a missing CID
+	if received.Responses()[0].Status() != gsmsg.RequestCompletedPartial {
+		t.Fatal("transmitted full response when only partial was transmitted")
 	}
 }

--- a/ipldbridge/ipld_impl.go
+++ b/ipldbridge/ipld_impl.go
@@ -30,6 +30,18 @@ func NewIPLDBridge() IPLDBridge {
 	return &ipldBridge{}
 }
 
+func (rb *ipldBridge) BuildNode(buildFn func(NodeBuilder) ipld.Node) (ipld.Node, error) {
+	var node ipld.Node
+	err := fluent.Recover(func() {
+		nb := fluent.WrapNodeBuilder(free.NodeBuilder())
+		node = buildFn(nb)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return node, nil
+}
+
 func (rb *ipldBridge) Traverse(ctx context.Context, loader Loader, root ipld.Node, s Selector, fn AdvVisitFn) error {
 	config := &TraversalConfig{Ctx: ctx, LinkLoader: loader}
 	return TraversalProgress{TraversalConfig: config}.TraverseInformatively(root, s, fn)

--- a/ipldbridge/ipldbridge.go
+++ b/ipldbridge/ipldbridge.go
@@ -3,6 +3,8 @@ package ipldbridge
 import (
 	"context"
 
+	"github.com/ipld/go-ipld-prime/fluent"
+
 	ipld "github.com/ipld/go-ipld-prime"
 	ipldtraversal "github.com/ipld/go-ipld-prime/traversal"
 	ipldselector "github.com/ipld/go-ipld-prime/traversal/selector"
@@ -26,9 +28,19 @@ type TraversalProgress = ipldtraversal.TraversalProgress
 // TraversalReason is an alias from ipld, in case it's renamed/moved.
 type TraversalReason = ipldtraversal.TraversalReason
 
+// NodeBuilder is an alias from the ipld fluent nodebuilder, in case it's moved
+type NodeBuilder = fluent.NodeBuilder
+
+// ListBuilder is an alias from ipld fluent, in case it's moved
+type ListBuilder = fluent.ListBuilder
+
+// MapBuilder is an alias from ipld fluent, in case it's moved
+type MapBuilder = fluent.MapBuilder
+
 // IPLDBridge is an interface for making calls to IPLD, which can be
 // replaced with alternative implementations
 type IPLDBridge interface {
+	BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
 
 	// ValidateSelectorSpec verifies if a node matches the selector spec.
 	ValidateSelectorSpec(rootedSelector ipld.Node) []error

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -18,7 +18,7 @@ func TestAppendingRequests(t *testing.T) {
 	priority := GraphSyncPriority(rand.Int31())
 
 	gsm := New()
-	gsm.AddRequest(id, selector, priority)
+	gsm.AddRequest(NewRequest(id, selector, priority))
 	requests := gsm.Requests()
 	if len(requests) != 1 {
 		t.Fatal("Did not add request to message")
@@ -63,7 +63,7 @@ func TestAppendingResponses(t *testing.T) {
 	status := RequestAcknowledged
 
 	gsm := New()
-	gsm.AddResponse(requestID, status, extra)
+	gsm.AddResponse(NewResponse(requestID, status, extra))
 	responses := gsm.Responses()
 	if len(responses) != 1 {
 		t.Fatal("Did not add response to message")
@@ -135,9 +135,9 @@ func TestRequestCancel(t *testing.T) {
 	priority := GraphSyncPriority(rand.Int31())
 
 	gsm := New()
-	gsm.AddRequest(id, selector, priority)
+	gsm.AddRequest(NewRequest(id, selector, priority))
 
-	gsm.Cancel(id)
+	gsm.AddRequest(CancelRequest(id))
 
 	requests := gsm.Requests()
 	if len(requests) != 1 {
@@ -158,8 +158,8 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 	status := RequestAcknowledged
 
 	gsm := New()
-	gsm.AddRequest(id, selector, priority)
-	gsm.AddResponse(id, status, extra)
+	gsm.AddRequest(NewRequest(id, selector, priority))
+	gsm.AddResponse(NewResponse(id, status, extra))
 
 	gsm.AddBlock(blocks.NewBlock([]byte("W")))
 	gsm.AddBlock(blocks.NewBlock([]byte("E")))

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -69,8 +69,8 @@ func TestMessageSendAndReceive(t *testing.T) {
 	status := gsmsg.RequestAcknowledged
 
 	sent := gsmsg.New()
-	sent.AddRequest(id, selector, priority)
-	sent.AddResponse(id, status, extra)
+	sent.AddRequest(gsmsg.NewRequest(id, selector, priority))
+	sent.AddResponse(gsmsg.NewResponse(id, status, extra))
 
 	err = gsnet1.ConnectTo(ctx, host2.ID())
 	if err != nil {

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -23,10 +23,7 @@ var (
 
 // PeerQueue provides a queer of messages to be sent for a single peer.
 type PeerQueue interface {
-	AddRequest(id gsmsg.GraphSyncRequestID,
-		selector []byte,
-		priority gsmsg.GraphSyncPriority)
-	Cancel(id gsmsg.GraphSyncRequestID)
+	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest)
 	Startup()
 	Shutdown()
 }
@@ -101,23 +98,11 @@ func (pm *PeerManager) Disconnected(p peer.ID) {
 // SendRequest sends the given request to the given peer.
 func (pm *PeerManager) SendRequest(
 	p peer.ID,
-	id gsmsg.GraphSyncRequestID,
-	selector []byte,
-	priority gsmsg.GraphSyncPriority) {
+	graphSyncRequest gsmsg.GraphSyncRequest) {
 	pm.peerQueuesLk.Lock()
 	pqi := pm.getOrCreate(p)
 	pm.peerQueuesLk.Unlock()
-	pqi.pq.AddRequest(id, selector, priority)
-}
-
-// CancelRequest cancels the given request id on the given peer.
-func (pm *PeerManager) CancelRequest(
-	p peer.ID,
-	id gsmsg.GraphSyncRequestID) {
-	pm.peerQueuesLk.Lock()
-	pqi := pm.getOrCreate(p)
-	pm.peerQueuesLk.Unlock()
-	pqi.pq.Cancel(id)
+	pqi.pq.AddRequest(graphSyncRequest)
 }
 
 func (pm *PeerManager) getOrCreate(p peer.ID) *peerQueueInstance {

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -3,63 +3,48 @@ package peermanager
 import (
 	"context"
 	"sync"
-	"time"
-
-	gsmsg "github.com/ipfs/go-graphsync/message"
-	logging "github.com/ipfs/go-log"
 
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-const (
-	defaultCleanupInterval = time.Minute
-)
-
-var log = logging.Logger("graphsync")
-
-var (
-	metricsBuckets = []float64{1 << 6, 1 << 10, 1 << 14, 1 << 18, 1<<18 + 15, 1 << 22}
-)
-
-// PeerQueue provides a queer of messages to be sent for a single peer.
-type PeerQueue interface {
-	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest)
+// PeerProcess is any process that provides services for a peer
+type PeerProcess interface {
 	Startup()
 	Shutdown()
 }
 
-// PeerQueueFactory provides a function that will create a PeerQueue.
-type PeerQueueFactory func(ctx context.Context, p peer.ID) PeerQueue
+// PeerProcessFactory provides a function that will create a PeerQueue.
+type PeerProcessFactory func(ctx context.Context, p peer.ID) PeerProcess
 
-type peerQueueInstance struct {
-	refcnt int
-	pq     PeerQueue
+type peerProcessInstance struct {
+	refcnt  int
+	process PeerProcess
 }
 
 // PeerManager manages a pool of peers and sends messages to peers in the pool.
 type PeerManager struct {
-	peerQueues   map[peer.ID]*peerQueueInstance
-	peerQueuesLk sync.RWMutex
+	peerProcesses   map[peer.ID]*peerProcessInstance
+	peerProcessesLk sync.RWMutex
 
-	createPeerQueue PeerQueueFactory
-	ctx             context.Context
+	createPeerProcess PeerProcessFactory
+	ctx               context.Context
 }
 
 // New creates a new PeerManager, given a context and a peerQueueFactory.
-func New(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerManager {
+func New(ctx context.Context, createPeerQueue PeerProcessFactory) *PeerManager {
 	return &PeerManager{
-		peerQueues:      make(map[peer.ID]*peerQueueInstance),
-		createPeerQueue: createPeerQueue,
-		ctx:             ctx,
+		peerProcesses:     make(map[peer.ID]*peerProcessInstance),
+		createPeerProcess: createPeerQueue,
+		ctx:               ctx,
 	}
 }
 
 // ConnectedPeers returns a list of peers this PeerManager is managing.
 func (pm *PeerManager) ConnectedPeers() []peer.ID {
-	pm.peerQueuesLk.RLock()
-	defer pm.peerQueuesLk.RUnlock()
-	peers := make([]peer.ID, 0, len(pm.peerQueues))
-	for p := range pm.peerQueues {
+	pm.peerProcessesLk.RLock()
+	defer pm.peerProcessesLk.RUnlock()
+	peers := make([]peer.ID, 0, len(pm.peerProcesses))
+	for p := range pm.peerProcesses {
 		peers = append(peers, p)
 	}
 	return peers
@@ -67,51 +52,50 @@ func (pm *PeerManager) ConnectedPeers() []peer.ID {
 
 // Connected is called to add a new peer to the pool
 func (pm *PeerManager) Connected(p peer.ID) {
-	pm.peerQueuesLk.Lock()
+	pm.peerProcessesLk.Lock()
 	pq := pm.getOrCreate(p)
 	pq.refcnt++
-	pm.peerQueuesLk.Unlock()
+	pm.peerProcessesLk.Unlock()
 }
 
 // Disconnected is called to remove a peer from the pool.
 func (pm *PeerManager) Disconnected(p peer.ID) {
-	pm.peerQueuesLk.Lock()
-	pq, ok := pm.peerQueues[p]
+	pm.peerProcessesLk.Lock()
+	pq, ok := pm.peerProcesses[p]
 	if !ok {
-		pm.peerQueuesLk.Unlock()
+		pm.peerProcessesLk.Unlock()
 		return
 	}
 
 	pq.refcnt--
 	if pq.refcnt > 0 {
-		pm.peerQueuesLk.Unlock()
+		pm.peerProcessesLk.Unlock()
 		return
 	}
 
-	delete(pm.peerQueues, p)
-	pm.peerQueuesLk.Unlock()
+	delete(pm.peerProcesses, p)
+	pm.peerProcessesLk.Unlock()
 
-	pq.pq.Shutdown()
+	pq.process.Shutdown()
 
 }
 
-// SendRequest sends the given request to the given peer.
-func (pm *PeerManager) SendRequest(
-	p peer.ID,
-	graphSyncRequest gsmsg.GraphSyncRequest) {
-	pm.peerQueuesLk.Lock()
+// GetProcess returns the process for the given peer
+func (pm *PeerManager) GetProcess(
+	p peer.ID) PeerProcess {
+	pm.peerProcessesLk.Lock()
 	pqi := pm.getOrCreate(p)
-	pm.peerQueuesLk.Unlock()
-	pqi.pq.AddRequest(graphSyncRequest)
+	pm.peerProcessesLk.Unlock()
+	return pqi.process
 }
 
-func (pm *PeerManager) getOrCreate(p peer.ID) *peerQueueInstance {
-	pqi, ok := pm.peerQueues[p]
+func (pm *PeerManager) getOrCreate(p peer.ID) *peerProcessInstance {
+	pqi, ok := pm.peerProcesses[p]
 	if !ok {
-		pq := pm.createPeerQueue(pm.ctx, p)
+		pq := pm.createPeerProcess(pm.ctx, p)
 		pq.Startup()
-		pqi = &peerQueueInstance{0, pq}
-		pm.peerQueues[p] = pqi
+		pqi = &peerProcessInstance{0, pq}
+		pm.peerProcesses[p] = pqi
 	}
 	return pqi
 }

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -2,51 +2,27 @@ package peermanager
 
 import (
 	"context"
-	"math/rand"
-	"reflect"
 	"testing"
-	"time"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/libp2p/go-libp2p-peer"
 )
 
-type messageSent struct {
-	p       peer.ID
-	message gsmsg.GraphSyncMessage
+type fakePeerProcess struct {
 }
 
-type fakePeer struct {
-	p            peer.ID
-	messagesSent chan messageSent
-}
-
-func (fp *fakePeer) Startup()  {}
-func (fp *fakePeer) Shutdown() {}
-
-func (fp *fakePeer) AddRequest(graphSyncRequest gsmsg.GraphSyncRequest) {
-	message := gsmsg.New()
-	message.AddRequest(graphSyncRequest)
-	fp.messagesSent <- messageSent{fp.p, message}
-}
-
-func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
-	return func(ctx context.Context, p peer.ID) PeerQueue {
-		return &fakePeer{
-			p:            p,
-			messagesSent: messagesSent,
-		}
-	}
-}
+func (fp *fakePeerProcess) Startup()  {}
+func (fp *fakePeerProcess) Shutdown() {}
 
 func TestAddingAndRemovingPeers(t *testing.T) {
 	ctx := context.Background()
-	peerQueueFactory := makePeerQueueFactory(nil)
+	peerProcessFatory := func(ctx context.Context, p peer.ID) PeerProcess {
+		return &fakePeerProcess{}
+	}
 
 	tp := testutil.GeneratePeers(5)
 	peer1, peer2, peer3, peer4, peer5 := tp[0], tp[1], tp[2], tp[3], tp[4]
-	peerManager := New(ctx, peerQueueFactory)
+	peerManager := New(ctx, peerProcessFatory)
 
 	peerManager.Connected(peer1)
 	peerManager.Connected(peer2)
@@ -80,77 +56,5 @@ func TestAddingAndRemovingPeers(t *testing.T) {
 
 	if !testutil.ContainsPeer(connectedPeers, peer2) {
 		t.Fatal("Peer was disconnected but should not have been")
-	}
-}
-
-func TestSendingMessagesToPeers(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
-	messagesSent := make(chan messageSent, 5)
-	peerQueueFactory := makePeerQueueFactory(messagesSent)
-
-	tp := testutil.GeneratePeers(5)
-
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
-	selector := testutil.RandomBytes(100)
-
-	peerManager := New(ctx, peerQueueFactory)
-
-	request := gsmsg.NewRequest(id, selector, priority)
-	peerManager.SendRequest(tp[0], request)
-	peerManager.SendRequest(tp[1], request)
-	cancelRequest := gsmsg.CancelRequest(id)
-	peerManager.SendRequest(tp[0], cancelRequest)
-
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not send first message")
-	case firstMessage := <-messagesSent:
-		if firstMessage.p != tp[0] {
-			t.Fatal("First message sent to wrong peer")
-		}
-		request := firstMessage.message.Requests()[0]
-		if request.ID() != id ||
-			request.IsCancel() != false ||
-			request.Priority() != priority ||
-			!reflect.DeepEqual(request.Selector(), selector) {
-			t.Fatal("did not send correct first message")
-		}
-	}
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not send second message")
-	case secondMessage := <-messagesSent:
-		if secondMessage.p != tp[1] {
-			t.Fatal("Second message sent to wrong peer")
-		}
-		request := secondMessage.message.Requests()[0]
-		if request.ID() != id ||
-			request.IsCancel() != false ||
-			request.Priority() != priority ||
-			!reflect.DeepEqual(request.Selector(), selector) {
-			t.Fatal("did not send correct second message")
-		}
-	}
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not send third message")
-	case thirdMessage := <-messagesSent:
-		if thirdMessage.p != tp[0] {
-			t.Fatal("Third message sent to wrong peer")
-		}
-		request := thirdMessage.message.Requests()[0]
-		if request.ID() != id ||
-			request.IsCancel() != true {
-			t.Fatal("third message was not a cancel")
-		}
-	}
-	connectedPeers := peerManager.ConnectedPeers()
-	if len(connectedPeers) != 2 ||
-		!testutil.ContainsPeer(connectedPeers, tp[0]) ||
-		!testutil.ContainsPeer(connectedPeers, tp[1]) {
-		t.Fatal("did not connect all peers that were sent messages")
 	}
 }

--- a/peermanager/peermessagemanager.go
+++ b/peermanager/peermessagemanager.go
@@ -3,6 +3,8 @@ package peermanager
 import (
 	"context"
 
+	"github.com/ipfs/go-block-format"
+
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
@@ -11,6 +13,7 @@ import (
 type PeerQueue interface {
 	PeerProcess
 	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest)
+	AddResponses(responses []gsmsg.GraphSyncResponse, blks []blocks.Block) <-chan struct{}
 }
 
 // PeerQueueFactory provides a function that will create a PeerQueue.
@@ -34,4 +37,11 @@ func NewMessageManager(ctx context.Context, createPeerQueue PeerQueueFactory) *P
 func (pmm *PeerMessageManager) SendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
 	pq := pmm.GetProcess(p).(PeerQueue)
 	pq.AddRequest(request)
+}
+
+// SendResponse sends the given GraphSyncResponses and blocks to the given peer.
+func (pmm *PeerMessageManager) SendResponse(p peer.ID,
+	responses []gsmsg.GraphSyncResponse, blks []blocks.Block) <-chan struct{} {
+	pq := pmm.GetProcess(p).(PeerQueue)
+	return pq.AddResponses(responses, blks)
 }

--- a/peermanager/peermessagemanager.go
+++ b/peermanager/peermessagemanager.go
@@ -1,0 +1,37 @@
+package peermanager
+
+import (
+	"context"
+
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// PeerQueue is a process that sends messages to a peer
+type PeerQueue interface {
+	PeerProcess
+	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest)
+}
+
+// PeerQueueFactory provides a function that will create a PeerQueue.
+type PeerQueueFactory func(ctx context.Context, p peer.ID) PeerQueue
+
+// PeerMessageManager manages message queues for peers
+type PeerMessageManager struct {
+	*PeerManager
+}
+
+// NewMessageManager generates a new manger for sending messages
+func NewMessageManager(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerMessageManager {
+	return &PeerMessageManager{
+		PeerManager: New(ctx, func(ctx context.Context, p peer.ID) PeerProcess {
+			return createPeerQueue(ctx, p)
+		}),
+	}
+}
+
+// SendRequest sends the given GraphSyncRequest to the given peer
+func (pmm *PeerMessageManager) SendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
+	pq := pmm.GetProcess(p).(PeerQueue)
+	pq.AddRequest(request)
+}

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -1,0 +1,113 @@
+package peermanager
+
+import (
+	"context"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/libp2p/go-libp2p-peer"
+)
+
+type messageSent struct {
+	p       peer.ID
+	message gsmsg.GraphSyncMessage
+}
+
+type fakePeer struct {
+	p            peer.ID
+	messagesSent chan messageSent
+}
+
+func (fp *fakePeer) Startup()  {}
+func (fp *fakePeer) Shutdown() {}
+
+func (fp *fakePeer) AddRequest(graphSyncRequest gsmsg.GraphSyncRequest) {
+	message := gsmsg.New()
+	message.AddRequest(graphSyncRequest)
+	fp.messagesSent <- messageSent{fp.p, message}
+}
+
+func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
+	return func(ctx context.Context, p peer.ID) PeerQueue {
+		return &fakePeer{
+			p:            p,
+			messagesSent: messagesSent,
+		}
+	}
+}
+
+func TestSendingMessagesToPeers(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	messagesSent := make(chan messageSent, 5)
+	peerQueueFactory := makePeerQueueFactory(messagesSent)
+
+	tp := testutil.GeneratePeers(5)
+
+	id := gsmsg.GraphSyncRequestID(rand.Int31())
+	priority := gsmsg.GraphSyncPriority(rand.Int31())
+	selector := testutil.RandomBytes(100)
+
+	peerManager := NewMessageManager(ctx, peerQueueFactory)
+
+	request := gsmsg.NewRequest(id, selector, priority)
+	peerManager.SendRequest(tp[0], request)
+	peerManager.SendRequest(tp[1], request)
+	cancelRequest := gsmsg.CancelRequest(id)
+	peerManager.SendRequest(tp[0], cancelRequest)
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("did not send first message")
+	case firstMessage := <-messagesSent:
+		if firstMessage.p != tp[0] {
+			t.Fatal("First message sent to wrong peer")
+		}
+		request := firstMessage.message.Requests()[0]
+		if request.ID() != id ||
+			request.IsCancel() != false ||
+			request.Priority() != priority ||
+			!reflect.DeepEqual(request.Selector(), selector) {
+			t.Fatal("did not send correct first message")
+		}
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("did not send second message")
+	case secondMessage := <-messagesSent:
+		if secondMessage.p != tp[1] {
+			t.Fatal("Second message sent to wrong peer")
+		}
+		request := secondMessage.message.Requests()[0]
+		if request.ID() != id ||
+			request.IsCancel() != false ||
+			request.Priority() != priority ||
+			!reflect.DeepEqual(request.Selector(), selector) {
+			t.Fatal("did not send correct second message")
+		}
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("did not send third message")
+	case thirdMessage := <-messagesSent:
+		if thirdMessage.p != tp[0] {
+			t.Fatal("Third message sent to wrong peer")
+		}
+		request := thirdMessage.message.Requests()[0]
+		if request.ID() != id ||
+			request.IsCancel() != true {
+			t.Fatal("third message was not a cancel")
+		}
+	}
+	connectedPeers := peerManager.ConnectedPeers()
+	if len(connectedPeers) != 2 ||
+		!testutil.ContainsPeer(connectedPeers, tp[0]) ||
+		!testutil.ContainsPeer(connectedPeers, tp[1]) {
+		t.Fatal("did not connect all peers that were sent messages")
+	}
+}

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-block-format"
+
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/libp2p/go-libp2p-peer"
@@ -29,6 +31,10 @@ func (fp *fakePeer) AddRequest(graphSyncRequest gsmsg.GraphSyncRequest) {
 	message := gsmsg.New()
 	message.AddRequest(graphSyncRequest)
 	fp.messagesSent <- messageSent{fp.p, message}
+}
+
+func (fp *fakePeer) AddResponses([]gsmsg.GraphSyncResponse, []blocks.Block) <-chan struct{} {
+	return nil
 }
 
 func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {

--- a/responsemanager/linktracker/linktracker.go
+++ b/responsemanager/linktracker/linktracker.go
@@ -1,0 +1,64 @@
+package linktracker
+
+import (
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipld/go-ipld-prime"
+)
+
+// LinkTracker records links being traversed to determine useful information
+// in crafting responses for a peer. Specifically, if any in progress request
+// has already sent a block for a given link, don't send it again.
+// Second, keep track of whether links are missing blocks so you can determine
+// at the end if a complete response has been transmitted.
+type LinkTracker struct {
+	isMissingBlocks                   map[gsmsg.GraphSyncRequestID]struct{}
+	linksWithBlocksTraversedByRequest map[gsmsg.GraphSyncRequestID][]ipld.Link
+	traversalsWithBlocksInProgress    map[ipld.Link]int
+}
+
+// New makes a new link tracker
+func New() *LinkTracker {
+	return &LinkTracker{
+		isMissingBlocks:                   make(map[gsmsg.GraphSyncRequestID]struct{}),
+		linksWithBlocksTraversedByRequest: make(map[gsmsg.GraphSyncRequestID][]ipld.Link),
+		traversalsWithBlocksInProgress:    make(map[ipld.Link]int),
+	}
+}
+
+// ShouldSendBlockFor says whether we should send a block for a given link, based
+// on whether we have traversed it already in one of the in progress requests and
+// sent a block already.
+func (lt *LinkTracker) ShouldSendBlockFor(link ipld.Link) bool {
+	return lt.traversalsWithBlocksInProgress[link] == 0
+}
+
+// RecordLinkTraversal records that we traversed a link during a request, and
+// whether we had the block when we did it.
+func (lt *LinkTracker) RecordLinkTraversal(requestID gsmsg.GraphSyncRequestID, link ipld.Link, hasBlock bool) {
+	if hasBlock {
+		lt.linksWithBlocksTraversedByRequest[requestID] = append(lt.linksWithBlocksTraversedByRequest[requestID], link)
+		lt.traversalsWithBlocksInProgress[link]++
+	} else {
+		lt.isMissingBlocks[requestID] = struct{}{}
+	}
+}
+
+// FinishRequest records that we have completed the given request, and returns
+// true if all links traversed had blocks present.
+func (lt *LinkTracker) FinishRequest(requestID gsmsg.GraphSyncRequestID) (hasAllBlocks bool) {
+	_, ok := lt.isMissingBlocks[requestID]
+	hasAllBlocks = !ok
+	links, ok := lt.linksWithBlocksTraversedByRequest[requestID]
+	if !ok {
+		return
+	}
+	for _, link := range links {
+		lt.traversalsWithBlocksInProgress[link]--
+		if lt.traversalsWithBlocksInProgress[link] <= 0 {
+			delete(lt.traversalsWithBlocksInProgress, link)
+		}
+	}
+	delete(lt.linksWithBlocksTraversedByRequest, requestID)
+
+	return
+}

--- a/responsemanager/linktracker/linktracker_test.go
+++ b/responsemanager/linktracker/linktracker_test.go
@@ -1,0 +1,83 @@
+package linktracker
+
+import (
+	"math/rand"
+	"testing"
+
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/testbridge"
+)
+
+func TestShouldSendBlocks(t *testing.T) {
+	linkTracker := New()
+	link1 := testbridge.NewMockLink()
+	link2 := testbridge.NewMockLink()
+	if !linkTracker.ShouldSendBlockFor(link1) || !linkTracker.ShouldSendBlockFor(link2) {
+		t.Fatal("Links not traversed should send blocks")
+	}
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+
+	linkTracker.RecordLinkTraversal(requestID1, link1, true)
+	linkTracker.RecordLinkTraversal(requestID1, link2, true)
+	linkTracker.RecordLinkTraversal(requestID2, link1, true)
+
+	if linkTracker.ShouldSendBlockFor(link1) || linkTracker.ShouldSendBlockFor(link2) {
+		t.Fatal("Links already traversed with blocks should not send blocks again")
+	}
+
+	linkTracker.FinishRequest(requestID1)
+	if linkTracker.ShouldSendBlockFor(link1) || !linkTracker.ShouldSendBlockFor(link2) {
+		t.Fatal("Finishing request should resend blocks only if there are no in progress requests for that block remain")
+	}
+}
+
+func TestHasAllBlocks(t *testing.T) {
+	linkTracker := New()
+	link1 := testbridge.NewMockLink()
+	link2 := testbridge.NewMockLink()
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+
+	linkTracker.RecordLinkTraversal(requestID1, link1, true)
+	linkTracker.RecordLinkTraversal(requestID1, link2, false)
+	linkTracker.RecordLinkTraversal(requestID2, link1, true)
+
+	hasAllBlocksRequest1 := linkTracker.FinishRequest(requestID1)
+	hasAllBlocksRequest2 := linkTracker.FinishRequest(requestID2)
+	if hasAllBlocksRequest1 || !hasAllBlocksRequest2 {
+		t.Fatal("A request has all blocks if and only if all link traversals occurred with blocks present")
+	}
+}
+
+func TestBlockBecomesAvailable(t *testing.T) {
+	linkTracker := New()
+	link1 := testbridge.NewMockLink()
+	if !linkTracker.ShouldSendBlockFor(link1) {
+		t.Fatal("Links not traversed should send blocks")
+	}
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+
+	linkTracker.RecordLinkTraversal(requestID1, link1, false)
+	linkTracker.RecordLinkTraversal(requestID2, link1, false)
+
+	if !linkTracker.ShouldSendBlockFor(link1) {
+		t.Fatal("Links traversed without blocks should still send them if they become availabe")
+	}
+
+	linkTracker.RecordLinkTraversal(requestID1, link1, true)
+
+	if linkTracker.ShouldSendBlockFor(link1) {
+		t.Fatal("Links traversed with blocks should no longer send")
+	}
+
+	hasAllBlocks := linkTracker.FinishRequest(requestID1)
+	if hasAllBlocks {
+		t.Fatal("Even if block becomes available, traversal may be incomplete, request still should not be considered to have all blocks")
+	}
+
+	if !linkTracker.ShouldSendBlockFor(link1) {
+		t.Fatal("Block traversals should resend for requests that never traversed while block was present")
+	}
+}

--- a/responsemanager/loader/loader.go
+++ b/responsemanager/loader/loader.go
@@ -1,0 +1,40 @@
+package loader
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	ipld "github.com/ipld/go-ipld-prime"
+)
+
+// ResponseSender sends responses over the network
+type ResponseSender interface {
+	SendResponse(
+		requestID gsmsg.GraphSyncRequestID,
+		link ipld.Link,
+		data []byte,
+	)
+}
+
+// WrapLoader wraps a given loader with an interceptor that sends loaded
+// blocks out to the network with the given response sender.
+func WrapLoader(loader ipldbridge.Loader,
+	requestID gsmsg.GraphSyncRequestID,
+	responseSender ResponseSender) ipldbridge.Loader {
+	return func(lnk ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
+		result, err := loader(lnk, lnkCtx)
+		var data []byte
+		var blockBuffer bytes.Buffer
+		if err == nil {
+			_, err = io.Copy(&blockBuffer, result)
+			if err == nil {
+				result = &blockBuffer
+				data = blockBuffer.Bytes()
+			}
+		}
+		responseSender.SendResponse(requestID, lnk, data)
+		return result, err
+	}
+}

--- a/responsemanager/loader/loader_test.go
+++ b/responsemanager/loader/loader_test.go
@@ -1,0 +1,78 @@
+package loader
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"reflect"
+	"testing"
+
+	"github.com/ipfs/go-graphsync/testbridge"
+	"github.com/ipfs/go-graphsync/testutil"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	ipld "github.com/ipld/go-ipld-prime"
+)
+
+type fakeResponseSender struct {
+	lastRequestID gsmsg.GraphSyncRequestID
+	lastLink      ipld.Link
+	lastData      []byte
+}
+
+func (frs *fakeResponseSender) SendResponse(
+	requestID gsmsg.GraphSyncRequestID,
+	link ipld.Link,
+	data []byte,
+) {
+	frs.lastRequestID = requestID
+	frs.lastLink = link
+	frs.lastData = data
+}
+
+func TestWrappedLoaderSendsRequests(t *testing.T) {
+	frs := &fakeResponseSender{}
+	link1 := testbridge.NewMockLink()
+	link2 := testbridge.NewMockLink()
+	sourceBytes := testutil.RandomBytes(100)
+	byteBuffer := bytes.NewReader(sourceBytes)
+
+	loader := func(ipldLink ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
+		if ipldLink == link1 {
+			return byteBuffer, nil
+		}
+		return nil, fmt.Errorf("unable to load block")
+	}
+	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	wrappedLoader := WrapLoader(loader, requestID, frs)
+
+	reader, err := wrappedLoader(link1, ipldbridge.LinkContext{})
+	if err != nil {
+		t.Fatal("Should not have error if underlying loader returns valid buffer and no error")
+	}
+	result, err := ioutil.ReadAll(reader)
+	if err != nil || !reflect.DeepEqual(result, sourceBytes) {
+		t.Fatal("Should return reader that functions identical to source reader")
+	}
+	if frs.lastRequestID != requestID ||
+		frs.lastLink != link1 ||
+		!reflect.DeepEqual(frs.lastData, sourceBytes) {
+		t.Fatal("Should have sent block to response sender with correct params but did not")
+	}
+
+	reader, err = wrappedLoader(link2, ipldbridge.LinkContext{})
+	fmt.Println(reader)
+	fmt.Println(err)
+	if reader != nil || err == nil {
+		t.Fatal("Should return an error and empty reader if underlying loader does")
+	}
+
+	if frs.lastRequestID != requestID ||
+		frs.lastLink != link2 ||
+		frs.lastData != nil {
+		t.Fatal("Should sent metadata for link but no block, but did not")
+	}
+}

--- a/responsemanager/peerresponsemanager/peerresponsemanager.go
+++ b/responsemanager/peerresponsemanager/peerresponsemanager.go
@@ -1,0 +1,161 @@
+package peerresponsemanager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ipld/go-ipld-prime/linking/cid"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/ipld/go-ipld-prime"
+
+	"github.com/ipfs/go-block-format"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/responsemanager/linktracker"
+	"github.com/ipfs/go-graphsync/responsemanager/responsebuilder"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var log = logging.Logger("graphsync")
+
+// PeerHandler is an interface that can send a response for a given peer across
+// the network.
+type PeerHandler interface {
+	SendResponse(peer.ID, []gsmsg.GraphSyncResponse, []blocks.Block) <-chan struct{}
+}
+
+// PeerResponseManager handles batching, deduping, and sending responses for
+// a given peer across multiple requests.
+type PeerResponseManager struct {
+	p            peer.ID
+	ctx          context.Context
+	cancel       context.CancelFunc
+	peerHandler  PeerHandler
+	ipldBridge   ipldbridge.IPLDBridge
+	outgoingWork chan struct{}
+
+	linkTrackerLk     sync.RWMutex
+	linkTracker       *linktracker.LinkTracker
+	responseBuilderLk sync.RWMutex
+	responseBuilder   *responsebuilder.ResponseBuilder
+}
+
+// New generates a new PeerResponse manager for the given context, peer ID,
+// using the given peer handler and bridge to IPLD.
+func New(ctx context.Context, p peer.ID, peerHandler PeerHandler, ipldBridge ipldbridge.IPLDBridge) *PeerResponseManager {
+	ctx, cancel := context.WithCancel(ctx)
+	return &PeerResponseManager{
+		p:            p,
+		ctx:          ctx,
+		cancel:       cancel,
+		peerHandler:  peerHandler,
+		ipldBridge:   ipldBridge,
+		outgoingWork: make(chan struct{}, 1),
+		linkTracker:  linktracker.New(),
+	}
+}
+
+// Startup initiates message sending for a peer
+func (prm *PeerResponseManager) Startup() {
+	go prm.run()
+}
+
+// Shutdown stops sending messages for a peer
+func (prm *PeerResponseManager) Shutdown() {
+	prm.cancel()
+}
+
+// SendResponse sends a given link for a given
+// requestID across the wire, as well as its corresponding
+// block if the block is present and has not already been sent
+func (prm *PeerResponseManager) SendResponse(
+	requestID gsmsg.GraphSyncRequestID,
+	link ipld.Link,
+	data []byte,
+) {
+	hasBlock := data != nil
+	prm.linkTrackerLk.Lock()
+	sendBlock := hasBlock && prm.linkTracker.ShouldSendBlockFor(link)
+	prm.linkTracker.RecordLinkTraversal(requestID, link, hasBlock)
+	prm.linkTrackerLk.Unlock()
+
+	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
+		if sendBlock {
+			cidLink := link.(cidlink.Link)
+			block, err := blocks.NewBlockWithCid(data, cidLink.Cid)
+			if err != nil {
+				log.Errorf("Data did not match cid when sending link for %s", cidLink.String())
+			}
+			responseBuilder.AddBlock(block)
+		}
+		responseBuilder.AddLink(requestID, link, hasBlock)
+	}) {
+		prm.signalWork()
+	}
+}
+
+// FinishRequest marks the given requestID as having sent all responses
+func (prm *PeerResponseManager) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
+	prm.linkTrackerLk.Lock()
+	isComplete := prm.linkTracker.FinishRequest(requestID)
+	prm.linkTrackerLk.Unlock()
+
+	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
+		responseBuilder.AddCompletedRequest(requestID, isComplete)
+	}) {
+		prm.signalWork()
+	}
+}
+
+func (prm *PeerResponseManager) buildResponse(buildResponseFn func(*responsebuilder.ResponseBuilder)) bool {
+	prm.responseBuilderLk.Lock()
+	defer prm.responseBuilderLk.Unlock()
+	if prm.responseBuilder == nil {
+		prm.responseBuilder = responsebuilder.New()
+	}
+	buildResponseFn(prm.responseBuilder)
+	return !prm.responseBuilder.Empty()
+}
+
+func (prm *PeerResponseManager) signalWork() {
+	select {
+	case prm.outgoingWork <- struct{}{}:
+	default:
+	}
+}
+
+func (prm *PeerResponseManager) run() {
+	for {
+		select {
+		case <-prm.ctx.Done():
+			return
+		case <-prm.outgoingWork:
+			prm.sendResponseMessage()
+		}
+	}
+}
+
+func (prm *PeerResponseManager) sendResponseMessage() {
+	prm.responseBuilderLk.Lock()
+	builder := prm.responseBuilder
+	prm.responseBuilder = nil
+	prm.responseBuilderLk.Unlock()
+
+	if builder == nil || builder.Empty() {
+		return
+	}
+	responses, blks, err := builder.Build(prm.ipldBridge)
+	if err != nil {
+		log.Errorf("Unable to assemble GraphSync response: %s", err.Error())
+	}
+
+	done := prm.peerHandler.SendResponse(prm.p, responses, blks)
+
+	// wait for message to be processed
+	select {
+	case <-done:
+	case <-prm.ctx.Done():
+	}
+}

--- a/responsemanager/peerresponsemanager/peerresponsemanager.go
+++ b/responsemanager/peerresponsemanager/peerresponsemanager.go
@@ -2,160 +2,29 @@ package peerresponsemanager
 
 import (
 	"context"
-	"sync"
 
-	"github.com/ipld/go-ipld-prime/linking/cid"
-
-	"github.com/ipfs/go-graphsync/ipldbridge"
-
-	logging "github.com/ipfs/go-log"
-	"github.com/ipld/go-ipld-prime"
-
-	"github.com/ipfs/go-block-format"
-	gsmsg "github.com/ipfs/go-graphsync/message"
-	"github.com/ipfs/go-graphsync/responsemanager/linktracker"
-	"github.com/ipfs/go-graphsync/responsemanager/responsebuilder"
+	"github.com/ipfs/go-graphsync/peermanager"
 	peer "github.com/libp2p/go-libp2p-peer"
 )
 
-var log = logging.Logger("graphsync")
+// PeerSenderFactory provides a function that will create a PeerResponseSender.
+type PeerSenderFactory func(ctx context.Context, p peer.ID) PeerResponseSender
 
-// PeerHandler is an interface that can send a response for a given peer across
-// the network.
-type PeerHandler interface {
-	SendResponse(peer.ID, []gsmsg.GraphSyncResponse, []blocks.Block) <-chan struct{}
+// PeerReponseManager manages message queues for peers
+type PeerReponseManager struct {
+	*peermanager.PeerManager
 }
 
-// PeerResponseManager handles batching, deduping, and sending responses for
-// a given peer across multiple requests.
-type PeerResponseManager struct {
-	p            peer.ID
-	ctx          context.Context
-	cancel       context.CancelFunc
-	peerHandler  PeerHandler
-	ipldBridge   ipldbridge.IPLDBridge
-	outgoingWork chan struct{}
-
-	linkTrackerLk     sync.RWMutex
-	linkTracker       *linktracker.LinkTracker
-	responseBuilderLk sync.RWMutex
-	responseBuilder   *responsebuilder.ResponseBuilder
-}
-
-// New generates a new PeerResponse manager for the given context, peer ID,
-// using the given peer handler and bridge to IPLD.
-func New(ctx context.Context, p peer.ID, peerHandler PeerHandler, ipldBridge ipldbridge.IPLDBridge) *PeerResponseManager {
-	ctx, cancel := context.WithCancel(ctx)
-	return &PeerResponseManager{
-		p:            p,
-		ctx:          ctx,
-		cancel:       cancel,
-		peerHandler:  peerHandler,
-		ipldBridge:   ipldBridge,
-		outgoingWork: make(chan struct{}, 1),
-		linkTracker:  linktracker.New(),
+// New generates a new peer manager for sending responses
+func New(ctx context.Context, createPeerSender PeerSenderFactory) *PeerReponseManager {
+	return &PeerReponseManager{
+		PeerManager: peermanager.New(ctx, func(ctx context.Context, p peer.ID) peermanager.PeerProcess {
+			return createPeerSender(ctx, p)
+		}),
 	}
 }
 
-// Startup initiates message sending for a peer
-func (prm *PeerResponseManager) Startup() {
-	go prm.run()
-}
-
-// Shutdown stops sending messages for a peer
-func (prm *PeerResponseManager) Shutdown() {
-	prm.cancel()
-}
-
-// SendResponse sends a given link for a given
-// requestID across the wire, as well as its corresponding
-// block if the block is present and has not already been sent
-func (prm *PeerResponseManager) SendResponse(
-	requestID gsmsg.GraphSyncRequestID,
-	link ipld.Link,
-	data []byte,
-) {
-	hasBlock := data != nil
-	prm.linkTrackerLk.Lock()
-	sendBlock := hasBlock && prm.linkTracker.ShouldSendBlockFor(link)
-	prm.linkTracker.RecordLinkTraversal(requestID, link, hasBlock)
-	prm.linkTrackerLk.Unlock()
-
-	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
-		if sendBlock {
-			cidLink := link.(cidlink.Link)
-			block, err := blocks.NewBlockWithCid(data, cidLink.Cid)
-			if err != nil {
-				log.Errorf("Data did not match cid when sending link for %s", cidLink.String())
-			}
-			responseBuilder.AddBlock(block)
-		}
-		responseBuilder.AddLink(requestID, link, hasBlock)
-	}) {
-		prm.signalWork()
-	}
-}
-
-// FinishRequest marks the given requestID as having sent all responses
-func (prm *PeerResponseManager) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
-	prm.linkTrackerLk.Lock()
-	isComplete := prm.linkTracker.FinishRequest(requestID)
-	prm.linkTrackerLk.Unlock()
-
-	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
-		responseBuilder.AddCompletedRequest(requestID, isComplete)
-	}) {
-		prm.signalWork()
-	}
-}
-
-func (prm *PeerResponseManager) buildResponse(buildResponseFn func(*responsebuilder.ResponseBuilder)) bool {
-	prm.responseBuilderLk.Lock()
-	defer prm.responseBuilderLk.Unlock()
-	if prm.responseBuilder == nil {
-		prm.responseBuilder = responsebuilder.New()
-	}
-	buildResponseFn(prm.responseBuilder)
-	return !prm.responseBuilder.Empty()
-}
-
-func (prm *PeerResponseManager) signalWork() {
-	select {
-	case prm.outgoingWork <- struct{}{}:
-	default:
-	}
-}
-
-func (prm *PeerResponseManager) run() {
-	for {
-		select {
-		case <-prm.ctx.Done():
-			return
-		case <-prm.outgoingWork:
-			prm.sendResponseMessage()
-		}
-	}
-}
-
-func (prm *PeerResponseManager) sendResponseMessage() {
-	prm.responseBuilderLk.Lock()
-	builder := prm.responseBuilder
-	prm.responseBuilder = nil
-	prm.responseBuilderLk.Unlock()
-
-	if builder == nil || builder.Empty() {
-		return
-	}
-	responses, blks, err := builder.Build(prm.ipldBridge)
-	if err != nil {
-		log.Errorf("Unable to assemble GraphSync response: %s", err.Error())
-	}
-
-	done := prm.peerHandler.SendResponse(prm.p, responses, blks)
-
-	// wait for message to be processed
-	select {
-	case <-done:
-	case <-prm.ctx.Done():
-	}
+// SenderForPeer returns a response sender to use with the given peer
+func (prm *PeerReponseManager) SenderForPeer(p peer.ID) PeerResponseSender {
+	return prm.GetProcess(p).(PeerResponseSender)
 }

--- a/responsemanager/peerresponsemanager/peerresponsemanager.go
+++ b/responsemanager/peerresponsemanager/peerresponsemanager.go
@@ -10,14 +10,14 @@ import (
 // PeerSenderFactory provides a function that will create a PeerResponseSender.
 type PeerSenderFactory func(ctx context.Context, p peer.ID) PeerResponseSender
 
-// PeerReponseManager manages message queues for peers
-type PeerReponseManager struct {
+// PeerResponseManager manages message queues for peers
+type PeerResponseManager struct {
 	*peermanager.PeerManager
 }
 
 // New generates a new peer manager for sending responses
-func New(ctx context.Context, createPeerSender PeerSenderFactory) *PeerReponseManager {
-	return &PeerReponseManager{
+func New(ctx context.Context, createPeerSender PeerSenderFactory) *PeerResponseManager {
+	return &PeerResponseManager{
 		PeerManager: peermanager.New(ctx, func(ctx context.Context, p peer.ID) peermanager.PeerProcess {
 			return createPeerSender(ctx, p)
 		}),
@@ -25,6 +25,6 @@ func New(ctx context.Context, createPeerSender PeerSenderFactory) *PeerReponseMa
 }
 
 // SenderForPeer returns a response sender to use with the given peer
-func (prm *PeerReponseManager) SenderForPeer(p peer.ID) PeerResponseSender {
+func (prm *PeerResponseManager) SenderForPeer(p peer.ID) PeerResponseSender {
 	return prm.GetProcess(p).(PeerResponseSender)
 }

--- a/responsemanager/peerresponsemanager/peerresponsemanager_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsemanager_test.go
@@ -1,0 +1,176 @@
+package peerresponsemanager
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-graphsync/testbridge"
+
+	"github.com/ipfs/go-block-format"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/linking/cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type fakePeerHandler struct {
+	lastBlocks    []blocks.Block
+	lastResponses []gsmsg.GraphSyncResponse
+	sent          chan struct{}
+	done          chan struct{}
+}
+
+func (fph *fakePeerHandler) SendResponse(p peer.ID, responses []gsmsg.GraphSyncResponse, blks []blocks.Block) <-chan struct{} {
+	fph.lastResponses = responses
+	fph.lastBlocks = blks
+	fph.sent <- struct{}{}
+	return fph.done
+}
+
+func TestPeerResponseManagerSendsResponses(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+	defer cancel()
+	p := testutil.GeneratePeers(1)[0]
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID3 := gsmsg.GraphSyncRequestID(rand.Int31())
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+	links := make([]ipld.Link, 0, len(blks))
+	for _, block := range blks {
+		links = append(links, cidlink.Link{Cid: block.Cid()})
+	}
+	done := make(chan struct{}, 1)
+	sent := make(chan struct{}, 1)
+	fph := &fakePeerHandler{
+		done: done,
+		sent: sent,
+	}
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	peerResponseManager := New(ctx, p, fph, ipldBridge)
+	peerResponseManager.Startup()
+
+	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Did not send first message")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[0].Cid() {
+		t.Fatal("Did not send correct blocks for first message")
+	}
+
+	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID1 ||
+		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		t.Fatal("Did not send correct responses for first message")
+	}
+
+	peerResponseManager.SendResponse(requestID2, links[0], blks[0].RawData())
+	peerResponseManager.SendResponse(requestID1, links[1], blks[1].RawData())
+	peerResponseManager.SendResponse(requestID1, links[2], nil)
+	peerResponseManager.FinishRequest(requestID1)
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent second message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[1].Cid() {
+		t.Fatal("Did not dedup blocks correctly on second message")
+	}
+
+	if len(fph.lastResponses) != 2 {
+		t.Fatal("Did not send correct number of responses")
+	}
+	response1, err := findResponseForRequestID(fph.lastResponses, requestID1)
+	if err != nil {
+		t.Fatal("Did not send correct response for second message")
+	}
+	if response1.Status() != gsmsg.RequestCompletedPartial {
+		t.Fatal("Did not send proper response code in second message")
+	}
+	response2, err := findResponseForRequestID(fph.lastResponses, requestID2)
+	if err != nil {
+		t.Fatal("Did not send correct response for second message")
+	}
+	if response2.Status() != gsmsg.PartialResponse {
+		t.Fatal("Did not send proper response code in second message")
+	}
+
+	peerResponseManager.SendResponse(requestID2, links[3], blks[3].RawData())
+	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
+	peerResponseManager.FinishRequest(requestID2)
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent third message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 2 ||
+		!testutil.ContainsBlock(fph.lastBlocks, blks[3]) ||
+		!testutil.ContainsBlock(fph.lastBlocks, blks[4]) {
+		t.Fatal("Did not send correct blocks for third message")
+	}
+
+	if len(fph.lastResponses) != 2 {
+		t.Fatal("Did not send correct number of responses")
+	}
+	response2, err = findResponseForRequestID(fph.lastResponses, requestID2)
+	if err != nil {
+		t.Fatal("Did not send correct response for third message")
+	}
+	if response2.Status() != gsmsg.RequestCompletedFull {
+		t.Fatal("Did not send proper response code in third message")
+	}
+	response3, err := findResponseForRequestID(fph.lastResponses, requestID3)
+	if err != nil {
+		t.Fatal("Did not send correct response for third message")
+	}
+	if response3.Status() != gsmsg.PartialResponse {
+		t.Fatal("Did not send proper response code in third message")
+	}
+
+	peerResponseManager.SendResponse(requestID3, links[0], blks[0].RawData())
+	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent third message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[0].Cid() {
+		t.Fatal("Should have resent block cause there were no in progress requests but did not")
+	}
+
+	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID3 ||
+		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		t.Fatal("Did not send correct responses for fourth message")
+	}
+}
+
+func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID gsmsg.GraphSyncRequestID) (gsmsg.GraphSyncResponse, error) {
+	for _, response := range responses {
+		if response.RequestID() == requestID {
+			return response, nil
+		}
+	}
+	return gsmsg.GraphSyncResponse{}, fmt.Errorf("Response Not Found")
+}

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -1,0 +1,173 @@
+package peerresponsemanager
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ipfs/go-graphsync/peermanager"
+
+	"github.com/ipld/go-ipld-prime/linking/cid"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+
+	logging "github.com/ipfs/go-log"
+	"github.com/ipld/go-ipld-prime"
+
+	"github.com/ipfs/go-block-format"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/responsemanager/linktracker"
+	"github.com/ipfs/go-graphsync/responsemanager/responsebuilder"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+var log = logging.Logger("graphsync")
+
+// PeerMessageHandler is an interface that can send a response for a given peer across
+// the network.
+type PeerMessageHandler interface {
+	SendResponse(peer.ID, []gsmsg.GraphSyncResponse, []blocks.Block) <-chan struct{}
+}
+
+type peerResponseSender struct {
+	p            peer.ID
+	ctx          context.Context
+	cancel       context.CancelFunc
+	peerHandler  PeerMessageHandler
+	ipldBridge   ipldbridge.IPLDBridge
+	outgoingWork chan struct{}
+
+	linkTrackerLk     sync.RWMutex
+	linkTracker       *linktracker.LinkTracker
+	responseBuilderLk sync.RWMutex
+	responseBuilder   *responsebuilder.ResponseBuilder
+}
+
+// PeerResponseSender handles batching, deduping, and sending responses for
+// a given peer across multiple requests.
+type PeerResponseSender interface {
+	peermanager.PeerProcess
+	SendResponse(
+		requestID gsmsg.GraphSyncRequestID,
+		link ipld.Link,
+		data []byte,
+	)
+	FinishRequest(requestID gsmsg.GraphSyncRequestID)
+}
+
+// NewResponseSender generates a new PeerResponseSender for the given context, peer ID,
+// using the given peer message handler and bridge to IPLD.
+func NewResponseSender(ctx context.Context, p peer.ID, peerHandler PeerMessageHandler, ipldBridge ipldbridge.IPLDBridge) PeerResponseSender {
+	ctx, cancel := context.WithCancel(ctx)
+	return &peerResponseSender{
+		p:            p,
+		ctx:          ctx,
+		cancel:       cancel,
+		peerHandler:  peerHandler,
+		ipldBridge:   ipldBridge,
+		outgoingWork: make(chan struct{}, 1),
+		linkTracker:  linktracker.New(),
+	}
+}
+
+// Startup initiates message sending for a peer
+func (prm *peerResponseSender) Startup() {
+	go prm.run()
+}
+
+// Shutdown stops sending messages for a peer
+func (prm *peerResponseSender) Shutdown() {
+	prm.cancel()
+}
+
+// SendResponse sends a given link for a given
+// requestID across the wire, as well as its corresponding
+// block if the block is present and has not already been sent
+func (prm *peerResponseSender) SendResponse(
+	requestID gsmsg.GraphSyncRequestID,
+	link ipld.Link,
+	data []byte,
+) {
+	hasBlock := data != nil
+	prm.linkTrackerLk.Lock()
+	sendBlock := hasBlock && prm.linkTracker.ShouldSendBlockFor(link)
+	prm.linkTracker.RecordLinkTraversal(requestID, link, hasBlock)
+	prm.linkTrackerLk.Unlock()
+
+	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
+		if sendBlock {
+			cidLink := link.(cidlink.Link)
+			block, err := blocks.NewBlockWithCid(data, cidLink.Cid)
+			if err != nil {
+				log.Errorf("Data did not match cid when sending link for %s", cidLink.String())
+			}
+			responseBuilder.AddBlock(block)
+		}
+		responseBuilder.AddLink(requestID, link, hasBlock)
+	}) {
+		prm.signalWork()
+	}
+}
+
+// FinishRequest marks the given requestID as having sent all responses
+func (prm *peerResponseSender) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
+	prm.linkTrackerLk.Lock()
+	isComplete := prm.linkTracker.FinishRequest(requestID)
+	prm.linkTrackerLk.Unlock()
+
+	if prm.buildResponse(func(responseBuilder *responsebuilder.ResponseBuilder) {
+		responseBuilder.AddCompletedRequest(requestID, isComplete)
+	}) {
+		prm.signalWork()
+	}
+}
+
+func (prm *peerResponseSender) buildResponse(buildResponseFn func(*responsebuilder.ResponseBuilder)) bool {
+	prm.responseBuilderLk.Lock()
+	defer prm.responseBuilderLk.Unlock()
+	if prm.responseBuilder == nil {
+		prm.responseBuilder = responsebuilder.New()
+	}
+	buildResponseFn(prm.responseBuilder)
+	return !prm.responseBuilder.Empty()
+}
+
+func (prm *peerResponseSender) signalWork() {
+	select {
+	case prm.outgoingWork <- struct{}{}:
+	default:
+	}
+}
+
+func (prm *peerResponseSender) run() {
+	for {
+		select {
+		case <-prm.ctx.Done():
+			return
+		case <-prm.outgoingWork:
+			prm.sendResponseMessage()
+		}
+	}
+}
+
+func (prm *peerResponseSender) sendResponseMessage() {
+	prm.responseBuilderLk.Lock()
+	builder := prm.responseBuilder
+	prm.responseBuilder = nil
+	prm.responseBuilderLk.Unlock()
+
+	if builder == nil || builder.Empty() {
+		return
+	}
+	responses, blks, err := builder.Build(prm.ipldBridge)
+	if err != nil {
+		log.Errorf("Unable to assemble GraphSync response: %s", err.Error())
+	}
+
+	done := prm.peerHandler.SendResponse(prm.p, responses, blks)
+
+	// wait for message to be processed
+	select {
+	case <-done:
+	case <-prm.ctx.Done():
+	}
+}

--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -51,7 +51,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 		sent: sent,
 	}
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	peerResponseManager := New(ctx, p, fph, ipldBridge)
+	peerResponseManager := NewResponseSender(ctx, p, fph, ipldBridge)
 	peerResponseManager.Startup()
 
 	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())

--- a/responsemanager/peertaskqueue/peertask/peertask.go
+++ b/responsemanager/peertaskqueue/peertask/peertask.go
@@ -1,0 +1,97 @@
+package peertask
+
+import (
+	"time"
+
+	pq "github.com/ipfs/go-ipfs-pq"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// FIFOCompare is a basic task comparator that returns tasks in the order created.
+var FIFOCompare = func(a, b *TaskBlock) bool {
+	return a.created.Before(b.created)
+}
+
+// PriorityCompare respects the target peer's task priority. For tasks involving
+// different peers, the oldest task is prioritized.
+var PriorityCompare = func(a, b *TaskBlock) bool {
+	if a.Target == b.Target {
+		return a.Priority > b.Priority
+	}
+	return FIFOCompare(a, b)
+}
+
+// WrapCompare wraps a TaskBlock comparison function so it can be used as
+// comparison for a priority queue
+func WrapCompare(f func(a, b *TaskBlock) bool) func(a, b pq.Elem) bool {
+	return func(a, b pq.Elem) bool {
+		return f(a.(*TaskBlock), b.(*TaskBlock))
+	}
+}
+
+// Identifier is a unique identifier for a task. It's used by the client library
+// to act on a task once it exits the queue.
+type Identifier interface{}
+
+// Task is a single task to be executed as part of a task block.
+type Task struct {
+	Identifier Identifier
+	Priority   int
+}
+
+// TaskBlock is a block of tasks to execute on a single peer.
+type TaskBlock struct {
+	Tasks    []Task
+	Priority int
+	Target   peer.ID
+
+	// A callback to signal that this task block has been completed
+	Done func([]Task)
+
+	// toPrune are the tasks that have already been taken care of as part of
+	// a different task block which can be removed from the task block.
+	toPrune map[Identifier]struct{}
+	created time.Time // created marks the time that the task was added to the queue
+	index   int       // book-keeping field used by the pq container
+}
+
+// NewTaskBlock creates a new task block with the given tasks, priority, target
+// peer, and task completion function.
+func NewTaskBlock(tasks []Task, priority int, target peer.ID, done func([]Task)) *TaskBlock {
+	return &TaskBlock{
+		Tasks:    tasks,
+		Priority: priority,
+		Target:   target,
+		Done:     done,
+		toPrune:  make(map[Identifier]struct{}, len(tasks)),
+		created:  time.Now(),
+	}
+}
+
+// MarkPrunable marks any tasks with the given identifier as prunable at the time
+// the task block is pulled of the queue to execute (because they've already been removed).
+func (pt *TaskBlock) MarkPrunable(identifier Identifier) {
+	pt.toPrune[identifier] = struct{}{}
+}
+
+// PruneTasks removes all tasks previously marked as prunable from the lists of
+// tasks in the block
+func (pt *TaskBlock) PruneTasks() {
+	newTasks := make([]Task, 0, len(pt.Tasks)-len(pt.toPrune))
+	for _, task := range pt.Tasks {
+		if _, ok := pt.toPrune[task.Identifier]; !ok {
+			newTasks = append(newTasks, task)
+		}
+	}
+	pt.Tasks = newTasks
+}
+
+// Index implements pq.Elem.
+func (pt *TaskBlock) Index() int {
+	return pt.index
+}
+
+// SetIndex implements pq.Elem.
+func (pt *TaskBlock) SetIndex(i int) {
+	pt.index = i
+}

--- a/responsemanager/peertaskqueue/peertaskqueue.go
+++ b/responsemanager/peertaskqueue/peertaskqueue.go
@@ -1,0 +1,118 @@
+package peertaskqueue
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertask"
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertracker"
+	pq "github.com/ipfs/go-ipfs-pq"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// PeerTaskQueue is a prioritized list of tasks to be executed on peers.
+// The queue puts tasks on in blocks, then alternates between peers (roughly)
+// to execute the block with the highest priority, or otherwise the one added
+// first if priorities are equal.
+type PeerTaskQueue struct {
+	lock         sync.Mutex
+	pQueue       pq.PQ
+	peerTrackers map[peer.ID]*peertracker.PeerTracker
+	frozenPeers  map[peer.ID]struct{}
+}
+
+// New creates a new PeerTaskQueue
+func New() *PeerTaskQueue {
+	return &PeerTaskQueue{
+		peerTrackers: make(map[peer.ID]*peertracker.PeerTracker),
+		frozenPeers:  make(map[peer.ID]struct{}),
+		pQueue:       pq.New(peertracker.PeerCompare),
+	}
+}
+
+// PushBlock adds a new block of tasks for the given peer to the queue
+func (ptq *PeerTaskQueue) PushBlock(to peer.ID, tasks ...peertask.Task) {
+	ptq.lock.Lock()
+	defer ptq.lock.Unlock()
+	peerTracker, ok := ptq.peerTrackers[to]
+	if !ok {
+		peerTracker = peertracker.New()
+		ptq.pQueue.Push(peerTracker)
+		ptq.peerTrackers[to] = peerTracker
+	}
+
+	peerTracker.PushBlock(to, tasks, func(e []peertask.Task) {
+		ptq.lock.Lock()
+		for _, task := range e {
+			peerTracker.TaskDone(task.Identifier)
+		}
+		ptq.pQueue.Update(peerTracker.Index())
+		ptq.lock.Unlock()
+	})
+	ptq.pQueue.Update(peerTracker.Index())
+}
+
+// PopBlock 'pops' the next block of tasks to be performed. Returns nil if no block exists.
+func (ptq *PeerTaskQueue) PopBlock() *peertask.TaskBlock {
+	ptq.lock.Lock()
+	defer ptq.lock.Unlock()
+	if ptq.pQueue.Len() == 0 {
+		return nil
+	}
+	peerTracker := ptq.pQueue.Pop().(*peertracker.PeerTracker)
+
+	out := peerTracker.PopBlock()
+	ptq.pQueue.Push(peerTracker)
+	return out
+}
+
+// Remove removes a task from the queue.
+func (ptq *PeerTaskQueue) Remove(identifier peertask.Identifier, p peer.ID) {
+	ptq.lock.Lock()
+	peerTracker, ok := ptq.peerTrackers[p]
+	if ok {
+		peerTracker.Remove(identifier)
+		// we now also 'freeze' that partner. If they sent us a cancel for a
+		// block we were about to send them, we should wait a short period of time
+		// to make sure we receive any other in-flight cancels before sending
+		// them a block they already potentially have
+		if !peerTracker.IsFrozen() {
+			ptq.frozenPeers[p] = struct{}{}
+		}
+
+		peerTracker.Freeze()
+		ptq.pQueue.Update(peerTracker.Index())
+	}
+	ptq.lock.Unlock()
+}
+
+// FullThaw completely thaws all peers in the queue so they can execute tasks.
+func (ptq *PeerTaskQueue) FullThaw() {
+	ptq.lock.Lock()
+	defer ptq.lock.Unlock()
+
+	for p := range ptq.frozenPeers {
+		peerTracker, ok := ptq.peerTrackers[p]
+		if ok {
+			peerTracker.FullThaw()
+			delete(ptq.frozenPeers, p)
+			ptq.pQueue.Update(peerTracker.Index())
+		}
+	}
+}
+
+// ThawRound unthaws peers incrementally, so that those have been frozen the least
+// become unfrozen and able to execute tasks first.
+func (ptq *PeerTaskQueue) ThawRound() {
+	ptq.lock.Lock()
+	defer ptq.lock.Unlock()
+
+	for p := range ptq.frozenPeers {
+		peerTracker, ok := ptq.peerTrackers[p]
+		if ok {
+			if peerTracker.Thaw() {
+				delete(ptq.frozenPeers, p)
+			}
+			ptq.pQueue.Update(peerTracker.Index())
+		}
+	}
+}

--- a/responsemanager/peertaskqueue/peertaskqueue_test.go
+++ b/responsemanager/peertaskqueue/peertaskqueue_test.go
@@ -1,0 +1,126 @@
+package peertaskqueue
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertask"
+	"github.com/ipfs/go-graphsync/testutil"
+)
+
+func TestPushPop(t *testing.T) {
+	ptq := New()
+	partner := testutil.GeneratePeers(1)[0]
+	alphabet := strings.Split("abcdefghijklmnopqrstuvwxyz", "")
+	vowels := strings.Split("aeiou", "")
+	consonants := func() []string {
+		var out []string
+		for _, letter := range alphabet {
+			skip := false
+			for _, vowel := range vowels {
+				if letter == vowel {
+					skip = true
+				}
+			}
+			if !skip {
+				out = append(out, letter)
+			}
+		}
+		return out
+	}()
+	sort.Strings(alphabet)
+	sort.Strings(vowels)
+	sort.Strings(consonants)
+
+	// add a bunch of blocks. cancel some. drain the queue. the queue should only have the kept tasks
+
+	for _, index := range rand.Perm(len(alphabet)) { // add blocks for all letters
+		letter := alphabet[index]
+		t.Log(partner.String())
+
+		ptq.PushBlock(partner, peertask.Task{Identifier: letter, Priority: math.MaxInt32 - index})
+	}
+	for _, consonant := range consonants {
+		ptq.Remove(consonant, partner)
+	}
+
+	ptq.FullThaw()
+
+	var out []string
+	for {
+		received := ptq.PopBlock()
+		if received == nil {
+			break
+		}
+
+		for _, task := range received.Tasks {
+			out = append(out, task.Identifier.(string))
+		}
+	}
+
+	// Tasks popped should already be in correct order
+	for i, expected := range vowels {
+		if out[i] != expected {
+			t.Fatal("received", out[i], "expected", expected)
+		}
+	}
+}
+
+// This test checks that peers wont starve out other peers
+func TestPeerRepeats(t *testing.T) {
+	ptq := New()
+	peers := testutil.GeneratePeers(4)
+	a := peers[0]
+	b := peers[1]
+	c := peers[2]
+	d := peers[3]
+
+	// Have each push some blocks
+
+	for i := 0; i < 5; i++ {
+		is := fmt.Sprint(i)
+		ptq.PushBlock(a, peertask.Task{Identifier: is})
+		ptq.PushBlock(b, peertask.Task{Identifier: is})
+		ptq.PushBlock(c, peertask.Task{Identifier: is})
+		ptq.PushBlock(d, peertask.Task{Identifier: is})
+	}
+
+	// now, pop off four tasks, there should be one from each
+	var targets []string
+	var tasks []*peertask.TaskBlock
+	for i := 0; i < 4; i++ {
+		t := ptq.PopBlock()
+		targets = append(targets, t.Target.Pretty())
+		tasks = append(tasks, t)
+	}
+
+	expected := []string{a.Pretty(), b.Pretty(), c.Pretty(), d.Pretty()}
+	sort.Strings(expected)
+	sort.Strings(targets)
+
+	t.Log(targets)
+	t.Log(expected)
+	for i, s := range targets {
+		if expected[i] != s {
+			t.Fatal("unexpected peer", s, expected[i])
+		}
+	}
+
+	// Now, if one of the tasks gets finished, the next task off the queue should
+	// be for the same peer
+	for blockI := 0; blockI < 4; blockI++ {
+		for i := 0; i < 4; i++ {
+			// its okay to mark the same task done multiple times here (JUST FOR TESTING)
+			tasks[i].Done(tasks[i].Tasks)
+
+			ntask := ptq.PopBlock()
+			if ntask.Target != tasks[i].Target {
+				t.Fatal("Expected task from peer with lowest active count")
+			}
+		}
+	}
+}

--- a/responsemanager/peertaskqueue/peertracker/peertracker.go
+++ b/responsemanager/peertaskqueue/peertracker/peertracker.go
@@ -1,0 +1,198 @@
+package peertracker
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertask"
+	pq "github.com/ipfs/go-ipfs-pq"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+// PeerTracker tracks task blocks for a single peer, as well as active tasks
+// for that peer
+type PeerTracker struct {
+
+	// Active is the number of track tasks this peer is currently
+	// processing
+	// active must be locked around as it will be updated externally
+	activelk    sync.Mutex
+	active      int
+	activeTasks map[peertask.Identifier]struct{}
+
+	// total number of task tasks for this task
+	numTasks int
+
+	// for the PQ interface
+	index int
+
+	freezeVal int
+
+	taskMap map[peertask.Identifier]*peertask.TaskBlock
+
+	// priority queue of tasks belonging to this peer
+	taskBlockQueue pq.PQ
+}
+
+// New creates a new PeerTracker
+func New() *PeerTracker {
+	return &PeerTracker{
+		taskBlockQueue: pq.New(peertask.WrapCompare(peertask.PriorityCompare)),
+		taskMap:        make(map[peertask.Identifier]*peertask.TaskBlock),
+		activeTasks:    make(map[peertask.Identifier]struct{}),
+	}
+}
+
+// PeerCompare implements pq.ElemComparator
+// returns true if peer 'a' has higher priority than peer 'b'
+func PeerCompare(a, b pq.Elem) bool {
+	pa := a.(*PeerTracker)
+	pb := b.(*PeerTracker)
+
+	// having no tasks means lowest priority
+	// having both of these checks ensures stability of the sort
+	if pa.numTasks == 0 {
+		return false
+	}
+	if pb.numTasks == 0 {
+		return true
+	}
+
+	if pa.freezeVal > pb.freezeVal {
+		return false
+	}
+	if pa.freezeVal < pb.freezeVal {
+		return true
+	}
+
+	if pa.active == pb.active {
+		// sorting by taskQueue.Len() aids in cleaning out trash tasks faster
+		// if we sorted instead by requests, one peer could potentially build up
+		// a huge number of cancelled tasks in the queue resulting in a memory leak
+		return pa.taskBlockQueue.Len() > pb.taskBlockQueue.Len()
+	}
+	return pa.active < pb.active
+}
+
+// StartTask signals that a task was started for this peer.
+func (p *PeerTracker) StartTask(identifier peertask.Identifier) {
+	p.activelk.Lock()
+	p.activeTasks[identifier] = struct{}{}
+	p.active++
+	p.activelk.Unlock()
+}
+
+// TaskDone signals that a task was completed for this peer.
+func (p *PeerTracker) TaskDone(identifier peertask.Identifier) {
+	p.activelk.Lock()
+	delete(p.activeTasks, identifier)
+	p.active--
+	if p.active < 0 {
+		panic("more tasks finished than started!")
+	}
+	p.activelk.Unlock()
+}
+
+// Index implements pq.Elem.
+func (p *PeerTracker) Index() int {
+	return p.index
+}
+
+// SetIndex implements pq.Elem.
+func (p *PeerTracker) SetIndex(i int) {
+	p.index = i
+}
+
+// PushBlock adds a new block of tasks on to a peers queue from the given
+// peer ID, list of tasks, and task block completion function
+func (p *PeerTracker) PushBlock(target peer.ID, tasks []peertask.Task, done func(e []peertask.Task)) {
+
+	p.activelk.Lock()
+	defer p.activelk.Unlock()
+
+	var priority int
+	newTasks := make([]peertask.Task, 0, len(tasks))
+	for _, task := range tasks {
+		if _, ok := p.activeTasks[task.Identifier]; ok {
+			continue
+		}
+		if taskBlock, ok := p.taskMap[task.Identifier]; ok {
+			if task.Priority > taskBlock.Priority {
+				taskBlock.Priority = task.Priority
+				p.taskBlockQueue.Update(taskBlock.Index())
+			}
+			continue
+		}
+		if task.Priority > priority {
+			priority = task.Priority
+		}
+		newTasks = append(newTasks, task)
+	}
+
+	if len(newTasks) == 0 {
+		return
+	}
+
+	taskBlock := peertask.NewTaskBlock(newTasks, priority, target, done)
+	p.taskBlockQueue.Push(taskBlock)
+	for _, task := range newTasks {
+		p.taskMap[task.Identifier] = taskBlock
+	}
+	p.numTasks += len(newTasks)
+}
+
+// PopBlock removes a block of tasks from this peers queue
+func (p *PeerTracker) PopBlock() *peertask.TaskBlock {
+	var out *peertask.TaskBlock
+	for p.taskBlockQueue.Len() > 0 && p.freezeVal == 0 {
+		out = p.taskBlockQueue.Pop().(*peertask.TaskBlock)
+
+		for _, task := range out.Tasks {
+			delete(p.taskMap, task.Identifier)
+		}
+		out.PruneTasks()
+
+		if len(out.Tasks) > 0 {
+			for _, task := range out.Tasks {
+				p.numTasks--
+				p.StartTask(task.Identifier)
+			}
+		} else {
+			out = nil
+			continue
+		}
+		break
+	}
+	return out
+}
+
+// Remove removes the task with the given identifier from this peers queue
+func (p *PeerTracker) Remove(identifier peertask.Identifier) {
+	taskBlock, ok := p.taskMap[identifier]
+	if ok {
+		taskBlock.MarkPrunable(identifier)
+		p.numTasks--
+	}
+}
+
+// Freeze increments the freeze value for this peer. While a peer is frozen
+// (freeze value > 0) it will not execute tasks.
+func (p *PeerTracker) Freeze() {
+	p.freezeVal++
+}
+
+// Thaw decrements the freeze value for this peer. While a peer is frozen
+// (freeze value > 0) it will not execute tasks.
+func (p *PeerTracker) Thaw() bool {
+	p.freezeVal -= (p.freezeVal + 1) / 2
+	return p.freezeVal <= 0
+}
+
+// FullThaw completely unfreezes this peer so it can execute tasks.
+func (p *PeerTracker) FullThaw() {
+	p.freezeVal = 0
+}
+
+// IsFrozen returns whether this peer is frozen and unable to execute tasks.
+func (p *PeerTracker) IsFrozen() bool {
+	return p.freezeVal > 0
+}

--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -1,0 +1,101 @@
+package responsebuilder
+
+import (
+	"github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipld/go-ipld-prime"
+)
+
+// ResponseBuilder captures componenst of a response message across multiple
+// requests for a given peer and then generates the corresponding
+// GraphSync message components once responses are ready to send.
+type ResponseBuilder struct {
+	outgoingBlocks     []blocks.Block
+	completedResponses map[gsmsg.GraphSyncRequestID]bool
+	outgoingResponses  map[gsmsg.GraphSyncRequestID]map[ipld.Link]bool
+}
+
+// New generates a new ResponseBuilder.
+func New() *ResponseBuilder {
+	return &ResponseBuilder{
+		completedResponses: make(map[gsmsg.GraphSyncRequestID]bool),
+		outgoingResponses:  make(map[gsmsg.GraphSyncRequestID]map[ipld.Link]bool),
+	}
+}
+
+// AddBlock adds the given block to the response.
+func (rb *ResponseBuilder) AddBlock(block blocks.Block) {
+	rb.outgoingBlocks = append(rb.outgoingBlocks, block)
+}
+
+// AddLink adds the given link and whether its block is present
+// to the response for the given request ID.
+func (rb *ResponseBuilder) AddLink(requestID gsmsg.GraphSyncRequestID, link ipld.Link, blockPresent bool) {
+	linksForRequest, ok := rb.outgoingResponses[requestID]
+	if !ok {
+		linksForRequest = make(map[ipld.Link]bool)
+		rb.outgoingResponses[requestID] = linksForRequest
+	}
+	linksForRequest[link] = blockPresent
+}
+
+// AddCompletedRequest marks the given request as completed in the response,
+// as well as whether the graphsync request responded with complete or partial
+// data.
+func (rb *ResponseBuilder) AddCompletedRequest(requestID gsmsg.GraphSyncRequestID, isComplete bool) {
+	rb.completedResponses[requestID] = isComplete
+	// make sure this completion goes out in next response even if no links are sent
+	_, ok := rb.outgoingResponses[requestID]
+	if !ok {
+		rb.outgoingResponses[requestID] = make(map[ipld.Link]bool)
+	}
+}
+
+// Empty returns true if there is no content to send
+func (rb *ResponseBuilder) Empty() bool {
+	return len(rb.outgoingBlocks) == 0 && len(rb.outgoingResponses) == 0
+}
+
+// Build assembles and encodes response data from the added requests, links, and blocks.
+func (rb *ResponseBuilder) Build(ipldBridge ipldbridge.IPLDBridge) ([]gsmsg.GraphSyncResponse, []blocks.Block, error) {
+	responses := make([]gsmsg.GraphSyncResponse, 0, len(rb.outgoingResponses))
+	for requestID, linkMap := range rb.outgoingResponses {
+		extra, err := makeEncodedData(linkMap, ipldBridge)
+		if err != nil {
+			return nil, nil, err
+		}
+		isFull, isComplete := rb.completedResponses[requestID]
+		responses = append(responses, gsmsg.NewResponse(requestID, responseCode(isFull, isComplete), extra))
+	}
+	return responses, rb.outgoingBlocks, nil
+}
+
+func makeEncodedData(entries map[ipld.Link]bool, ipldBridge ipldbridge.IPLDBridge) ([]byte, error) {
+	node, err := ipldBridge.BuildNode(func(nb ipldbridge.NodeBuilder) ipld.Node {
+		return nb.CreateList(func(lb ipldbridge.ListBuilder, nb ipldbridge.NodeBuilder) {
+			for link, blockPresent := range entries {
+				lb.Append(
+					nb.CreateMap(func(mb ipldbridge.MapBuilder, knb ipldbridge.NodeBuilder, vnb ipldbridge.NodeBuilder) {
+						mb.Insert(knb.CreateString("link"), vnb.CreateLink(link))
+						mb.Insert(knb.CreateString("blockPresent"), vnb.CreateBool(blockPresent))
+					}),
+				)
+			}
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+	return ipldBridge.EncodeNode(node)
+}
+
+func responseCode(isFull bool, isComplete bool) gsmsg.GraphSyncResponseStatusCode {
+	if !isComplete {
+		return gsmsg.PartialResponse
+	}
+	if isFull {
+		return gsmsg.RequestCompletedFull
+	}
+	return gsmsg.RequestCompletedPartial
+}

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -31,17 +31,17 @@ func TestMessageBuilding(t *testing.T) {
 	rb.AddLink(requestID1, links[1], false)
 	rb.AddLink(requestID1, links[2], true)
 
-	rb.AddCompletedRequest(requestID1, false)
+	rb.AddCompletedRequest(requestID1, gsmsg.RequestCompletedPartial)
 
 	rb.AddLink(requestID2, links[1], true)
 	rb.AddLink(requestID2, links[2], true)
 
-	rb.AddCompletedRequest(requestID2, true)
+	rb.AddCompletedRequest(requestID2, gsmsg.RequestCompletedFull)
 
 	rb.AddLink(requestID3, links[0], true)
 	rb.AddLink(requestID3, links[1], true)
 
-	rb.AddCompletedRequest(requestID4, true)
+	rb.AddCompletedRequest(requestID4, gsmsg.RequestCompletedFull)
 
 	for _, block := range blocks {
 		rb.AddBlock(block)

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -1,0 +1,144 @@
+package responsebuilder
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/ipld/go-ipld-prime/fluent"
+
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/testbridge"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+func TestMessageBuilding(t *testing.T) {
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	rb := New()
+	blocks := testutil.GenerateBlocksOfSize(3, 100)
+	links := make([]ipld.Link, 0, len(blocks))
+	for _, block := range blocks {
+		links = append(links, cidlink.Link{Cid: block.Cid()})
+	}
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID3 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID4 := gsmsg.GraphSyncRequestID(rand.Int31())
+
+	rb.AddLink(requestID1, links[0], true)
+	rb.AddLink(requestID1, links[1], false)
+	rb.AddLink(requestID1, links[2], true)
+
+	rb.AddCompletedRequest(requestID1, false)
+
+	rb.AddLink(requestID2, links[1], true)
+	rb.AddLink(requestID2, links[2], true)
+
+	rb.AddCompletedRequest(requestID2, true)
+
+	rb.AddLink(requestID3, links[0], true)
+	rb.AddLink(requestID3, links[1], true)
+
+	rb.AddCompletedRequest(requestID4, true)
+
+	for _, block := range blocks {
+		rb.AddBlock(block)
+	}
+
+	responses, sentBlocks, err := rb.Build(ipldBridge)
+
+	if err != nil {
+		t.Fatal("Error building responses")
+	}
+
+	if len(responses) != 4 {
+		t.Fatal("Assembled wrong number of responses")
+	}
+
+	response1, err := findResponseForRequestID(responses, requestID1)
+	if err != nil || response1.Status() != gsmsg.RequestCompletedPartial {
+		t.Fatal("did not generate completed partial response")
+	}
+
+	response1Metadata, err := ipldBridge.DecodeNode(response1.Extra())
+	if err != nil {
+		t.Fatal("unable to read metadata from response")
+	}
+	analyzeMetadata(t, response1Metadata, map[ipld.Link]bool{
+		links[0]: true,
+		links[1]: false,
+		links[2]: true,
+	})
+	response2, err := findResponseForRequestID(responses, requestID2)
+	if err != nil || response2.Status() != gsmsg.RequestCompletedFull {
+		t.Fatal("did not generate completed partial response")
+	}
+	response2Metadata, err := ipldBridge.DecodeNode(response2.Extra())
+	if err != nil {
+		t.Fatal("unable to read metadata from response")
+	}
+	analyzeMetadata(t, response2Metadata, map[ipld.Link]bool{
+		links[1]: true,
+		links[2]: true,
+	})
+
+	response3, err := findResponseForRequestID(responses, requestID3)
+	if err != nil || response3.Status() != gsmsg.PartialResponse {
+		t.Fatal("did not generate completed partial response")
+	}
+	response3Metadata, err := ipldBridge.DecodeNode(response3.Extra())
+	if err != nil {
+		t.Fatal("unable to read metadata from response")
+	}
+	analyzeMetadata(t, response3Metadata, map[ipld.Link]bool{
+		links[0]: true,
+		links[1]: true,
+	})
+
+	response4, err := findResponseForRequestID(responses, requestID4)
+	if err != nil || response4.Status() != gsmsg.RequestCompletedFull {
+		t.Fatal("did not generate completed partial response")
+	}
+
+	if len(sentBlocks) != len(blocks) {
+		t.Fatal("Did not send all blocks")
+	}
+
+	for _, block := range sentBlocks {
+		if !testutil.ContainsBlock(blocks, block) {
+			t.Fatal("Sent incorrect block")
+		}
+	}
+}
+
+func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID gsmsg.GraphSyncRequestID) (gsmsg.GraphSyncResponse, error) {
+	for _, response := range responses {
+		if response.RequestID() == requestID {
+			return response, nil
+		}
+	}
+	return gsmsg.GraphSyncResponse{}, fmt.Errorf("Response Not Found")
+}
+
+func analyzeMetadata(t *testing.T, metadata ipld.Node, expectedMetadata map[ipld.Link]bool) {
+	if metadata.Length() != len(expectedMetadata) {
+		t.Fatal("Wrong amount of metadata on first response")
+	}
+	err := fluent.Recover(func() {
+		safeMetadata := fluent.WrapNode(metadata)
+		for i := 0; i < len(expectedMetadata); i++ {
+			metadatum := safeMetadata.TraverseIndex(i)
+			link := metadatum.TraverseField("link").AsLink()
+			blockPresent := metadatum.TraverseField("blockPresent").AsBool()
+			expectedBlockPresent, ok := expectedMetadata[link]
+			if !ok || expectedBlockPresent != blockPresent {
+				t.Fatal("Metadata did not match expected")
+			}
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -1,0 +1,287 @@
+package responsemanager
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/go-graphsync/responsemanager/loader"
+	ipld "github.com/ipld/go-ipld-prime"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertask"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+const (
+	maxInProcessRequests = 6
+	thawSpeed            = time.Millisecond * 100
+)
+
+type inProgressResponseStatus struct {
+	ctx      context.Context
+	cancelFn func()
+	selector []byte
+}
+
+type responseKey struct {
+	p         peer.ID
+	requestID gsmsg.GraphSyncRequestID
+}
+
+type responseTaskData struct {
+	ctx      context.Context
+	selector []byte
+}
+
+// QueryQueue is an interface that can receive new selector query tasks
+// and prioritize them as needed, and pop them off later
+type QueryQueue interface {
+	PushBlock(to peer.ID, tasks ...peertask.Task)
+	PopBlock() *peertask.TaskBlock
+	Remove(identifier peertask.Identifier, p peer.ID)
+	ThawRound()
+}
+
+// PeerManager is an interface that returns sender interfaces for peer responses.
+type PeerManager interface {
+	SenderForPeer(p peer.ID) peerresponsemanager.PeerResponseSender
+}
+
+type responseManagerMessage interface {
+	handle(rm *ResponseManager)
+}
+
+// ResponseManager handles incoming requests from the network, initiates selector
+// traversals, and transmits responses
+type ResponseManager struct {
+	ctx         context.Context
+	cancelFn    context.CancelFunc
+	loader      ipldbridge.Loader
+	ipldBridge  ipldbridge.IPLDBridge
+	peerManager PeerManager
+	queryQueue  QueryQueue
+
+	messages            chan responseManagerMessage
+	workSignal          chan struct{}
+	ticker              *time.Ticker
+	inProgressResponses map[responseKey]inProgressResponseStatus
+}
+
+// New creates a new response manager from the given context, loader,
+// bridge to IPLD interface, peerManager, and queryQueue.
+func New(ctx context.Context,
+	loader ipldbridge.Loader,
+	ipldBridge ipldbridge.IPLDBridge,
+	peerManager PeerManager,
+	queryQueue QueryQueue) *ResponseManager {
+	ctx, cancelFn := context.WithCancel(ctx)
+	return &ResponseManager{
+		ctx:                 ctx,
+		cancelFn:            cancelFn,
+		loader:              loader,
+		ipldBridge:          ipldBridge,
+		peerManager:         peerManager,
+		queryQueue:          queryQueue,
+		messages:            make(chan responseManagerMessage, 16),
+		workSignal:          make(chan struct{}, 1),
+		ticker:              time.NewTicker(thawSpeed),
+		inProgressResponses: make(map[responseKey]inProgressResponseStatus),
+	}
+}
+
+type processRequestMessage struct {
+	p        peer.ID
+	requests []gsmsg.GraphSyncRequest
+}
+
+// ProcessRequests processes incoming requests for the given peer
+func (rm *ResponseManager) ProcessRequests(p peer.ID, requests []gsmsg.GraphSyncRequest) {
+	select {
+	case rm.messages <- &processRequestMessage{p, requests}:
+	case <-rm.ctx.Done():
+	}
+}
+
+type synchronizeMessage struct {
+	sync chan struct{}
+}
+
+// this is a test utility method to force all messages to get processed
+func (rm *ResponseManager) synchronize() {
+	sync := make(chan struct{})
+	select {
+	case rm.messages <- &synchronizeMessage{sync}:
+	case <-rm.ctx.Done():
+	}
+	select {
+	case <-sync:
+	case <-rm.ctx.Done():
+	}
+}
+
+type responseDataRequest struct {
+	key          responseKey
+	taskDataChan chan *responseTaskData
+}
+
+type finishResponseRequest struct {
+	key responseKey
+}
+
+func (rm *ResponseManager) processQueriesWorker() {
+	taskDataChan := make(chan *responseTaskData)
+	var taskData *responseTaskData
+	for {
+		nextTaskBlock := rm.queryQueue.PopBlock()
+		for nextTaskBlock == nil {
+			select {
+			case <-rm.ctx.Done():
+				return
+			case <-rm.workSignal:
+				nextTaskBlock = rm.queryQueue.PopBlock()
+			case <-rm.ticker.C:
+				rm.queryQueue.ThawRound()
+				nextTaskBlock = rm.queryQueue.PopBlock()
+			}
+		}
+		for _, task := range nextTaskBlock.Tasks {
+			key := task.Identifier.(responseKey)
+			select {
+			case rm.messages <- &responseDataRequest{key, taskDataChan}:
+			case <-rm.ctx.Done():
+				return
+			}
+			select {
+			case taskData = <-taskDataChan:
+			case <-rm.ctx.Done():
+				return
+			}
+			rm.executeQuery(taskData.ctx, key.p, key.requestID, taskData.selector)
+			select {
+			case rm.messages <- &finishResponseRequest{key}:
+			case <-rm.ctx.Done():
+			}
+		}
+		nextTaskBlock.Done(nextTaskBlock.Tasks)
+
+	}
+
+}
+
+func noopVisitor(ipldbridge.TraversalProgress, ipld.Node, ipldbridge.TraversalReason) error {
+	return nil
+}
+
+func (rm *ResponseManager) executeQuery(ctx context.Context,
+	p peer.ID,
+	requestID gsmsg.GraphSyncRequestID,
+	selector []byte) {
+	peerResponseSender := rm.peerManager.SenderForPeer(p)
+	selectorSpec, err := rm.ipldBridge.DecodeNode(selector)
+	if err != nil {
+		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		return
+	}
+	root, reifiedSelector, err := rm.ipldBridge.DecodeSelectorSpec(selectorSpec)
+	if err != nil {
+		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		return
+	}
+	wrappedLoader := loader.WrapLoader(rm.loader, requestID, peerResponseSender)
+	err = rm.ipldBridge.Traverse(ctx, wrappedLoader, root, reifiedSelector, noopVisitor)
+	if err != nil {
+		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		return
+	}
+	peerResponseSender.FinishRequest(requestID)
+}
+
+// Startup starts processing for the WantManager.
+func (rm *ResponseManager) Startup() {
+	go rm.run()
+}
+
+// Shutdown ends processing for the want manager.
+func (rm *ResponseManager) Shutdown() {
+	rm.cancelFn()
+}
+
+func (rm *ResponseManager) cleanupInProcessResponses() {
+	for _, response := range rm.inProgressResponses {
+		response.cancelFn()
+	}
+}
+
+func (rm *ResponseManager) run() {
+	defer rm.cleanupInProcessResponses()
+	for i := 0; i < maxInProcessRequests; i++ {
+		go rm.processQueriesWorker()
+	}
+
+	for {
+		select {
+		case <-rm.ctx.Done():
+			return
+		case message := <-rm.messages:
+			message.handle(rm)
+		}
+	}
+}
+
+func (prm *processRequestMessage) handle(rm *ResponseManager) {
+	for _, request := range prm.requests {
+		key := responseKey{p: prm.p, requestID: request.ID()}
+		if !request.IsCancel() {
+			ctx, cancelFn := context.WithCancel(rm.ctx)
+			rm.inProgressResponses[key] =
+				inProgressResponseStatus{
+					ctx:      ctx,
+					cancelFn: cancelFn,
+					selector: request.Selector(),
+				}
+			rm.queryQueue.PushBlock(prm.p, peertask.Task{Identifier: key, Priority: int(request.Priority())})
+			select {
+			case rm.workSignal <- struct{}{}:
+			default:
+			}
+		} else {
+			rm.queryQueue.Remove(key, key.p)
+			response, ok := rm.inProgressResponses[key]
+			if ok {
+				response.cancelFn()
+			}
+		}
+	}
+}
+
+func (rdr *responseDataRequest) handle(rm *ResponseManager) {
+	response, ok := rm.inProgressResponses[rdr.key]
+	var taskData *responseTaskData
+	if ok {
+		taskData = &responseTaskData{response.ctx, response.selector}
+	} else {
+		taskData = nil
+	}
+	select {
+	case <-rm.ctx.Done():
+	case rdr.taskDataChan <- taskData:
+	}
+}
+
+func (frr *finishResponseRequest) handle(rm *ResponseManager) {
+	response, ok := rm.inProgressResponses[frr.key]
+	if !ok {
+		return
+	}
+	delete(rm.inProgressResponses, frr.key)
+	response.cancelFn()
+}
+
+func (sm *synchronizeMessage) handle(rm *ResponseManager) {
+	select {
+	case <-rm.ctx.Done():
+	case sm.sync <- struct{}{}:
+	}
+}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -97,10 +97,11 @@ type processRequestMessage struct {
 }
 
 // ProcessRequests processes incoming requests for the given peer
-func (rm *ResponseManager) ProcessRequests(p peer.ID, requests []gsmsg.GraphSyncRequest) {
+func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, requests []gsmsg.GraphSyncRequest) {
 	select {
 	case rm.messages <- &processRequestMessage{p, requests}:
 	case <-rm.ctx.Done():
+	case <-ctx.Done():
 	}
 }
 

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -1,0 +1,321 @@
+package responsemanager
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-block-format"
+
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
+	"github.com/ipfs/go-graphsync/responsemanager/peertaskqueue/peertask"
+	"github.com/ipfs/go-graphsync/testbridge"
+	"github.com/ipfs/go-graphsync/testutil"
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	peer "github.com/libp2p/go-libp2p-peer"
+)
+
+type fakeQueryQueue struct {
+	popWait   sync.WaitGroup
+	queriesLk sync.RWMutex
+	queries   []*peertask.TaskBlock
+}
+
+func (fqq *fakeQueryQueue) PushBlock(to peer.ID, tasks ...peertask.Task) {
+	fqq.queriesLk.Lock()
+	fqq.queries = append(fqq.queries, &peertask.TaskBlock{
+		Tasks:    tasks,
+		Priority: tasks[0].Priority,
+		Target:   to,
+		Done:     func([]peertask.Task) {},
+	})
+	fqq.queriesLk.Unlock()
+}
+
+func (fqq *fakeQueryQueue) PopBlock() *peertask.TaskBlock {
+	fqq.popWait.Wait()
+	fqq.queriesLk.Lock()
+	defer fqq.queriesLk.Unlock()
+	if len(fqq.queries) == 0 {
+		return nil
+	}
+	block := fqq.queries[0]
+	fqq.queries = fqq.queries[1:]
+	return block
+}
+
+func (fqq *fakeQueryQueue) Remove(identifier peertask.Identifier, p peer.ID) {
+	fqq.queriesLk.Lock()
+	defer fqq.queriesLk.Unlock()
+	for i, query := range fqq.queries {
+		if query.Target == p {
+			for j, task := range query.Tasks {
+				if task.Identifier == identifier {
+					query.Tasks = append(query.Tasks[:j], query.Tasks[j+1:]...)
+				}
+			}
+			if len(query.Tasks) == 0 {
+				fqq.queries = append(fqq.queries[:i], fqq.queries[i+1:]...)
+			}
+		}
+	}
+}
+
+func (fqq *fakeQueryQueue) ThawRound() {
+
+}
+
+type fakePeerManager struct {
+	lastPeer           peer.ID
+	peerResponseSender peerresponsemanager.PeerResponseSender
+}
+
+func (fpm *fakePeerManager) SenderForPeer(p peer.ID) peerresponsemanager.PeerResponseSender {
+	fpm.lastPeer = p
+	return fpm.peerResponseSender
+}
+
+type sentResponse struct {
+	requestID gsmsg.GraphSyncRequestID
+	link      ipld.Link
+	data      []byte
+}
+
+type fakePeerResponseSender struct {
+	sentResponses        chan sentResponse
+	lastCompletedRequest chan gsmsg.GraphSyncRequestID
+}
+
+func (fprs *fakePeerResponseSender) Startup()  {}
+func (fprs *fakePeerResponseSender) Shutdown() {}
+
+func (fprs *fakePeerResponseSender) SendResponse(
+	requestID gsmsg.GraphSyncRequestID,
+	link ipld.Link,
+	data []byte,
+) {
+	fprs.sentResponses <- sentResponse{requestID, link, data}
+}
+
+func (fprs *fakePeerResponseSender) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
+	fprs.lastCompletedRequest <- requestID
+}
+
+func (fprs *fakePeerResponseSender) FinishWithError(requestID gsmsg.GraphSyncRequestID, status gsmsg.GraphSyncResponseStatusCode) {
+	fprs.lastCompletedRequest <- requestID
+}
+
+func makeLoader(blks []blocks.Block) ipldbridge.Loader {
+	return func(ipldLink ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
+		lnk := ipldLink.(cidlink.Link).Cid
+		for _, block := range blks {
+			if block.Cid() == lnk {
+				return bytes.NewReader(block.RawData()), nil
+			}
+		}
+		return nil, fmt.Errorf("unable to load block")
+	}
+}
+func TestIncomingQuery(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	blks := testutil.GenerateBlocksOfSize(5, 20)
+	loader := makeLoader(blks)
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	requestIDChan := make(chan gsmsg.GraphSyncRequestID, 1)
+	sentResponses := make(chan sentResponse, len(blks))
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	peerManager := &fakePeerManager{peerResponseSender: fprs}
+	queryQueue := &fakeQueryQueue{}
+	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+	responseManager.Startup()
+
+	cids := make([]cid.Cid, 0, 5)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	selectorSpec := testbridge.NewMockSelectorSpec(cids)
+	selector, err := ipldBridge.EncodeNode(selectorSpec)
+	if err != nil {
+		t.Fatal("error encoding selector")
+	}
+	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requests := []gsmsg.GraphSyncRequest{
+		gsmsg.NewRequest(requestID, selector, gsmsg.GraphSyncPriority(math.MaxInt32)),
+	}
+	p := testutil.GeneratePeers(1)[0]
+	responseManager.ProcessRequests(p, requests)
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have completed request but didn't")
+	case <-requestIDChan:
+	}
+	for i := 0; i < len(blks); i++ {
+		select {
+		case sentResponse := <-sentResponses:
+			k := sentResponse.link.(cidlink.Link)
+			blockIndex := testutil.IndexOf(blks, k.Cid)
+			if blockIndex == -1 {
+				t.Fatal("sent incorrect link")
+			}
+			if !reflect.DeepEqual(sentResponse.data, blks[blockIndex].RawData()) {
+				t.Fatal("sent incorrect data")
+			}
+			if sentResponse.requestID != requestID {
+				t.Fatal("incorrect response id")
+			}
+		case <-ctx.Done():
+			t.Fatal("did not send enough responses")
+		}
+	}
+}
+
+func TestCancellationQueryInProgress(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	blks := testutil.GenerateBlocksOfSize(5, 20)
+	loader := makeLoader(blks)
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	requestIDChan := make(chan gsmsg.GraphSyncRequestID)
+	sentResponses := make(chan sentResponse)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	peerManager := &fakePeerManager{peerResponseSender: fprs}
+	queryQueue := &fakeQueryQueue{}
+	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+	responseManager.Startup()
+
+	cids := make([]cid.Cid, 0, 5)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	selectorSpec := testbridge.NewMockSelectorSpec(cids)
+	selector, err := ipldBridge.EncodeNode(selectorSpec)
+	if err != nil {
+		t.Fatal("error encoding selector")
+	}
+	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requests := []gsmsg.GraphSyncRequest{
+		gsmsg.NewRequest(requestID, selector, gsmsg.GraphSyncPriority(math.MaxInt32)),
+	}
+	p := testutil.GeneratePeers(1)[0]
+	responseManager.ProcessRequests(p, requests)
+
+	// read one block
+	select {
+	case sentResponse := <-sentResponses:
+		k := sentResponse.link.(cidlink.Link)
+		blockIndex := testutil.IndexOf(blks, k.Cid)
+		if blockIndex == -1 {
+			t.Fatal("sent incorrect link")
+		}
+		if !reflect.DeepEqual(sentResponse.data, blks[blockIndex].RawData()) {
+			t.Fatal("sent incorrect data")
+		}
+		if sentResponse.requestID != requestID {
+			t.Fatal("incorrect response id")
+		}
+	case <-ctx.Done():
+		t.Fatal("did not send responses")
+	}
+
+	// send a cancellation
+	requests = []gsmsg.GraphSyncRequest{
+		gsmsg.CancelRequest(requestID),
+	}
+	responseManager.ProcessRequests(p, requests)
+
+	responseManager.synchronize()
+
+	// read one block -- to unblock processing
+	select {
+	case sentResponse := <-sentResponses:
+		k := sentResponse.link.(cidlink.Link)
+		blockIndex := testutil.IndexOf(blks, k.Cid)
+		if blockIndex == -1 {
+			t.Fatal("sent incorrect link")
+		}
+		if !reflect.DeepEqual(sentResponse.data, blks[blockIndex].RawData()) {
+			t.Fatal("sent incorrect data")
+		}
+		if sentResponse.requestID != requestID {
+			t.Fatal("incorrect response id")
+		}
+	case <-ctx.Done():
+		t.Fatal("did not send responses")
+	}
+
+	// at this point traversal should abort and we should receive a completion
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have completed request but didn't")
+	case <-sentResponses:
+		t.Fatal("should not send any more responses")
+	case <-requestIDChan:
+	}
+}
+
+func TestEarlyCancellation(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	blks := testutil.GenerateBlocksOfSize(5, 20)
+	loader := makeLoader(blks)
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	requestIDChan := make(chan gsmsg.GraphSyncRequestID)
+	sentResponses := make(chan sentResponse)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	peerManager := &fakePeerManager{peerResponseSender: fprs}
+	queryQueue := &fakeQueryQueue{}
+	queryQueue.popWait.Add(1)
+	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+	responseManager.Startup()
+
+	cids := make([]cid.Cid, 0, 5)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+	selectorSpec := testbridge.NewMockSelectorSpec(cids)
+	selector, err := ipldBridge.EncodeNode(selectorSpec)
+	if err != nil {
+		t.Fatal("error encoding selector")
+	}
+	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requests := []gsmsg.GraphSyncRequest{
+		gsmsg.NewRequest(requestID, selector, gsmsg.GraphSyncPriority(math.MaxInt32)),
+	}
+	p := testutil.GeneratePeers(1)[0]
+	responseManager.ProcessRequests(p, requests)
+
+	// send a cancellation
+	requests = []gsmsg.GraphSyncRequest{
+		gsmsg.CancelRequest(requestID),
+	}
+	responseManager.ProcessRequests(p, requests)
+
+	responseManager.synchronize()
+
+	// unblock popping from queue
+	queryQueue.popWait.Done()
+
+	// verify no responses processed
+	select {
+	case <-ctx.Done():
+	case <-sentResponses:
+		t.Fatal("should not send any more responses")
+	case <-requestIDChan:
+		t.Fatal("should not send have completed response")
+	}
+}

--- a/testbridge/mockLoader.go
+++ b/testbridge/mockLoader.go
@@ -1,0 +1,26 @@
+package testbridge
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/ipfs/go-block-format"
+
+	ipldbridge "github.com/ipfs/go-graphsync/ipldbridge"
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+)
+
+// NewMockLoader returns a new loader function that loads only the given blocks
+func NewMockLoader(blks []blocks.Block) ipldbridge.Loader {
+	return func(ipldLink ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
+		lnk := ipldLink.(cidlink.Link).Cid
+		for _, block := range blks {
+			if block.Cid() == lnk {
+				return bytes.NewReader(block.RawData()), nil
+			}
+		}
+		return nil, fmt.Errorf("unable to load block")
+	}
+}

--- a/testbridge/mocklink.go
+++ b/testbridge/mocklink.go
@@ -1,0 +1,30 @@
+package testbridge
+
+import (
+	"context"
+	"fmt"
+
+	ipldbridge "github.com/ipfs/go-graphsync/ipldbridge"
+	ipld "github.com/ipld/go-ipld-prime"
+)
+
+type mockLink struct {
+	index int
+}
+
+var nextIndex int
+
+// NewMockLink produces an object that conforms to the ipld Link interface.
+func NewMockLink() ipld.Link {
+	nextIndex++
+	return &mockLink{index: nextIndex}
+}
+func (ml *mockLink) Load(context.Context, ipldbridge.LinkContext, ipld.NodeBuilder, ipldbridge.Loader) (ipld.Node, error) {
+	return nil, fmt.Errorf("Cannot load mock link")
+}
+
+func (ml *mockLink) LinkBuilder() ipld.LinkBuilder {
+	return nil
+}
+
+func (ml *mockLink) String() string { return "" }

--- a/testbridge/mocknodes.go
+++ b/testbridge/mocknodes.go
@@ -31,17 +31,16 @@ func NewUnencodableSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
 	return &mockSelectorSpec{cidsVisited, false, true}
 }
 
-func (mss *mockSelectorSpec) Kind() ipld.ReprKind { return ipld.ReprKind_Null }
+func (mss *mockSelectorSpec) ReprKind() ipld.ReprKind { return ipld.ReprKind_Null }
 func (mss *mockSelectorSpec) TraverseField(key string) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")
 }
 func (mss *mockSelectorSpec) TraverseIndex(idx int) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")
 }
-func (mss *mockSelectorSpec) Keys() ipld.KeyIterator { return &mockKeyIterator{} }
-func (mss *mockSelectorSpec) KeysImmediate() ([]string, error) {
-	return nil, fmt.Errorf("404")
-}
+func (mss *mockSelectorSpec) ListIterator() ipld.ListIterator { return nil }
+func (mss *mockSelectorSpec) MapIterator() ipld.MapIterator   { return nil }
+
 func (mss *mockSelectorSpec) Length() int                   { return 0 }
 func (mss *mockSelectorSpec) IsNull() bool                  { return true }
 func (mss *mockSelectorSpec) AsBool() (bool, error)         { return false, fmt.Errorf("404") }
@@ -52,12 +51,6 @@ func (mss *mockSelectorSpec) AsBytes() ([]byte, error)      { return nil, fmt.Er
 func (mss *mockSelectorSpec) AsLink() (ipld.Link, error)    { return nil, fmt.Errorf("404") }
 func (mss *mockSelectorSpec) NodeBuilder() ipld.NodeBuilder { return &mockBuilder{} }
 
-type mockKeyIterator struct {
-}
-
-func (mki *mockKeyIterator) Next() (string, error) { return "", fmt.Errorf("404") }
-func (mki *mockKeyIterator) HasNext() bool         { return false }
-
 type mockBlockNode struct {
 	data []byte
 }
@@ -67,17 +60,17 @@ func NewMockBlockNode(data []byte) ipld.Node {
 	return &mockBlockNode{data}
 }
 
-func (mbn *mockBlockNode) Kind() ipld.ReprKind { return ipld.ReprKind_Bytes }
+func (mbn *mockBlockNode) ReprKind() ipld.ReprKind { return ipld.ReprKind_Bytes }
 func (mbn *mockBlockNode) TraverseField(key string) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")
 }
 func (mbn *mockBlockNode) TraverseIndex(idx int) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")
 }
-func (mbn *mockBlockNode) Keys() ipld.KeyIterator { return &mockKeyIterator{} }
-func (mbn *mockBlockNode) KeysImmediate() ([]string, error) {
-	return nil, fmt.Errorf("404")
-}
+
+func (mbn *mockBlockNode) ListIterator() ipld.ListIterator { return nil }
+func (mbn *mockBlockNode) MapIterator() ipld.MapIterator   { return nil }
+
 func (mbn *mockBlockNode) Length() int                   { return 0 }
 func (mbn *mockBlockNode) IsNull() bool                  { return false }
 func (mbn *mockBlockNode) AsBool() (bool, error)         { return false, fmt.Errorf("404") }

--- a/testbridge/mockselector.go
+++ b/testbridge/mockselector.go
@@ -14,7 +14,8 @@ func newMockSelector(mss *mockSelectorSpec) ipldbridge.Selector {
 	return &mockSelector{mss.cidsVisited}
 }
 
-func (ms *mockSelector) Explore(ipld.Node) (ipld.KeyIterator, ipldbridge.Selector) {
-	return nil, ms
+func (ms *mockSelector) Explore(ipld.Node) (ipld.MapIterator, ipld.ListIterator, ipldbridge.Selector) {
+	return nil, nil, ms
 }
+
 func (ms *mockSelector) Decide(ipld.Node) bool { return false }

--- a/testbridge/testbridge.go
+++ b/testbridge/testbridge.go
@@ -87,22 +87,19 @@ func (mb *mockIPLDBridge) Traverse(ctx context.Context, loader ipldbridge.Loader
 	if !ok {
 		return fmt.Errorf("not supported")
 	}
-	var lastErr error
 	for _, lnk := range ms.cidsVisited {
 
 		node, err := loadNode(lnk, loader)
-		if err != nil {
-			lastErr = err
-		} else {
+		if err == nil {
 			fn(ipldbridge.TraversalProgress{}, node, 0)
 		}
 		select {
 		case <-ctx.Done():
-			return lastErr
+			return nil
 		default:
 		}
 	}
-	return lastErr
+	return nil
 }
 
 func loadNode(lnk cid.Cid, loader ipldbridge.Loader) (ipld.Node, error) {

--- a/testbridge/testbridge.go
+++ b/testbridge/testbridge.go
@@ -96,6 +96,11 @@ func (mb *mockIPLDBridge) Traverse(ctx context.Context, loader ipldbridge.Loader
 		} else {
 			fn(ipldbridge.TraversalProgress{}, node, 0)
 		}
+		select {
+		case <-ctx.Done():
+			return lastErr
+		default:
+		}
 	}
 	return lastErr
 }


### PR DESCRIPTION
# Goals

The PR implements the Responder side of a graphsync exchange

# Implementation

![GraphSync](https://user-images.githubusercontent.com/1450680/55525919-d94ed600-5647-11e9-8c6c-5909f00e0063.png)

Overall notes:
As discussed in #14 , the basic way the responder works is:
1. When it request is received from a peer, decode the selector and execute a selector traversal with go-ipld-prime
2. Provide ipld-prime with an overloaded link loader, so that whenever IPLD prime loads a link during traversal, intercept the block load and send a message across the network to the requestor with the block and/or metadata about the block

Additional Implementation Concerns:
1. #21 - Don't get DDOS'd. The basic approach here is two pronged --
  i. Only execute a maximum of n selector queries at once on a single node so as not to overload the processor (currently 6)
  ii. Use a prioritized queue for incoming queries. This PR pulls directly from Bitswaps decision engine and uses a generalized version of the PeerRequestQueue in Bitswap (called the PeerTaskQueue), which will be extracted to a package shortly for use in both. The PeerRequestQueue first balances peers so that those with the most current in progress requests are prioritized after those with no fewer in progress requests, and then within a peer prioritizes the requests with highest priority or earliest received.
  iii. The net here is that no peer can have more than n requests in progress at once, and even if a peer sends infinite requests, other peers will still jump ahead of it and get a chance to process their requests.

2. Deduping blocks and data. Ideally, we should not send blocks multiple times across the network for in progress requests. Moreover, we want to be efficient with our network bandwidth usage, and buffer response output so that each new network message contains all response data we have at the time the pipe becomes free. These tasks are generally accomplished by the PeerResponseManager and PeerResponseSender, and their contained classes (LinkTracker for deduping links and ResponseBuilder for collecting and building responses). A future optimization could be to create a second PeerTaskQueue to balance out network usage in addition to balancing in process selector queries.

Other Odds And Ends

- In the ResponseManager, once responses are collected they are send out to the network with the same underlying infrastructure for message sending the RequestManager uses, so requests can be combined in the same message with responses
- Currently metadata about responses is encoded by constructing an IPLD node and serializing it into the extra field of the response
- Because PeerResponseManager was so similar to the underlying manager for messages, I abstracted out common functionality so there is now PeerManager as a base, then PeerMessageManager and PeerResponseManager with embed the PeerManager
- Updated IPLDBridge for the latest IPLD code 
- Reformat the GraphSyncMessage structure both for optimization and to minimize use of unnecessary interfaces, provided mechanism for directly generated Request & Response structs

# For Discussion

- How does the anti-DDOS approach sound?
- Is it necessary to equalize bandwidth usage between peers? (a second prioritized PeerTaskQueue)
- This is a lot of code -- what questions do you have that I can provide more information on?
 
fix #7
fix #8
fix #21