### PR TITLE
fix(messagequeue): no retry after queue shutdown

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	gsnet "github.com/ipfs/go-graphsync/network"
@@ -189,6 +189,8 @@ func (mq *MessageQueue) attemptSendAndRecovery(message gsmsg.GraphSyncMessage) b
 	mq.sender = nil
 
 	select {
+	case <-mq.done:
+		return true
 	case <-mq.ctx.Done():
 		return true
 	case <-time.After(time.Millisecond * 100):


### PR DESCRIPTION
# Goals

Remove warning log messages, but also shutdown quickly without unneccesary send attempts

# Implementation

Previously, we allowed the last message send attempt to run to maxRetries if the queue was shutdown, which also generated warning logs. 

Now, if a send attempt fails, check that the queue has shutdownand immediately return if it has

Adds a test to replicate the failing behavior and verify the fix resolves it -- the test does involve use of time expiry, which is non-ideal, but probably there is nothing we can do until we have a mocked time in this repo.