### PR TITLE
Change readme badges to point to go-graphsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
 [![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
 [![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![Coverage Status](https://codecov.io/gh/ipfs/go-bitswap/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-graphsync/branch/master)
-[![Travis CI](https://travis-ci.org/ipfs/go-bitswap.svg?branch=master)](https://travis-ci.org/ipfs/go-graphsync)
+[![Coverage Status](https://codecov.io/gh/ipfs/go-graphsync/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/go-graphsync)
+[![Travis CI](https://travis-ci.org/ipfs/go-graphsync.svg?branch=master)](https://travis-ci.org/ipfs/go-graphsync)
 
 > An implementation of the [graphsync protocol](https://github.com/ipld/specs/blob/master/block-layer/graphsync/graphsync.md) in go!
 


### PR DESCRIPTION
I think these are just typos, pretty straightforward.

Although that's not all that needs to be done:

<img width="704" alt="image" src="https://user-images.githubusercontent.com/100039/59303867-f86f7280-8c4b-11e9-9c21-9cc758c045da.png">

I'm setting this stuff up for https://github.com/ipfs/go-ipfs-provider and so I'll try to get these badges working as well.