### PR TITLE
Refactor file organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If your existing library (i.e. `go-ipfs` or `go-filecoin`) uses these other olde
 
 ```golang
 import (
-  graphsync "github.com/ipfs/go-graphsync"
+  graphsync "github.com/ipfs/go-graphsync/impl"
   gsnet "github.com/ipfs/go-graphsync/network"
   gsbridge "github.com/ipfs/go-graphsync/ipldbridge"
   ipld "github.com/ipfs/go-ipld-prime"

--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -194,8 +194,8 @@ package "go-graphsync" {
 
       class AsyncLoader {
         StartRequest(GraphSyncRequestID)
-        ProcessResponse(map[gsmsg.GraphSyncRequestID]metadata.Metadata, []blocks.Block)
-        AsyncLoad(requestID gsmsg.GraphSyncRequestID, link ipld.Link) AsyncLoadResult
+        ProcessResponse(map[graphsync.RequestID]metadata.Metadata, []blocks.Block)
+        AsyncLoad(requestID graphsync.RequestID, link ipld.Link) AsyncLoadResult
         CompleteResponsesFor(GraphSyncRequestID)
         CleanupRequest(GraphSyncRequestID)
       }
@@ -299,7 +299,7 @@ package "go-graphsync" {
       class ResponseBuilder {
         AddBlock(Block)
         AddLink(GraphSyncRequestID, Link, bool)
-        AddCompletedRequest(GraphSyncRequestID, GraphSyncResponseStatusCode)
+        AddCompletedRequest(GraphSyncRequestID, graphsync.ResponseStatusCode)
         Empty() bool
         Build(IPLDBridge) ([]GraphSyncResponse, []Block, error)    
       }
@@ -317,7 +317,7 @@ package "go-graphsync" {
         Shutdown()
         SendResponse(GraphSyncRequestID,Link,[]byte)
 	      FinishRequest(GraphSyncRequestID)
-	      FinishWithError(GraphSyncRequestID, GraphSyncResponseStatusCode)
+	      FinishWithError(GraphSyncRequestID, graphsync.ResponseStatusCode)
       }
 
       object "Package Public Functions" as goPeerResponseManagerPF {
@@ -356,7 +356,7 @@ package "go-graphsync" {
       func New() GraphSyncMessage
       func NewRequest(GraphSyncRequestID, []byte, GraphSyncPriority) GraphSyncRequest
       func CancelRequest(GraphSyncRequestID) GraphSyncRequest
-      func NewResponse(GraphSyncRequestID, GraphSyncResponseStatusCode, []byte) GraphSyncResponse
+      func NewResponse(GraphSyncRequestID, graphsync.ResponseStatusCode, []byte) GraphSyncResponse
     }
     goGraphSyncMessagePF .. libP2PGraphSyncNetwork
 

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/libp2p/go-eventbus v0.0.3 // indirect
 	github.com/libp2p/go-libp2p v0.2.1
 	github.com/libp2p/go-libp2p-core v0.0.9
+	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-secio v0.1.1 // indirect
 	github.com/libp2p/go-msgio v0.0.4 // indirect
 	github.com/mattn/go-colorable v0.1.2 // indirect

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -1,0 +1,125 @@
+package graphsync
+
+import (
+	"context"
+
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/requestmanager/asyncloader"
+
+	"github.com/ipfs/go-graphsync/ipldbridge"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/messagequeue"
+	gsnet "github.com/ipfs/go-graphsync/network"
+	"github.com/ipfs/go-graphsync/peermanager"
+	"github.com/ipfs/go-graphsync/requestmanager"
+	"github.com/ipfs/go-graphsync/responsemanager"
+	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
+	logging "github.com/ipfs/go-log"
+	"github.com/ipfs/go-peertaskqueue"
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var log = logging.Logger("graphsync")
+
+// GraphSync is an instance of a GraphSync exchange that implements
+// the graphsync protocol.
+type GraphSync struct {
+	ipldBridge          ipldbridge.IPLDBridge
+	network             gsnet.GraphSyncNetwork
+	loader              ipldbridge.Loader
+	storer              ipldbridge.Storer
+	requestManager      *requestmanager.RequestManager
+	responseManager     *responsemanager.ResponseManager
+	asyncLoader         *asyncloader.AsyncLoader
+	peerResponseManager *peerresponsemanager.PeerResponseManager
+	peerTaskQueue       *peertaskqueue.PeerTaskQueue
+	peerManager         *peermanager.PeerMessageManager
+	ctx                 context.Context
+	cancel              context.CancelFunc
+}
+
+// New creates a new GraphSync Exchange on the given network,
+// using the given bridge to IPLD and the given link loader.
+func New(parent context.Context, network gsnet.GraphSyncNetwork,
+	ipldBridge ipldbridge.IPLDBridge, loader ipldbridge.Loader,
+	storer ipldbridge.Storer) graphsync.GraphExchange {
+	ctx, cancel := context.WithCancel(parent)
+
+	createMessageQueue := func(ctx context.Context, p peer.ID) peermanager.PeerQueue {
+		return messagequeue.New(ctx, p, network)
+	}
+	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
+	asyncLoader := asyncloader.New(ctx, loader, storer)
+	requestManager := requestmanager.New(ctx, asyncLoader, ipldBridge)
+	peerTaskQueue := peertaskqueue.New()
+	createdResponseQueue := func(ctx context.Context, p peer.ID) peerresponsemanager.PeerResponseSender {
+		return peerresponsemanager.NewResponseSender(ctx, p, peerManager, ipldBridge)
+	}
+	peerResponseManager := peerresponsemanager.New(ctx, createdResponseQueue)
+	responseManager := responsemanager.New(ctx, loader, ipldBridge, peerResponseManager, peerTaskQueue)
+	graphSync := &GraphSync{
+		ipldBridge:          ipldBridge,
+		network:             network,
+		loader:              loader,
+		storer:              storer,
+		asyncLoader:         asyncLoader,
+		requestManager:      requestManager,
+		peerManager:         peerManager,
+		peerTaskQueue:       peerTaskQueue,
+		peerResponseManager: peerResponseManager,
+		responseManager:     responseManager,
+		ctx:                 ctx,
+		cancel:              cancel,
+	}
+
+	asyncLoader.Startup()
+	requestManager.SetDelegate(peerManager)
+	requestManager.Startup()
+	responseManager.Startup()
+	network.SetDelegate((*graphSyncReceiver)(graphSync))
+	return graphSync
+}
+
+// Request initiates a new GraphSync request to the given peer using the given selector spec.
+func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node) (<-chan graphsync.ResponseProgress, <-chan error) {
+	return gs.requestManager.SendRequest(ctx, p, root, selector)
+}
+
+type graphSyncReceiver GraphSync
+
+func (gsr *graphSyncReceiver) graphSync() *GraphSync {
+	return (*GraphSync)(gsr)
+}
+
+// ReceiveMessage is part of the networks Receiver interface and receives
+// incoming messages from the network
+func (gsr *graphSyncReceiver) ReceiveMessage(
+	ctx context.Context,
+	sender peer.ID,
+	incoming gsmsg.GraphSyncMessage) {
+	gsr.graphSync().responseManager.ProcessRequests(ctx, sender, incoming.Requests())
+	gsr.graphSync().requestManager.ProcessResponses(sender, incoming.Responses(), incoming.Blocks())
+}
+
+// ReceiveError is part of the network's Receiver interface and handles incoming
+// errors from the network.
+func (gsr *graphSyncReceiver) ReceiveError(err error) {
+	log.Infof("Graphsync ReceiveError: %s", err)
+	// TODO log the network error
+	// TODO bubble the network error up to the parent context/error logger
+}
+
+// Connected is part of the networks 's Receiver interface and handles peers connecting
+// on the network
+func (gsr *graphSyncReceiver) Connected(p peer.ID) {
+	gsr.graphSync().peerManager.Connected(p)
+	gsr.graphSync().peerResponseManager.Connected(p)
+}
+
+// Connected is part of the networks 's Receiver interface and handles peers connecting
+// on the network
+func (gsr *graphSyncReceiver) Disconnected(p peer.ID) {
+	gsr.graphSync().peerManager.Disconnected(p)
+	gsr.graphSync().peerResponseManager.Disconnected(p)
+}

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -12,6 +12,7 @@ import (
 
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
 
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsmsg "github.com/ipfs/go-graphsync/message"
@@ -263,10 +264,10 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	if err != nil {
 		t.Fatal("could not encode selector spec")
 	}
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 
 	message := gsmsg.New()
-	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.tipLink.(cidlink.Link).Cid, selectorData, gsmsg.GraphSyncPriority(math.MaxInt32)))
+	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.tipLink.(cidlink.Link).Cid, selectorData, graphsync.Priority(math.MaxInt32)))
 	// send request across network
 	gsnet1.SendMessage(ctx, host2.ID(), message)
 	// read the values sent back to requestor
@@ -292,7 +293,7 @@ readAllMessages:
 			if receivedResponses[0].RequestID() != requestID {
 				t.Fatal("Sent response for incorrect request id")
 			}
-			if receivedResponses[0].Status() != gsmsg.PartialResponse {
+			if receivedResponses[0].Status() != graphsync.PartialResponse {
 				break readAllMessages
 			}
 		}

--- a/linktracker/linktracker.go
+++ b/linktracker/linktracker.go
@@ -1,7 +1,7 @@
 package linktracker
 
 import (
-	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipld/go-ipld-prime"
 )
 
@@ -11,16 +11,16 @@ import (
 // Second, keep track of whether links are missing blocks so you can determine
 // at the end if a complete response has been transmitted.
 type LinkTracker struct {
-	missingBlocks                     map[gsmsg.GraphSyncRequestID]map[ipld.Link]struct{}
-	linksWithBlocksTraversedByRequest map[gsmsg.GraphSyncRequestID][]ipld.Link
+	missingBlocks                     map[graphsync.RequestID]map[ipld.Link]struct{}
+	linksWithBlocksTraversedByRequest map[graphsync.RequestID][]ipld.Link
 	traversalsWithBlocksInProgress    map[ipld.Link]int
 }
 
 // New makes a new link tracker
 func New() *LinkTracker {
 	return &LinkTracker{
-		missingBlocks:                     make(map[gsmsg.GraphSyncRequestID]map[ipld.Link]struct{}),
-		linksWithBlocksTraversedByRequest: make(map[gsmsg.GraphSyncRequestID][]ipld.Link),
+		missingBlocks:                     make(map[graphsync.RequestID]map[ipld.Link]struct{}),
+		linksWithBlocksTraversedByRequest: make(map[graphsync.RequestID][]ipld.Link),
 		traversalsWithBlocksInProgress:    make(map[ipld.Link]int),
 	}
 }
@@ -32,7 +32,7 @@ func (lt *LinkTracker) BlockRefCount(link ipld.Link) int {
 }
 
 // IsKnownMissingLink returns whether the given request recorded the given link as missing
-func (lt *LinkTracker) IsKnownMissingLink(requestID gsmsg.GraphSyncRequestID, link ipld.Link) bool {
+func (lt *LinkTracker) IsKnownMissingLink(requestID graphsync.RequestID, link ipld.Link) bool {
 	missingBlocks, ok := lt.missingBlocks[requestID]
 	if !ok {
 		return false
@@ -43,7 +43,7 @@ func (lt *LinkTracker) IsKnownMissingLink(requestID gsmsg.GraphSyncRequestID, li
 
 // RecordLinkTraversal records that we traversed a link during a request, and
 // whether we had the block when we did it.
-func (lt *LinkTracker) RecordLinkTraversal(requestID gsmsg.GraphSyncRequestID, link ipld.Link, hasBlock bool) {
+func (lt *LinkTracker) RecordLinkTraversal(requestID graphsync.RequestID, link ipld.Link, hasBlock bool) {
 	if hasBlock {
 		lt.linksWithBlocksTraversedByRequest[requestID] = append(lt.linksWithBlocksTraversedByRequest[requestID], link)
 		lt.traversalsWithBlocksInProgress[link]++
@@ -59,7 +59,7 @@ func (lt *LinkTracker) RecordLinkTraversal(requestID gsmsg.GraphSyncRequestID, l
 
 // FinishRequest records that we have completed the given request, and returns
 // true if all links traversed had blocks present.
-func (lt *LinkTracker) FinishRequest(requestID gsmsg.GraphSyncRequestID) (hasAllBlocks bool) {
+func (lt *LinkTracker) FinishRequest(requestID graphsync.RequestID) (hasAllBlocks bool) {
 	_, ok := lt.missingBlocks[requestID]
 	hasAllBlocks = !ok
 	delete(lt.missingBlocks, requestID)

--- a/linktracker/linktracker_test.go
+++ b/linktracker/linktracker_test.go
@@ -4,7 +4,7 @@ import (
 	"math/rand"
 	"testing"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testbridge"
 )
 
@@ -15,8 +15,8 @@ func TestBlockRefCount(t *testing.T) {
 	if linkTracker.BlockRefCount(link1) != 0 || linkTracker.BlockRefCount(link2) != 0 {
 		t.Fatal("Links not traversed should have refcount 0")
 	}
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
 
 	linkTracker.RecordLinkTraversal(requestID1, link1, true)
 	linkTracker.RecordLinkTraversal(requestID1, link2, true)
@@ -36,8 +36,8 @@ func TestHasAllBlocks(t *testing.T) {
 	linkTracker := New()
 	link1 := testbridge.NewMockLink()
 	link2 := testbridge.NewMockLink()
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
 
 	linkTracker.RecordLinkTraversal(requestID1, link1, true)
 	linkTracker.RecordLinkTraversal(requestID1, link2, false)
@@ -56,8 +56,8 @@ func TestBlockBecomesAvailable(t *testing.T) {
 	if linkTracker.BlockRefCount(link1) != 0 {
 		t.Fatal("Links not traversed should send blocks")
 	}
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
 
 	linkTracker.RecordLinkTraversal(requestID1, link1, false)
 	linkTracker.RecordLinkTraversal(requestID2, link1, false)
@@ -85,8 +85,8 @@ func TestMissingLink(t *testing.T) {
 	linkTracker := New()
 	link1 := testbridge.NewMockLink()
 	link2 := testbridge.NewMockLink()
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
 
 	linkTracker.RecordLinkTraversal(requestID1, link1, true)
 	linkTracker.RecordLinkTraversal(requestID1, link2, false)

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -7,21 +7,22 @@ import (
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-graphsync"
 
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync/testutil"
 )
 
 func TestAppendingRequests(t *testing.T) {
-	extensionName := GraphSyncExtensionName("graphsync/awesome")
-	extension := GraphSyncExtension{
+	extensionName := graphsync.ExtensionName("graphsync/awesome")
+	extension := graphsync.ExtensionData{
 		Name: extensionName,
 		Data: testutil.RandomBytes(100),
 	}
 	root := testutil.GenerateCids(1)[0]
 	selector := testutil.RandomBytes(100)
-	id := GraphSyncRequestID(rand.Int31())
-	priority := GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 
 	gsm := New()
 	gsm.AddRequest(NewRequest(id, root, selector, priority, extension))
@@ -74,13 +75,13 @@ func TestAppendingRequests(t *testing.T) {
 }
 
 func TestAppendingResponses(t *testing.T) {
-	extensionName := GraphSyncExtensionName("graphsync/awesome")
-	extension := GraphSyncExtension{
+	extensionName := graphsync.ExtensionName("graphsync/awesome")
+	extension := graphsync.ExtensionData{
 		Name: extensionName,
 		Data: testutil.RandomBytes(100),
 	}
-	requestID := GraphSyncRequestID(rand.Int31())
-	status := RequestAcknowledged
+	requestID := graphsync.RequestID(rand.Int31())
+	status := graphsync.RequestAcknowledged
 
 	gsm := New()
 	gsm.AddResponse(NewResponse(requestID, status, extension))
@@ -155,8 +156,8 @@ func contains(strs []string, x string) bool {
 
 func TestRequestCancel(t *testing.T) {
 	selector := testutil.RandomBytes(100)
-	id := GraphSyncRequestID(rand.Int31())
-	priority := GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 	root := testutil.GenerateCids(1)[0]
 
 	gsm := New()
@@ -178,14 +179,14 @@ func TestRequestCancel(t *testing.T) {
 func TestToNetFromNetEquivalency(t *testing.T) {
 	root := testutil.GenerateCids(1)[0]
 	selector := testutil.RandomBytes(100)
-	extensionName := GraphSyncExtensionName("graphsync/awesome")
-	extension := GraphSyncExtension{
+	extensionName := graphsync.ExtensionName("graphsync/awesome")
+	extension := graphsync.ExtensionData{
 		Name: extensionName,
 		Data: testutil.RandomBytes(100),
 	}
-	id := GraphSyncRequestID(rand.Int31())
-	priority := GraphSyncPriority(rand.Int31())
-	status := RequestAcknowledged
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
+	status := graphsync.RequestAcknowledged
 
 	gsm := New()
 	gsm.AddRequest(NewRequest(id, root, selector, priority, extension))

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testutil"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
@@ -65,8 +66,8 @@ func TestStartupAndShutdown(t *testing.T) {
 
 	messageQueue := New(ctx, peer, messageNetwork)
 	messageQueue.Startup()
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 	selector := testutil.RandomBytes(100)
 	root := testutil.GenerateCids(1)[0]
 
@@ -109,8 +110,8 @@ func TestShutdownDuringMessageSend(t *testing.T) {
 
 	messageQueue := New(ctx, peer, messageNetwork)
 	messageQueue.Startup()
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 	selector := testutil.RandomBytes(100)
 	root := testutil.GenerateCids(1)[0]
 
@@ -174,13 +175,13 @@ func TestProcessingNotification(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(3, 128)
 
 	newMessage := gsmsg.New()
-	responseID := gsmsg.GraphSyncRequestID(rand.Int31())
-	extensionName := gsmsg.GraphSyncExtensionName("graphsync/awesome")
-	extension := gsmsg.GraphSyncExtension{
+	responseID := graphsync.RequestID(rand.Int31())
+	extensionName := graphsync.ExtensionName("graphsync/awesome")
+	extension := graphsync.ExtensionData{
 		Name: extensionName,
 		Data: testutil.RandomBytes(100),
 	}
-	status := gsmsg.RequestCompletedFull
+	status := graphsync.RequestCompletedFull
 	newMessage.AddResponse(gsmsg.NewResponse(responseID, status, extension))
 	processing := messageQueue.AddResponses(newMessage.Responses(), blks)
 	select {
@@ -235,20 +236,20 @@ func TestDedupingMessages(t *testing.T) {
 	messageQueue := New(ctx, peer, messageNetwork)
 	messageQueue.Startup()
 	waitGroup.Add(1)
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 	selector := testutil.RandomBytes(100)
 	root := testutil.GenerateCids(1)[0]
 
 	messageQueue.AddRequest(gsmsg.NewRequest(id, root, selector, priority))
 	// wait for send attempt
 	waitGroup.Wait()
-	id2 := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority2 := gsmsg.GraphSyncPriority(rand.Int31())
+	id2 := graphsync.RequestID(rand.Int31())
+	priority2 := graphsync.Priority(rand.Int31())
 	selector2 := testutil.RandomBytes(100)
 	root2 := testutil.GenerateCids(1)[0]
-	id3 := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority3 := gsmsg.GraphSyncPriority(rand.Int31())
+	id3 := graphsync.RequestID(rand.Int31())
+	priority3 := graphsync.Priority(rand.Int31())
 	selector3 := testutil.RandomBytes(100)
 	root3 := testutil.GenerateCids(1)[0]
 

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-graphsync"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -73,14 +74,14 @@ func TestMessageSendAndReceive(t *testing.T) {
 
 	root := testutil.GenerateCids(1)[0]
 	selector := testutil.RandomBytes(100)
-	extensionName := gsmsg.GraphSyncExtensionName("graphsync/awesome")
-	extension := gsmsg.GraphSyncExtension{
+	extensionName := graphsync.ExtensionName("graphsync/awesome")
+	extension := graphsync.ExtensionData{
 		Name: extensionName,
 		Data: testutil.RandomBytes(100),
 	}
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
-	status := gsmsg.RequestAcknowledged
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
+	status := graphsync.RequestAcknowledged
 
 	sent := gsmsg.New()
 	sent.AddRequest(gsmsg.NewRequest(id, root, selector, priority))

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-graphsync"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testutil"
@@ -55,8 +56,8 @@ func TestSendingMessagesToPeers(t *testing.T) {
 
 	tp := testutil.GeneratePeers(5)
 
-	id := gsmsg.GraphSyncRequestID(rand.Int31())
-	priority := gsmsg.GraphSyncPriority(rand.Int31())
+	id := graphsync.RequestID(rand.Int31())
+	priority := graphsync.Priority(rand.Int31())
 	root := testutil.GenerateCids(1)[0]
 	selector := testutil.RandomBytes(100)
 

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	"github.com/ipfs/go-graphsync/metadata"
-	"github.com/ipld/go-ipld-prime/linking/cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/testbridge"
 	"github.com/ipfs/go-graphsync/testutil"
 	ipld "github.com/ipld/go-ipld-prime"
@@ -45,7 +45,7 @@ func TestAsyncLoadInitialLoadSucceedsLocallyPresent(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
 	select {
@@ -85,8 +85,8 @@ func TestAsyncLoadInitialLoadSucceedsResponsePresent(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	requestID := graphsync.RequestID(rand.Int31())
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
 				Link:         link,
@@ -135,9 +135,9 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 	asyncLoader.Startup()
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
 				Link:         link,
@@ -183,7 +183,7 @@ func TestAsyncLoadInitialLoadIndeterminateWhenRequestNotInProgress(t *testing.T)
 	asyncLoader.Startup()
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
 	select {
@@ -224,7 +224,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
@@ -236,7 +236,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 		t.Fatal("should have attempted load once")
 	}
 
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
 				Link:         link,
@@ -286,7 +286,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
@@ -297,7 +297,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 	case <-ctx.Done():
 		t.Fatal("should have attempted load once")
 	}
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
 				Link:         link,
@@ -343,7 +343,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
@@ -393,8 +393,8 @@ func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
 	asyncLoader := New(ctx, wrappedLoader, storer)
 	asyncLoader.Startup()
 
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	requestID := graphsync.RequestID(rand.Int31())
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
 				Link:         link,

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
@@ -3,7 +3,7 @@ package loadattemptqueue
 import (
 	"errors"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
 	"github.com/ipld/go-ipld-prime"
 )
@@ -11,14 +11,14 @@ import (
 // LoadRequest is a request to load the given link for the given request id,
 // with results returned to the given channel
 type LoadRequest struct {
-	requestID  gsmsg.GraphSyncRequestID
+	requestID  graphsync.RequestID
 	link       ipld.Link
 	resultChan chan types.AsyncLoadResult
 }
 
 // NewLoadRequest returns a new LoadRequest for the given request id, link,
 // and results channel
-func NewLoadRequest(requestID gsmsg.GraphSyncRequestID,
+func NewLoadRequest(requestID graphsync.RequestID,
 	link ipld.Link,
 	resultChan chan types.AsyncLoadResult) LoadRequest {
 	return LoadRequest{requestID, link, resultChan}
@@ -29,7 +29,7 @@ func NewLoadRequest(requestID gsmsg.GraphSyncRequestID,
 // bytes present, error nil = success
 // bytes nil, error present = error
 // bytes nil, error nil = did not load, but try again later
-type LoadAttempter func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error)
+type LoadAttempter func(graphsync.RequestID, ipld.Link) ([]byte, error)
 
 // LoadAttemptQueue attempts to load using the load attempter, and then can
 // place requests on a retry queue
@@ -68,7 +68,7 @@ func (laq *LoadAttemptQueue) AttemptLoad(lr LoadRequest, retry bool) {
 
 // ClearRequest purges the given request from the queue of load requests
 // to retry
-func (laq *LoadAttemptQueue) ClearRequest(requestID gsmsg.GraphSyncRequestID) {
+func (laq *LoadAttemptQueue) ClearRequest(requestID graphsync.RequestID) {
 	pausedRequests := laq.pausedRequests
 	laq.pausedRequests = nil
 	for _, lr := range pausedRequests {

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
 	"github.com/ipfs/go-graphsync/testbridge"
 	"github.com/ipfs/go-graphsync/testutil"
@@ -19,14 +19,14 @@ func TestAsyncLoadInitialLoadSucceeds(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
 		callCount++
 		return testutil.RandomBytes(100), nil
 	}
 	loadAttemptQueue := New(loadAttempter)
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 
 	resultChan := make(chan types.AsyncLoadResult, 1)
 	lr := NewLoadRequest(requestID, link, resultChan)
@@ -54,14 +54,14 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
 		callCount++
 		return nil, fmt.Errorf("something went wrong")
 	}
 	loadAttemptQueue := New(loadAttempter)
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := make(chan types.AsyncLoadResult, 1)
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, false)
@@ -89,7 +89,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryFalse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
 		var result []byte
 		if callCount > 0 {
 			result = testutil.RandomBytes(100)
@@ -101,7 +101,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryFalse(t *testing.T) {
 	loadAttemptQueue := New(loadAttempter)
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := make(chan types.AsyncLoadResult, 1)
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, false)
@@ -130,7 +130,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing
 	defer cancel()
 	callCount := 0
 	called := make(chan struct{}, 2)
-	loadAttempter := func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
 		var result []byte
 		called <- struct{}{}
 		if callCount > 0 {
@@ -142,7 +142,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing
 	loadAttemptQueue := New(loadAttempter)
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := make(chan types.AsyncLoadResult, 1)
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, true)
@@ -179,7 +179,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	defer cancel()
 	callCount := 0
 	called := make(chan struct{}, 2)
-	loadAttempter := func(gsmsg.GraphSyncRequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
 		var result []byte
 		called <- struct{}{}
 		if callCount > 0 {
@@ -191,7 +191,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	loadAttemptQueue := New(loadAttempter)
 
 	link := testbridge.NewMockLink()
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	resultChan := make(chan types.AsyncLoadResult, 1)
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, true)

--- a/requestmanager/asyncloader/responsecache/responsecache.go
+++ b/requestmanager/asyncloader/responsecache/responsecache.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/metadata"
 	logging "github.com/ipfs/go-log"
 
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-graphsync/linktracker"
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/linking/cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 )
 
 var log = logging.Logger("graphsync")
@@ -47,7 +47,7 @@ func New(unverifiedBlockStore UnverifiedBlockStore) *ResponseCache {
 
 // FinishRequest indicate there is no more need to track blocks tied to this
 // response
-func (rc *ResponseCache) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
+func (rc *ResponseCache) FinishRequest(requestID graphsync.RequestID) {
 	rc.responseCacheLk.Lock()
 	rc.linkTracker.FinishRequest(requestID)
 
@@ -58,7 +58,7 @@ func (rc *ResponseCache) FinishRequest(requestID gsmsg.GraphSyncRequestID) {
 }
 
 // AttemptLoad attempts to laod the given block from the cache
-func (rc *ResponseCache) AttemptLoad(requestID gsmsg.GraphSyncRequestID, link ipld.Link) ([]byte, error) {
+func (rc *ResponseCache) AttemptLoad(requestID graphsync.RequestID, link ipld.Link) ([]byte, error) {
 	rc.responseCacheLk.Lock()
 	defer rc.responseCacheLk.Unlock()
 	if rc.linkTracker.IsKnownMissingLink(requestID, link) {
@@ -70,7 +70,7 @@ func (rc *ResponseCache) AttemptLoad(requestID gsmsg.GraphSyncRequestID, link ip
 
 // ProcessResponse processes incoming response data, adding unverified blocks,
 // and tracking link metadata from a remote peer
-func (rc *ResponseCache) ProcessResponse(responses map[gsmsg.GraphSyncRequestID]metadata.Metadata,
+func (rc *ResponseCache) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
 	rc.responseCacheLk.Lock()
 

--- a/requestmanager/asyncloader/responsecache/responsecache_test.go
+++ b/requestmanager/asyncloader/responsecache/responsecache_test.go
@@ -6,12 +6,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-graphsync"
 
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
 	"github.com/ipfs/go-graphsync/testutil"
-	"github.com/ipld/go-ipld-prime/linking/cid"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
 	ipld "github.com/ipld/go-ipld-prime"
 )
@@ -54,8 +54,8 @@ func (ubs *fakeUnverifiedBlockStore) blocks() []blocks.Block {
 
 func TestResponseCacheManagingLinks(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 100)
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
 
 	request1Metadata := metadata.Metadata{
 		metadata.Item{
@@ -87,7 +87,7 @@ func TestResponseCacheManagingLinks(t *testing.T) {
 		},
 	}
 
-	responses := map[gsmsg.GraphSyncRequestID]metadata.Metadata{
+	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID1: request1Metadata,
 		requestID2: request2Metadata,
 	}

--- a/requestmanager/loader/loader.go
+++ b/requestmanager/loader/loader.go
@@ -6,15 +6,15 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
 	ipld "github.com/ipld/go-ipld-prime"
 )
 
 // AsyncLoadFn is a function which given a request id and an ipld.Link, returns
 // a channel which will eventually return data for the link or an err
-type AsyncLoadFn func(gsmsg.GraphSyncRequestID, ipld.Link) <-chan types.AsyncLoadResult
+type AsyncLoadFn func(graphsync.RequestID, ipld.Link) <-chan types.AsyncLoadResult
 
 // WrapAsyncLoader creates a regular ipld link laoder from an asynchronous load
 // function, with the given cancellation context, for the given requests, and will
@@ -22,7 +22,7 @@ type AsyncLoadFn func(gsmsg.GraphSyncRequestID, ipld.Link) <-chan types.AsyncLoa
 func WrapAsyncLoader(
 	ctx context.Context,
 	asyncLoadFn AsyncLoadFn,
-	requestID gsmsg.GraphSyncRequestID,
+	requestID graphsync.RequestID,
 	errorChan chan error) ipld.Loader {
 	return func(link ipld.Link, linkContext ipldbridge.LinkContext) (io.Reader, error) {
 		resultChan := asyncLoadFn(requestID, link)

--- a/requestmanager/loader/loader_test.go
+++ b/requestmanager/loader/loader_test.go
@@ -10,23 +10,22 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
 
 	"github.com/ipfs/go-graphsync/testbridge"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime"
-
-	gsmsg "github.com/ipfs/go-graphsync/message"
 )
 
 type callParams struct {
-	requestID gsmsg.GraphSyncRequestID
+	requestID graphsync.RequestID
 	link      ipld.Link
 }
 
 func makeAsyncLoadFn(responseChan chan types.AsyncLoadResult, calls chan callParams) AsyncLoadFn {
-	return func(requestID gsmsg.GraphSyncRequestID, link ipld.Link) <-chan types.AsyncLoadResult {
+	return func(requestID graphsync.RequestID, link ipld.Link) <-chan types.AsyncLoadResult {
 		calls <- callParams{requestID, link}
 		return responseChan
 	}
@@ -40,7 +39,7 @@ func TestWrappedAsyncLoaderReturnsValues(t *testing.T) {
 	calls := make(chan callParams, 1)
 	asyncLoadFn := makeAsyncLoadFn(responseChan, calls)
 	errChan := make(chan error)
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	loader := WrapAsyncLoader(ctx, asyncLoadFn, requestID, errChan)
 
 	link := testbridge.NewMockLink()
@@ -67,7 +66,7 @@ func TestWrappedAsyncLoaderSideChannelsErrors(t *testing.T) {
 	calls := make(chan callParams, 1)
 	asyncLoadFn := makeAsyncLoadFn(responseChan, calls)
 	errChan := make(chan error, 1)
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	loader := WrapAsyncLoader(ctx, asyncLoadFn, requestID, errChan)
 
 	link := testbridge.NewMockLink()
@@ -96,7 +95,7 @@ func TestWrappedAsyncLoaderContextCancels(t *testing.T) {
 	calls := make(chan callParams, 1)
 	asyncLoadFn := makeAsyncLoadFn(responseChan, calls)
 	errChan := make(chan error, 1)
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	loader := WrapAsyncLoader(subCtx, asyncLoadFn, requestID, errChan)
 	link := testbridge.NewMockLink()
 	resultsChan := make(chan struct {

--- a/requestmanager/responsecollector.go
+++ b/requestmanager/responsecollector.go
@@ -3,7 +3,7 @@ package requestmanager
 import (
 	"context"
 
-	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/ipfs/go-graphsync"
 )
 
 type responseCollector struct {
@@ -16,25 +16,25 @@ func newResponseCollector(ctx context.Context) *responseCollector {
 
 func (rc *responseCollector) collectResponses(
 	requestCtx context.Context,
-	incomingResponses <-chan types.ResponseProgress,
+	incomingResponses <-chan graphsync.ResponseProgress,
 	incomingErrors <-chan error,
-	cancelRequest func()) (<-chan types.ResponseProgress, <-chan error) {
+	cancelRequest func()) (<-chan graphsync.ResponseProgress, <-chan error) {
 
-	returnedResponses := make(chan types.ResponseProgress)
+	returnedResponses := make(chan graphsync.ResponseProgress)
 	returnedErrors := make(chan error)
 
 	go func() {
-		var receivedResponses []types.ResponseProgress
+		var receivedResponses []graphsync.ResponseProgress
 		defer close(returnedResponses)
-		outgoingResponses := func() chan<- types.ResponseProgress {
+		outgoingResponses := func() chan<- graphsync.ResponseProgress {
 			if len(receivedResponses) == 0 {
 				return nil
 			}
 			return returnedResponses
 		}
-		nextResponse := func() types.ResponseProgress {
+		nextResponse := func() graphsync.ResponseProgress {
 			if len(receivedResponses) == 0 {
-				return types.ResponseProgress{}
+				return graphsync.ResponseProgress{}
 			}
 			return receivedResponses[0]
 		}

--- a/requestmanager/responsecollector_test.go
+++ b/requestmanager/responsecollector_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testbridge"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -22,7 +22,7 @@ func TestBufferingResponseProgress(t *testing.T) {
 	rc := newResponseCollector(ctx)
 	requestCtx, requestCancel := context.WithCancel(backgroundCtx)
 	defer requestCancel()
-	incomingResponses := make(chan types.ResponseProgress)
+	incomingResponses := make(chan graphsync.ResponseProgress)
 	incomingErrors := make(chan error)
 	cancelRequest := func() {}
 
@@ -35,7 +35,7 @@ func TestBufferingResponseProgress(t *testing.T) {
 		select {
 		case <-ctx.Done():
 			t.Fatal("should have written to channel but couldn't")
-		case incomingResponses <- types.ResponseProgress{
+		case incomingResponses <- graphsync.ResponseProgress{
 			Node: testbridge.NewMockBlockNode(block.RawData()),
 			LastBlock: struct {
 				Path ipld.Path

--- a/requestmanager/types/data.go
+++ b/requestmanager/types/data.go
@@ -1,20 +1,7 @@
 package types
 
-import ipld "github.com/ipld/go-ipld-prime"
-
 // AsyncLoadResult is sent once over the channel returned by an async load.
 type AsyncLoadResult struct {
 	Data []byte
 	Err  error
-}
-
-// ResponseProgress is the fundamental unit of responses making progress in
-// the RequestManager.
-type ResponseProgress struct {
-	Node      ipld.Node // a node which matched the graphsync query
-	Path      ipld.Path // the path of that node relative to the traversal start
-	LastBlock struct {  // LastBlock stores the Path and Link of the last block edge we had to load.
-		Path ipld.Path
-		Link ipld.Link
-	}
 }

--- a/requestmanager/utils.go
+++ b/requestmanager/utils.go
@@ -3,18 +3,18 @@ package requestmanager
 import (
 	"context"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
-	"github.com/ipfs/go-graphsync/requestmanager/types"
 	ipld "github.com/ipld/go-ipld-prime"
 )
 
-func visitToChannel(ctx context.Context, inProgressChan chan types.ResponseProgress) ipldbridge.AdvVisitFn {
+func visitToChannel(ctx context.Context, inProgressChan chan graphsync.ResponseProgress) ipldbridge.AdvVisitFn {
 	return func(tp ipldbridge.TraversalProgress, node ipld.Node, tr ipldbridge.TraversalReason) error {
 		select {
 		case <-ctx.Done():
-		case inProgressChan <- types.ResponseProgress{
+		case inProgressChan <- graphsync.ResponseProgress{
 			Node:      node,
 			Path:      tp.Path,
 			LastBlock: tp.LastBlock,
@@ -24,10 +24,10 @@ func visitToChannel(ctx context.Context, inProgressChan chan types.ResponseProgr
 	}
 }
 
-func metadataForResponses(responses []gsmsg.GraphSyncResponse, ipldBridge ipldbridge.IPLDBridge) map[gsmsg.GraphSyncRequestID]metadata.Metadata {
-	responseMetadata := make(map[gsmsg.GraphSyncRequestID]metadata.Metadata, len(responses))
+func metadataForResponses(responses []gsmsg.GraphSyncResponse, ipldBridge ipldbridge.IPLDBridge) map[graphsync.RequestID]metadata.Metadata {
+	responseMetadata := make(map[graphsync.RequestID]metadata.Metadata, len(responses))
 	for _, response := range responses {
-		mdRaw, found := response.Extension(gsmsg.ExtensionMetadata)
+		mdRaw, found := response.Extension(graphsync.ExtensionMetadata)
 		if !found {
 			log.Warningf("Unable to decode metadata in response for request id: %d", response.RequestID())
 			continue

--- a/responsemanager/loader/loader.go
+++ b/responsemanager/loader/loader.go
@@ -4,15 +4,15 @@ import (
 	"bytes"
 	"io"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	ipld "github.com/ipld/go-ipld-prime"
 )
 
 // ResponseSender sends responses over the network
 type ResponseSender interface {
 	SendResponse(
-		requestID gsmsg.GraphSyncRequestID,
+		requestID graphsync.RequestID,
 		link ipld.Link,
 		data []byte,
 	)
@@ -21,7 +21,7 @@ type ResponseSender interface {
 // WrapLoader wraps a given loader with an interceptor that sends loaded
 // blocks out to the network with the given response sender.
 func WrapLoader(loader ipldbridge.Loader,
-	requestID gsmsg.GraphSyncRequestID,
+	requestID graphsync.RequestID,
 	responseSender ResponseSender) ipldbridge.Loader {
 	return func(lnk ipld.Link, lnkCtx ipldbridge.LinkContext) (io.Reader, error) {
 		result, err := loader(lnk, lnkCtx)

--- a/responsemanager/loader/loader_test.go
+++ b/responsemanager/loader/loader_test.go
@@ -9,22 +9,22 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testbridge"
 	"github.com/ipfs/go-graphsync/testutil"
 
 	"github.com/ipfs/go-graphsync/ipldbridge"
-	gsmsg "github.com/ipfs/go-graphsync/message"
 	ipld "github.com/ipld/go-ipld-prime"
 )
 
 type fakeResponseSender struct {
-	lastRequestID gsmsg.GraphSyncRequestID
+	lastRequestID graphsync.RequestID
 	lastLink      ipld.Link
 	lastData      []byte
 }
 
 func (frs *fakeResponseSender) SendResponse(
-	requestID gsmsg.GraphSyncRequestID,
+	requestID graphsync.RequestID,
 	link ipld.Link,
 	data []byte,
 ) {
@@ -46,7 +46,7 @@ func TestWrappedLoaderSendsResponses(t *testing.T) {
 		}
 		return nil, fmt.Errorf("unable to load block")
 	}
-	requestID := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID := graphsync.RequestID(rand.Int31())
 	wrappedLoader := WrapLoader(loader, requestID, frs)
 
 	reader, err := wrappedLoader(link1, ipldbridge.LinkContext{})

--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testbridge"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -36,9 +37,9 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
 	defer cancel()
 	p := testutil.GeneratePeers(1)[0]
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID3 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
+	requestID3 := graphsync.RequestID(rand.Int31())
 	blks := testutil.GenerateBlocksOfSize(5, 100)
 	links := make([]ipld.Link, 0, len(blks))
 	for _, block := range blks {
@@ -67,7 +68,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	}
 
 	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID1 ||
-		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		fph.lastResponses[0].Status() != graphsync.PartialResponse {
 		t.Fatal("Did not send correct responses for first message")
 	}
 
@@ -96,14 +97,14 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal("Did not send correct response for second message")
 	}
-	if response1.Status() != gsmsg.RequestCompletedPartial {
+	if response1.Status() != graphsync.RequestCompletedPartial {
 		t.Fatal("Did not send proper response code in second message")
 	}
 	response2, err := findResponseForRequestID(fph.lastResponses, requestID2)
 	if err != nil {
 		t.Fatal("Did not send correct response for second message")
 	}
-	if response2.Status() != gsmsg.PartialResponse {
+	if response2.Status() != graphsync.PartialResponse {
 		t.Fatal("Did not send proper response code in second message")
 	}
 
@@ -133,14 +134,14 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal("Did not send correct response for third message")
 	}
-	if response2.Status() != gsmsg.RequestCompletedFull {
+	if response2.Status() != graphsync.RequestCompletedFull {
 		t.Fatal("Did not send proper response code in third message")
 	}
 	response3, err := findResponseForRequestID(fph.lastResponses, requestID3)
 	if err != nil {
 		t.Fatal("Did not send correct response for third message")
 	}
-	if response3.Status() != gsmsg.PartialResponse {
+	if response3.Status() != graphsync.PartialResponse {
 		t.Fatal("Did not send proper response code in third message")
 	}
 
@@ -161,7 +162,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	}
 
 	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID3 ||
-		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		fph.lastResponses[0].Status() != graphsync.PartialResponse {
 		t.Fatal("Did not send correct responses for fourth message")
 	}
 }
@@ -169,7 +170,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 
 	p := testutil.GeneratePeers(1)[0]
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
 	// generate large blocks before proceeding
 	blks := testutil.GenerateBlocksOfSize(5, 1000000)
 	ctx := context.Background()
@@ -202,7 +203,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	}
 
 	if len(fph.lastResponses) != 1 || fph.lastResponses[0].RequestID() != requestID1 ||
-		fph.lastResponses[0].Status() != gsmsg.PartialResponse {
+		fph.lastResponses[0].Status() != graphsync.PartialResponse {
 		t.Fatal("Did not send correct responses for first message")
 	}
 
@@ -287,13 +288,13 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	if err != nil {
 		t.Fatal("Did not send correct response for fifth message")
 	}
-	if response.Status() != gsmsg.RequestCompletedFull {
+	if response.Status() != graphsync.RequestCompletedFull {
 		t.Fatal("Did not send proper response code in fifth message")
 	}
 
 }
 
-func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID gsmsg.GraphSyncRequestID) (gsmsg.GraphSyncResponse, error) {
+func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID graphsync.RequestID) (gsmsg.GraphSyncResponse, error) {
 	for _, response := range responses {
 		if response.RequestID() == requestID {
 			return response, nil

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/ipfs/go-graphsync"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
 	"github.com/ipfs/go-graphsync/testbridge"
@@ -22,27 +23,27 @@ func TestMessageBuilding(t *testing.T) {
 	for _, block := range blocks {
 		links = append(links, cidlink.Link{Cid: block.Cid()})
 	}
-	requestID1 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID2 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID3 := gsmsg.GraphSyncRequestID(rand.Int31())
-	requestID4 := gsmsg.GraphSyncRequestID(rand.Int31())
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
+	requestID3 := graphsync.RequestID(rand.Int31())
+	requestID4 := graphsync.RequestID(rand.Int31())
 
 	rb.AddLink(requestID1, links[0], true)
 	rb.AddLink(requestID1, links[1], false)
 	rb.AddLink(requestID1, links[2], true)
 
-	rb.AddCompletedRequest(requestID1, gsmsg.RequestCompletedPartial)
+	rb.AddCompletedRequest(requestID1, graphsync.RequestCompletedPartial)
 
 	rb.AddLink(requestID2, links[1], true)
 	rb.AddLink(requestID2, links[2], true)
 	rb.AddLink(requestID2, links[1], true)
 
-	rb.AddCompletedRequest(requestID2, gsmsg.RequestCompletedFull)
+	rb.AddCompletedRequest(requestID2, graphsync.RequestCompletedFull)
 
 	rb.AddLink(requestID3, links[0], true)
 	rb.AddLink(requestID3, links[1], true)
 
-	rb.AddCompletedRequest(requestID4, gsmsg.RequestCompletedFull)
+	rb.AddCompletedRequest(requestID4, graphsync.RequestCompletedFull)
 
 	for _, block := range blocks {
 		rb.AddBlock(block)
@@ -62,11 +63,11 @@ func TestMessageBuilding(t *testing.T) {
 	}
 
 	response1, err := findResponseForRequestID(responses, requestID1)
-	if err != nil || response1.Status() != gsmsg.RequestCompletedPartial {
+	if err != nil || response1.Status() != graphsync.RequestCompletedPartial {
 		t.Fatal("did not generate completed partial response")
 	}
 
-	response1MetadataRaw, found := response1.Extension(gsmsg.ExtensionMetadata)
+	response1MetadataRaw, found := response1.Extension(graphsync.ExtensionMetadata)
 	if !found {
 		t.Fatal("Metadata not included in response")
 	}
@@ -80,10 +81,10 @@ func TestMessageBuilding(t *testing.T) {
 	}
 
 	response2, err := findResponseForRequestID(responses, requestID2)
-	if err != nil || response2.Status() != gsmsg.RequestCompletedFull {
+	if err != nil || response2.Status() != graphsync.RequestCompletedFull {
 		t.Fatal("did not generate completed partial response")
 	}
-	response2MetadataRaw, found := response2.Extension(gsmsg.ExtensionMetadata)
+	response2MetadataRaw, found := response2.Extension(graphsync.ExtensionMetadata)
 	if !found {
 		t.Fatal("Metadata not included in response")
 	}
@@ -97,10 +98,10 @@ func TestMessageBuilding(t *testing.T) {
 	}
 
 	response3, err := findResponseForRequestID(responses, requestID3)
-	if err != nil || response3.Status() != gsmsg.PartialResponse {
+	if err != nil || response3.Status() != graphsync.PartialResponse {
 		t.Fatal("did not generate completed partial response")
 	}
-	response3MetadataRaw, found := response3.Extension(gsmsg.ExtensionMetadata)
+	response3MetadataRaw, found := response3.Extension(graphsync.ExtensionMetadata)
 	if !found {
 		t.Fatal("Metadata not included in response")
 	}
@@ -113,7 +114,7 @@ func TestMessageBuilding(t *testing.T) {
 	}
 
 	response4, err := findResponseForRequestID(responses, requestID4)
-	if err != nil || response4.Status() != gsmsg.RequestCompletedFull {
+	if err != nil || response4.Status() != graphsync.RequestCompletedFull {
 		t.Fatal("did not generate completed partial response")
 	}
 
@@ -128,7 +129,7 @@ func TestMessageBuilding(t *testing.T) {
 	}
 }
 
-func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID gsmsg.GraphSyncRequestID) (gsmsg.GraphSyncResponse, error) {
+func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID graphsync.RequestID) (gsmsg.GraphSyncResponse, error) {
 	for _, response := range responses {
 		if response.RequestID() == requestID {
 			return response, nil

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldbridge"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/responsemanager/loader"
@@ -29,7 +30,7 @@ type inProgressResponseStatus struct {
 
 type responseKey struct {
 	p         peer.ID
-	requestID gsmsg.GraphSyncRequestID
+	requestID graphsync.RequestID
 }
 
 type responseTaskData struct {
@@ -180,25 +181,25 @@ func noopVisitor(tp ipldbridge.TraversalProgress, n ipld.Node, tr ipldbridge.Tra
 
 func (rm *ResponseManager) executeQuery(ctx context.Context,
 	p peer.ID,
-	requestID gsmsg.GraphSyncRequestID,
+	requestID graphsync.RequestID,
 	root cid.Cid,
 	selectorBytes []byte) {
 	peerResponseSender := rm.peerManager.SenderForPeer(p)
 	selectorSpec, err := rm.ipldBridge.DecodeNode(selectorBytes)
 	if err != nil {
-		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		peerResponseSender.FinishWithError(requestID, graphsync.RequestFailedUnknown)
 		return
 	}
 	rootLink := cidlink.Link{Cid: root}
 	selector, err := rm.ipldBridge.ParseSelector(selectorSpec)
 	if err != nil {
-		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		peerResponseSender.FinishWithError(requestID, graphsync.RequestFailedUnknown)
 		return
 	}
 	wrappedLoader := loader.WrapLoader(rm.loader, requestID, peerResponseSender)
 	err = rm.ipldBridge.Traverse(ctx, wrappedLoader, rootLink, selector, noopVisitor)
 	if err != nil {
-		peerResponseSender.FinishWithError(requestID, gsmsg.RequestFailedUnknown)
+		peerResponseSender.FinishWithError(requestID, graphsync.RequestFailedUnknown)
 		return
 	}
 	peerResponseSender.FinishRequest(requestID)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -5,9 +5,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ipfs/go-block-format"
+	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
-	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/ipfs/go-graphsync"
 	blocksutil "github.com/ipfs/go-ipfs-blocksutil"
 	random "github.com/jbenet/go-random"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -86,8 +86,8 @@ func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
 
 // CollectResponses is just a utility to convert a graphsync response progress
 // channel into an array.
-func CollectResponses(ctx context.Context, t *testing.T, responseChan <-chan types.ResponseProgress) []types.ResponseProgress {
-	var collectedBlocks []types.ResponseProgress
+func CollectResponses(ctx context.Context, t *testing.T, responseChan <-chan graphsync.ResponseProgress) []graphsync.ResponseProgress {
+	var collectedBlocks []graphsync.ResponseProgress
 	for {
 		select {
 		case blk, ok := <-responseChan:
@@ -119,8 +119,8 @@ func CollectErrors(ctx context.Context, t *testing.T, errChan <-chan error) []er
 
 // ReadNResponses does a partial read from a ResponseProgress channel -- up
 // to n values
-func ReadNResponses(ctx context.Context, t *testing.T, responseChan <-chan types.ResponseProgress, count int) []types.ResponseProgress {
-	var returnedBlocks []types.ResponseProgress
+func ReadNResponses(ctx context.Context, t *testing.T, responseChan <-chan graphsync.ResponseProgress, count int) []graphsync.ResponseProgress {
+	var returnedBlocks []graphsync.ResponseProgress
 	for i := 0; i < count; i++ {
 		select {
 		case blk := <-responseChan:
@@ -171,7 +171,7 @@ func VerifyEmptyErrors(ctx context.Context, t *testing.T, errChan <-chan error) 
 
 // VerifyEmptyResponse verifies that no response progress happened before the
 // channel was closed.
-func VerifyEmptyResponse(ctx context.Context, t *testing.T, responseChan <-chan types.ResponseProgress) {
+func VerifyEmptyResponse(ctx context.Context, t *testing.T, responseChan <-chan graphsync.ResponseProgress) {
 	for {
 		select {
 		case _, ok := <-responseChan:


### PR DESCRIPTION
# Goals

Reduce future import cycles, and expose more types properly, and expose an actual interface
other implementers can replace.

# Implementation

- Root package is now interface/types file
- The main implementation is moved into /impl
- Move some common types in gsmsg (weird place) to the root package