### PR TITLE
Limit Response Size

### DIFF
--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/ipfs/go-graphsync/testbridge"
 
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/linking/cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -164,6 +164,133 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
 		t.Fatal("Did not send correct responses for fourth message")
 	}
+}
+
+func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
+
+	p := testutil.GeneratePeers(1)[0]
+	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	// generate large blocks before proceeding
+	blks := testutil.GenerateBlocksOfSize(5, 1000000)
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	links := make([]ipld.Link, 0, len(blks))
+	for _, block := range blks {
+		links = append(links, cidlink.Link{Cid: block.Cid()})
+	}
+	done := make(chan struct{}, 1)
+	sent := make(chan struct{}, 1)
+	fph := &fakePeerHandler{
+		done: done,
+		sent: sent,
+	}
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	peerResponseManager := NewResponseSender(ctx, p, fph, ipldBridge)
+	peerResponseManager.Startup()
+
+	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Did not send first message")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[0].Cid() {
+		t.Fatal("Did not send correct blocks for first message")
+	}
+
+	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID1 ||
+		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		t.Fatal("Did not send correct responses for first message")
+	}
+
+	// Send 3 very large blocks
+	peerResponseManager.SendResponse(requestID1, links[1], blks[1].RawData())
+	peerResponseManager.SendResponse(requestID1, links[2], blks[2].RawData())
+	peerResponseManager.SendResponse(requestID1, links[3], blks[3].RawData())
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent second message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[1].Cid() {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	if len(fph.lastResponses) != 1 {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	// Send one more block while waiting
+	peerResponseManager.SendResponse(requestID1, links[4], blks[4].RawData())
+	peerResponseManager.FinishRequest(requestID1)
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent third message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[2].Cid() {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	if len(fph.lastResponses) != 1 {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent fourth message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[3].Cid() {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	if len(fph.lastResponses) != 1 {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	select {
+	case <-ctx.Done():
+		t.Fatal("Should have sent fifth message but didn't")
+	case <-sent:
+	}
+
+	if len(fph.lastBlocks) != 1 || fph.lastBlocks[0].Cid() != blks[4].Cid() {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	if len(fph.lastResponses) != 1 {
+		t.Fatal("Should have broken up message but didn't")
+	}
+
+	response, err := findResponseForRequestID(fph.lastResponses, requestID1)
+	if err != nil {
+		t.Fatal("Did not send correct response for fifth message")
+	}
+	if response.Status() != gsmsg.RequestCompletedFull {
+		t.Fatal("Did not send proper response code in fifth message")
+	}
+
 }
 
 func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID gsmsg.GraphSyncRequestID) (gsmsg.GraphSyncResponse, error) {

--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -1,7 +1,7 @@
 package responsebuilder
 
 import (
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
@@ -13,6 +13,7 @@ import (
 // GraphSync message components once responses are ready to send.
 type ResponseBuilder struct {
 	outgoingBlocks     []blocks.Block
+	blkSize            int
 	completedResponses map[gsmsg.GraphSyncRequestID]gsmsg.GraphSyncResponseStatusCode
 	outgoingResponses  map[gsmsg.GraphSyncRequestID]metadata.Metadata
 }
@@ -27,7 +28,13 @@ func New() *ResponseBuilder {
 
 // AddBlock adds the given block to the response.
 func (rb *ResponseBuilder) AddBlock(block blocks.Block) {
+	rb.blkSize += len(block.RawData())
 	rb.outgoingBlocks = append(rb.outgoingBlocks, block)
+}
+
+// BlockSize returns the total size of all blocks in this response
+func (rb *ResponseBuilder) BlockSize() int {
+	return rb.blkSize
 }
 
 // AddLink adds the given link and whether its block is present

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipfs/go-graphsync/testbridge"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/linking/cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
 
 func TestMessageBuilding(t *testing.T) {
@@ -48,6 +48,9 @@ func TestMessageBuilding(t *testing.T) {
 		rb.AddBlock(block)
 	}
 
+	if rb.BlockSize() != 300 {
+		t.Fatal("did not calculate block size correctly")
+	}
 	responses, sentBlocks, err := rb.Build(ipldBridge)
 
 	if err != nil {


### PR DESCRIPTION
# Goals

Prevent a Graphsync responder form sending a response message that is too large for the requester to process when it receives the message

# Implementation

- track total block size for a given graphsync response message in the ResponseBuilder class
- buffer a new message every time we exceed the max response size (512K for now, taken from bitswap.

# For Discussion

512k is perhaps aggressive? Not sure though. It's purely a limit on block size so messages could be larger through metadata, though my guess is we could punch it up to 2MB before we came anywhere close to the 4MB limit on the receiving side.