### PR TITLE
WIP: User Extensions! (needs cleanup)

### DIFF
--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -395,7 +395,6 @@ package "go-graphsync" {
 
   package ipldbridge {
     interface IPLDBridge {
-      BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
 	    EncodeNode(ipld.Node) ([]byte, error)
 	    DecodeNode([]byte) (ipld.Node, error)
 	    ParseSelector(selector ipld.Node) (Selector, error)

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -91,6 +91,8 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 // it is considered to have "validated" the request -- and that validation supersedes
 // the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
 func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	gs.responseManager.RegisterHook(overrideDefaultValidation, hook)
+	// may be a need to return errors here in the future...
 	return nil
 }
 

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -86,6 +86,19 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 	return gs.requestManager.SendRequest(ctx, p, root, selector, extensions...)
 }
 
+// RegisterRequestReceivedHook adds a hook that runs when a request is received
+// If overrideDefaultValidation is set to true, then if the hook does not error,
+// it is considered to have "validated" the request -- and that validation supersedes
+// the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
+func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	return nil
+}
+
+// RegisterResponseReceivedHook adds a hook that runs when a response is received
+func (gs *GraphSync) RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
+	return nil
+}
+
 type graphSyncReceiver GraphSync
 
 func (gsr *graphSyncReceiver) graphSync() *GraphSync {

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -97,7 +97,8 @@ func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool,
 }
 
 // RegisterResponseReceivedHook adds a hook that runs when a response is received
-func (gs *GraphSync) RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
+func (gs *GraphSync) RegisterResponseReceivedHook(hook graphsync.OnResponseReceivedHook) error {
+        gs.requestManager.RegisterHook(hook)
 	return nil
 }
 

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -26,10 +26,362 @@ import (
 	ipld "github.com/ipld/go-ipld-prime"
 	ipldselector "github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 	mh "github.com/multiformats/go-multihash"
 )
+
+func TestMakeRequestToNetwork(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+	r := &receiver{
+		messageReceived: make(chan receivedMessage),
+	}
+	td.gsnet2.SetDelegate(r)
+	graphSync := td.GraphSyncHost1()
+
+	blockChainLength := 100
+	blockChain := setupBlockChain(ctx, t, td.storer1, td.bridge, 100, blockChainLength)
+
+	spec := blockChainSelector(blockChainLength)
+
+	requestCtx, requestCancel := context.WithCancel(ctx)
+	defer requestCancel()
+	graphSync.Request(requestCtx, td.host2.ID(), blockChain.tipLink, spec, td.extension)
+
+	var message receivedMessage
+	select {
+	case <-ctx.Done():
+		t.Fatal("did not receive message sent")
+	case message = <-r.messageReceived:
+	}
+
+	sender := message.sender
+	if sender != td.host1.ID() {
+		t.Fatal("received message from wrong node")
+	}
+
+	received := message.message
+	receivedRequests := received.Requests()
+	if len(receivedRequests) != 1 {
+		t.Fatal("Did not add request to received message")
+	}
+	receivedRequest := receivedRequests[0]
+	receivedSpec, err := td.bridge.DecodeNode(receivedRequest.Selector())
+	if err != nil {
+		t.Fatal("unable to decode transmitted selector")
+	}
+	if !reflect.DeepEqual(spec, receivedSpec) {
+		t.Fatal("did not transmit selector spec correctly")
+	}
+	_, err = td.bridge.ParseSelector(receivedSpec)
+	if err != nil {
+		t.Fatal("did not receive parsible selector on other side")
+	}
+
+	returnedData, found := receivedRequest.Extension(td.extensionName)
+	if !found || !reflect.DeepEqual(td.extensionData, returnedData) {
+		t.Fatal("Failed to encode extension")
+	}
+}
+
+func TestSendResponseToIncomingRequest(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+	r := &receiver{
+		messageReceived: make(chan receivedMessage),
+	}
+	td.gsnet1.SetDelegate(r)
+
+	var receivedRequestData []byte
+	// initialize graphsync on second node to response to requests
+	gsnet := td.GraphSyncHost2()
+	err := gsnet.RegisterRequestReceivedHook(false,
+		func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+			var has bool
+			receivedRequestData, has = requestData.Extension(td.extensionName)
+			if !has {
+				t.Fatal("did not have expected extension")
+			}
+			return []graphsync.ExtensionData{td.extensionResponse}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal("error registering extension")
+	}
+
+	blockChainLength := 100
+	blockChain := setupBlockChain(ctx, t, td.storer2, td.bridge, 100, blockChainLength)
+
+	spec := blockChainSelector(blockChainLength)
+
+	selectorData, err := td.bridge.EncodeNode(spec)
+	if err != nil {
+		t.Fatal("could not encode selector spec")
+	}
+	requestID := graphsync.RequestID(rand.Int31())
+
+	message := gsmsg.New()
+	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.tipLink.(cidlink.Link).Cid, selectorData, graphsync.Priority(math.MaxInt32), td.extension))
+	// send request across network
+	td.gsnet1.SendMessage(ctx, td.host2.ID(), message)
+	// read the values sent back to requestor
+	var received gsmsg.GraphSyncMessage
+	var receivedBlocks []blocks.Block
+	var receivedExtensions [][]byte
+readAllMessages:
+	for {
+		select {
+		case <-ctx.Done():
+			t.Fatal("did not receive complete response")
+		case message := <-r.messageReceived:
+			sender := message.sender
+			if sender != td.host2.ID() {
+				t.Fatal("received message from wrong node")
+			}
+
+			received = message.message
+			receivedBlocks = append(receivedBlocks, received.Blocks()...)
+			receivedResponses := received.Responses()
+			receivedExtension, found := receivedResponses[0].Extension(td.extensionName)
+			if found {
+				receivedExtensions = append(receivedExtensions, receivedExtension)
+			}
+			if len(receivedResponses) != 1 {
+				t.Fatal("Did not receive response")
+			}
+			if receivedResponses[0].RequestID() != requestID {
+				t.Fatal("Sent response for incorrect request id")
+			}
+			if receivedResponses[0].Status() != graphsync.PartialResponse {
+				break readAllMessages
+			}
+		}
+	}
+
+	if len(receivedBlocks) != blockChainLength {
+		t.Fatal("Send incorrect number of blocks or there were duplicate blocks")
+	}
+
+	if !reflect.DeepEqual(td.extensionData, receivedRequestData) {
+		t.Fatal("did not receive correct request extension data")
+	}
+
+	if len(receivedExtensions) != 1 {
+		t.Fatal("should have sent extension responses but didn't")
+	}
+
+	if !reflect.DeepEqual(receivedExtensions[0], td.extensionResponseData) {
+		t.Fatal("did not return correct extension data")
+	}
+}
+
+func TestGraphsyncRoundTrip(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+
+	// initialize graphsync on first node to make requests
+	requestor := td.GraphSyncHost1()
+
+	// setup receiving peer to just record message coming in
+	blockChainLength := 100
+	blockChain := setupBlockChain(ctx, t, td.storer2, td.bridge, 100, blockChainLength)
+
+	// initialize graphsync on second node to response to requests
+	responder := td.GraphSyncHost2()
+
+	var receivedResponseData []byte
+	var receivedRequestData []byte
+
+	err := requestor.RegisterResponseReceivedHook(
+		func(p peer.ID, responseData graphsync.ResponseData) error {
+			data, has := responseData.Extension(td.extensionName)
+			if has {
+				receivedResponseData = data
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal("Error setting up extension")
+	}
+
+	err = responder.RegisterRequestReceivedHook(false,
+		func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+			var has bool
+			receivedRequestData, has = requestData.Extension(td.extensionName)
+			if !has {
+				return nil, errors.New("Missing extension")
+			}
+			return []graphsync.ExtensionData{td.extensionResponse}, nil
+		})
+
+	if err != nil {
+		t.Fatal("Error setting up extension")
+	}
+
+	spec := blockChainSelector(blockChainLength)
+
+	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.tipLink, spec, td.extension)
+
+	responses := testutil.CollectResponses(ctx, t, progressChan)
+	errs := testutil.CollectErrors(ctx, t, errChan)
+
+	if len(responses) != blockChainLength*2 {
+		t.Fatal("did not traverse all nodes")
+	}
+	if len(errs) != 0 {
+		t.Fatal("errors during traverse")
+	}
+	if len(td.blockStore1) != blockChainLength {
+		t.Fatal("did not store all blocks")
+	}
+
+	expectedPath := ""
+	for i, response := range responses {
+		if response.Path.String() != expectedPath {
+			t.Fatal("incorrect path")
+		}
+		if i%2 == 0 {
+			if expectedPath == "" {
+				expectedPath = "Parents"
+			} else {
+				expectedPath = expectedPath + "/Parents"
+			}
+		} else {
+			expectedPath = expectedPath + "/0"
+		}
+	}
+
+	// verify extension roundtrip
+	if !reflect.DeepEqual(receivedRequestData, td.extensionData) {
+		t.Fatal("did not receive correct extension request data")
+	}
+
+	if !reflect.DeepEqual(receivedResponseData, td.extensionResponseData) {
+		t.Fatal("did not receive correct extension response data")
+	}
+}
+
+// TestRoundTripLargeBlocksSlowNetwork test verifies graphsync continues to work
+// under a specific of adverse conditions:
+// -- large blocks being returned by a query
+// -- slow network connection
+// It verifies that Graphsync will properly break up network message packets
+// so they can still be decoded on the client side, instead of building up a huge
+// backlog of blocks and then sending them in one giant network packet that can't
+// be decoded on the client side
+func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
+	// create network
+	if testing.Short() {
+		t.Skip()
+	}
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+	td.mn.SetLinkDefaults(mocknet.LinkOptions{Latency: 100 * time.Millisecond, Bandwidth: 3000000})
+
+	// initialize graphsync on first node to make requests
+	requestor := td.GraphSyncHost1()
+
+	// setup receiving peer to just record message coming in
+	blockChainLength := 40
+	blockChain := setupBlockChain(ctx, t, td.storer2, td.bridge, 200000, blockChainLength)
+
+	// initialize graphsync on second node to response to requests
+	td.GraphSyncHost2()
+
+	spec := blockChainSelector(blockChainLength)
+	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.tipLink, spec)
+
+	responses := testutil.CollectResponses(ctx, t, progressChan)
+	errs := testutil.CollectErrors(ctx, t, errChan)
+
+	if len(responses) != blockChainLength*2 {
+		t.Fatal("did not traverse all nodes")
+	}
+	if len(errs) != 0 {
+		t.Fatal("errors during traverse")
+	}
+}
+
+type gsTestData struct {
+	mn                       mocknet.Mocknet
+	ctx                      context.Context
+	host1                    host.Host
+	host2                    host.Host
+	gsnet1                   gsnet.GraphSyncNetwork
+	gsnet2                   gsnet.GraphSyncNetwork
+	blockStore1, blockStore2 map[ipld.Link][]byte
+	loader1, loader2         ipld.Loader
+	storer1, storer2         ipld.Storer
+	bridge                   ipldbridge.IPLDBridge
+	extensionData            []byte
+	extensionName            graphsync.ExtensionName
+	extension                graphsync.ExtensionData
+	extensionResponseData    []byte
+	extensionResponse        graphsync.ExtensionData
+}
+
+func newGsTestData(ctx context.Context, t *testing.T) *gsTestData {
+	td := &gsTestData{ctx: ctx}
+	td.mn = mocknet.New(ctx)
+	var err error
+	// setup network
+	td.host1, err = td.mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	td.host2, err = td.mn.GenPeer()
+	if err != nil {
+		t.Fatal("error generating host")
+	}
+	err = td.mn.LinkAll()
+	if err != nil {
+		t.Fatal("error linking hosts")
+	}
+
+	td.gsnet1 = gsnet.NewFromLibp2pHost(td.host1)
+	td.gsnet2 = gsnet.NewFromLibp2pHost(td.host2)
+	td.blockStore1 = make(map[ipld.Link][]byte)
+	td.loader1, td.storer1 = testbridge.NewMockStore(td.blockStore1)
+	td.blockStore2 = make(map[ipld.Link][]byte)
+	td.loader2, td.storer2 = testbridge.NewMockStore(td.blockStore2)
+	td.bridge = ipldbridge.NewIPLDBridge()
+	// setup extension handlers
+	td.extensionData = testutil.RandomBytes(100)
+	td.extensionName = graphsync.ExtensionName("AppleSauce/McGee")
+	td.extension = graphsync.ExtensionData{
+		Name: td.extensionName,
+		Data: td.extensionData,
+	}
+	td.extensionResponseData = testutil.RandomBytes(100)
+	td.extensionResponse = graphsync.ExtensionData{
+		Name: td.extensionName,
+		Data: td.extensionResponseData,
+	}
+
+	return td
+}
+
+func (td *gsTestData) GraphSyncHost1() graphsync.GraphExchange {
+	return New(td.ctx, td.gsnet1, td.bridge, td.loader1, td.storer1)
+}
+
+func (td *gsTestData) GraphSyncHost2() graphsync.GraphExchange {
+
+	return New(td.ctx, td.gsnet2, td.bridge, td.loader2, td.storer2)
+}
 
 type receivedMessage struct {
 	message gsmsg.GraphSyncMessage
@@ -138,435 +490,11 @@ func setupBlockChain(
 	return &blockChain{genisisNode, genesisLink, middleNodes, middleLinks, tipNode, tipLink}
 }
 
-func TestMakeRequestToNetwork(t *testing.T) {
-	// create network
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	mn := mocknet.New(ctx)
-
-	// setup network
-	host1, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	host2, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	err = mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
-
-	gsnet1 := gsnet.NewFromLibp2pHost(host1)
-
-	// setup receiving peer to just record message coming in
-	gsnet2 := gsnet.NewFromLibp2pHost(host2)
-	r := &receiver{
-		messageReceived: make(chan receivedMessage),
-	}
-	gsnet2.SetDelegate(r)
-
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testbridge.NewMockStore(blockStore)
-	bridge := ipldbridge.NewIPLDBridge()
-	graphSync := New(ctx, gsnet1, bridge, loader, storer)
-
-	blockChainLength := 100
-	blockChain := setupBlockChain(ctx, t, storer, bridge, 100, blockChainLength)
-
+func blockChainSelector(blockChainLength int) ipld.Node {
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
-	spec := ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
+	return ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
 		ssb.ExploreFields(func(efsb ipldbridge.ExploreFieldsSpecBuilder) {
 			efsb.Insert("Parents", ssb.ExploreAll(
 				ssb.ExploreRecursiveEdge()))
 		})).Node()
-
-	extensionData := testutil.RandomBytes(100)
-	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
-	extension := graphsync.ExtensionData{
-		Name: extensionName,
-		Data: extensionData,
-	}
-
-	requestCtx, requestCancel := context.WithCancel(ctx)
-	defer requestCancel()
-	graphSync.Request(requestCtx, host2.ID(), blockChain.tipLink, spec, extension)
-
-	var message receivedMessage
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not receive message sent")
-	case message = <-r.messageReceived:
-	}
-
-	sender := message.sender
-	if sender != host1.ID() {
-		t.Fatal("received message from wrong node")
-	}
-
-	received := message.message
-	receivedRequests := received.Requests()
-	if len(receivedRequests) != 1 {
-		t.Fatal("Did not add request to received message")
-	}
-	receivedRequest := receivedRequests[0]
-	receivedSpec, err := bridge.DecodeNode(receivedRequest.Selector())
-	if err != nil {
-		t.Fatal("unable to decode transmitted selector")
-	}
-	if !reflect.DeepEqual(spec, receivedSpec) {
-		t.Fatal("did not transmit selector spec correctly")
-	}
-	_, err = bridge.ParseSelector(receivedSpec)
-	if err != nil {
-		t.Fatal("did not receive parsible selector on other side")
-	}
-
-	returnedData, found := receivedRequest.Extension(extensionName)
-	if !found || !reflect.DeepEqual(extensionData, returnedData) {
-		t.Fatal("Failed to encode extension")
-	}
-}
-
-func TestSendResponseToIncomingRequest(t *testing.T) {
-	// create network
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
-	mn := mocknet.New(ctx)
-
-	// setup network
-	host1, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	host2, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	err = mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
-
-	gsnet1 := gsnet.NewFromLibp2pHost(host1)
-	r := &receiver{
-		messageReceived: make(chan receivedMessage),
-	}
-	gsnet1.SetDelegate(r)
-
-	// setup receiving peer to just record message coming in
-	gsnet2 := gsnet.NewFromLibp2pHost(host2)
-
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testbridge.NewMockStore(blockStore)
-	bridge := ipldbridge.NewIPLDBridge()
-
-	extensionData := testutil.RandomBytes(100)
-	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
-	extension := graphsync.ExtensionData{
-		Name: extensionName,
-		Data: extensionData,
-	}
-	extensionResponseData := testutil.RandomBytes(100)
-	extensionResponse := graphsync.ExtensionData{
-		Name: extensionName,
-		Data: extensionResponseData,
-	}
-
-	var receivedRequestData []byte
-	// initialize graphsync on second node to response to requests
-	gsnet := New(ctx, gsnet2, bridge, loader, storer)
-	err = gsnet.RegisterRequestReceivedHook(false,
-		func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
-			var has bool
-			receivedRequestData, has = requestData.Extension(extensionName)
-			if !has {
-				t.Fatal("did not have expected extension")
-			}
-			return []graphsync.ExtensionData{extensionResponse}, nil
-		},
-	)
-	if err != nil {
-		t.Fatal("error registering extension")
-	}
-
-	blockChainLength := 100
-	blockChain := setupBlockChain(ctx, t, storer, bridge, 100, blockChainLength)
-	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
-	spec := ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
-		ssb.ExploreFields(func(efsb ipldbridge.ExploreFieldsSpecBuilder) {
-			efsb.Insert("Parents", ssb.ExploreAll(
-				ssb.ExploreRecursiveEdge()))
-		})).Node()
-
-	selectorData, err := bridge.EncodeNode(spec)
-	if err != nil {
-		t.Fatal("could not encode selector spec")
-	}
-	requestID := graphsync.RequestID(rand.Int31())
-
-	message := gsmsg.New()
-	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.tipLink.(cidlink.Link).Cid, selectorData, graphsync.Priority(math.MaxInt32), extension))
-	// send request across network
-	gsnet1.SendMessage(ctx, host2.ID(), message)
-	// read the values sent back to requestor
-	var received gsmsg.GraphSyncMessage
-	var receivedBlocks []blocks.Block
-	var receivedExtensions [][]byte
-readAllMessages:
-	for {
-		select {
-		case <-ctx.Done():
-			t.Fatal("did not receive complete response")
-		case message := <-r.messageReceived:
-			sender := message.sender
-			if sender != host2.ID() {
-				t.Fatal("received message from wrong node")
-			}
-
-			received = message.message
-			receivedBlocks = append(receivedBlocks, received.Blocks()...)
-			receivedResponses := received.Responses()
-			receivedExtension, found := receivedResponses[0].Extension(extensionName)
-			if found {
-				receivedExtensions = append(receivedExtensions, receivedExtension)
-			}
-			if len(receivedResponses) != 1 {
-				t.Fatal("Did not receive response")
-			}
-			if receivedResponses[0].RequestID() != requestID {
-				t.Fatal("Sent response for incorrect request id")
-			}
-			if receivedResponses[0].Status() != graphsync.PartialResponse {
-				break readAllMessages
-			}
-		}
-	}
-
-	if len(receivedBlocks) != blockChainLength {
-		t.Fatal("Send incorrect number of blocks or there were duplicate blocks")
-	}
-
-	if !reflect.DeepEqual(extensionData, receivedRequestData) {
-		t.Fatal("did not receive correct request extension data")
-	}
-
-	if len(receivedExtensions) != 1 {
-		t.Fatal("should have sent extension responses but didn't")
-	}
-
-	if !reflect.DeepEqual(receivedExtensions[0], extensionResponseData) {
-		t.Fatal("did not return correct extension data")
-	}
-}
-
-func TestGraphsyncRoundTrip(t *testing.T) {
-	// create network
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
-	defer cancel()
-	mn := mocknet.New(ctx)
-
-	// setup network
-	host1, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	host2, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	err = mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
-
-	gsnet1 := gsnet.NewFromLibp2pHost(host1)
-
-	blockStore1 := make(map[ipld.Link][]byte)
-	loader1, storer1 := testbridge.NewMockStore(blockStore1)
-	bridge1 := ipldbridge.NewIPLDBridge()
-
-	// initialize graphsync on first node to make requests
-	requestor := New(ctx, gsnet1, bridge1, loader1, storer1)
-
-	// setup receiving peer to just record message coming in
-	gsnet2 := gsnet.NewFromLibp2pHost(host2)
-
-	blockStore2 := make(map[ipld.Link][]byte)
-	loader2, storer2 := testbridge.NewMockStore(blockStore2)
-	bridge2 := ipldbridge.NewIPLDBridge()
-
-	blockChainLength := 100
-	blockChain := setupBlockChain(ctx, t, storer2, bridge2, 100, blockChainLength)
-
-	// initialize graphsync on second node to response to requests
-	responder := New(ctx, gsnet2, bridge2, loader2, storer2)
-
-	// setup extension handlers
-	extensionData := testutil.RandomBytes(100)
-	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
-	extension := graphsync.ExtensionData{
-		Name: extensionName,
-		Data: extensionData,
-	}
-	extensionResponseData := testutil.RandomBytes(100)
-	extensionResponse := graphsync.ExtensionData{
-		Name: extensionName,
-		Data: extensionResponseData,
-	}
-
-	var receivedResponseData []byte
-	var receivedRequestData []byte
-
-	err = requestor.RegisterResponseReceivedHook(
-		func(p peer.ID, responseData graphsync.ResponseData) error {
-			data, has := responseData.Extension(extensionName)
-			if has {
-				receivedResponseData = data
-			}
-			return nil
-		})
-	if err != nil {
-		t.Fatal("Error setting up extension")
-	}
-
-	err = responder.RegisterRequestReceivedHook(false,
-		func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
-			var has bool
-			receivedRequestData, has = requestData.Extension(extensionName)
-			if !has {
-				return nil, errors.New("Missing extension")
-			}
-			return []graphsync.ExtensionData{extensionResponse}, nil
-		})
-
-	if err != nil {
-		t.Fatal("Error setting up extension")
-	}
-
-	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
-	spec := ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
-		ssb.ExploreFields(func(efsb ipldbridge.ExploreFieldsSpecBuilder) {
-			efsb.Insert("Parents", ssb.ExploreAll(
-				ssb.ExploreRecursiveEdge()))
-		})).Node()
-
-	progressChan, errChan := requestor.Request(ctx, host2.ID(), blockChain.tipLink, spec, extension)
-
-	responses := testutil.CollectResponses(ctx, t, progressChan)
-	errs := testutil.CollectErrors(ctx, t, errChan)
-
-	if len(responses) != blockChainLength*2 {
-		t.Fatal("did not traverse all nodes")
-	}
-	if len(errs) != 0 {
-		t.Fatal("errors during traverse")
-	}
-	if len(blockStore1) != blockChainLength {
-		t.Fatal("did not store all blocks")
-	}
-
-	expectedPath := ""
-	for i, response := range responses {
-		if response.Path.String() != expectedPath {
-			t.Fatal("incorrect path")
-		}
-		if i%2 == 0 {
-			if expectedPath == "" {
-				expectedPath = "Parents"
-			} else {
-				expectedPath = expectedPath + "/Parents"
-			}
-		} else {
-			expectedPath = expectedPath + "/0"
-		}
-	}
-
-	// verify extension roundtrip
-	if !reflect.DeepEqual(receivedRequestData, extensionData) {
-		t.Fatal("did not receive correct extension request data")
-	}
-
-	if !reflect.DeepEqual(receivedResponseData, extensionResponseData) {
-		t.Fatal("did not receive correct extension response data")
-	}
-}
-
-// TestRoundTripLargeBlocksSlowNetwork test verifies graphsync continues to work
-// under a specific of adverse conditions:
-// -- large blocks being returned by a query
-// -- slow network connection
-// It verifies that Graphsync will properly break up network message packets
-// so they can still be decoded on the client side, instead of building up a huge
-// backlog of blocks and then sending them in one giant network packet that can't
-// be decoded on the client side
-func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
-	// create network
-	if testing.Short() {
-		t.Skip()
-	}
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
-	defer cancel()
-	mn := mocknet.New(ctx)
-
-	// setup network
-	host1, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	host2, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
-	mn.SetLinkDefaults(mocknet.LinkOptions{Latency: 100 * time.Millisecond, Bandwidth: 3000000})
-	err = mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
-
-	gsnet1 := gsnet.NewFromLibp2pHost(host1)
-
-	blockStore1 := make(map[ipld.Link][]byte)
-	loader1, storer1 := testbridge.NewMockStore(blockStore1)
-	bridge1 := ipldbridge.NewIPLDBridge()
-
-	// initialize graphsync on first node to make requests
-	requestor := New(ctx, gsnet1, bridge1, loader1, storer1)
-
-	// setup receiving peer to just record message coming in
-	gsnet2 := gsnet.NewFromLibp2pHost(host2)
-
-	blockStore2 := make(map[ipld.Link][]byte)
-	loader2, storer2 := testbridge.NewMockStore(blockStore2)
-	bridge2 := ipldbridge.NewIPLDBridge()
-
-	blockChainLength := 40
-	blockChain := setupBlockChain(ctx, t, storer2, bridge2, 200000, blockChainLength)
-
-	// initialize graphsync on second node to response to requests
-	New(ctx, gsnet2, bridge2, loader2, storer2)
-
-	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
-	spec := ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
-		ssb.ExploreFields(func(efsb ipldbridge.ExploreFieldsSpecBuilder) {
-			efsb.Insert("Parents", ssb.ExploreAll(
-				ssb.ExploreRecursiveEdge()))
-		})).Node()
-
-	progressChan, errChan := requestor.Request(ctx, host2.ID(), blockChain.tipLink, spec)
-
-	responses := testutil.CollectResponses(ctx, t, progressChan)
-	errs := testutil.CollectErrors(ctx, t, errChan)
-
-	if len(responses) != blockChainLength*2 {
-		t.Fatal("did not traverse all nodes")
-	}
-	if len(errs) != 0 {
-		t.Fatal("errors during traverse")
-	}
 }

--- a/ipldbridge/ipld_impl.go
+++ b/ipldbridge/ipld_impl.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/ipld/go-ipld-prime/fluent"
-
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/encoding/dagcbor"
 	free "github.com/ipld/go-ipld-prime/impl/free"
@@ -22,30 +20,6 @@ type ipldBridge struct {
 // NewIPLDBridge returns an IPLD Bridge.
 func NewIPLDBridge() IPLDBridge {
 	return &ipldBridge{}
-}
-
-func (rb *ipldBridge) ExtractData(node ipld.Node, buildFn func(SimpleNode) interface{}) (interface{}, error) {
-	var value interface{}
-	err := fluent.Recover(func() {
-		simpleNode := fluent.WrapNode(node)
-		value = buildFn(simpleNode)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return value, nil
-}
-
-func (rb *ipldBridge) BuildNode(buildFn func(NodeBuilder) ipld.Node) (ipld.Node, error) {
-	var node ipld.Node
-	err := fluent.Recover(func() {
-		nb := fluent.WrapNodeBuilder(free.NodeBuilder())
-		node = buildFn(nb)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return node, nil
 }
 
 func (rb *ipldBridge) Traverse(ctx context.Context, loader Loader, root ipld.Link, s Selector, fn AdvVisitFn) error {

--- a/ipldbridge/ipldbridge.go
+++ b/ipldbridge/ipldbridge.go
@@ -72,14 +72,6 @@ type SimpleNode = fluent.Node
 // replaced with alternative implementations
 type IPLDBridge interface {
 
-	// ExtractData provides an efficient mechanism for reading nodes w/ fluent
-	// interface
-	ExtractData(ipld.Node, func(SimpleNode) interface{}) (interface{}, error)
-
-	// BuildNode provides an efficient mechanism for assembling nodes w/ fluent
-	// interface
-	BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
-
 	// EncodeNode encodes an IPLD Node to bytes for network transfer.
 	EncodeNode(ipld.Node) ([]byte, error)
 

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -57,6 +57,7 @@ type PeerResponseSender interface {
 		link ipld.Link,
 		data []byte,
 	)
+	SendExtensionData(graphsync.RequestID, graphsync.ExtensionData)
 	FinishRequest(requestID graphsync.RequestID)
 	FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode)
 }
@@ -84,6 +85,14 @@ func (prm *peerResponseSender) Startup() {
 // Shutdown stops sending messages for a peer
 func (prm *peerResponseSender) Shutdown() {
 	prm.cancel()
+}
+
+func (prm *peerResponseSender) SendExtensionData(requestID graphsync.RequestID, extension graphsync.ExtensionData) {
+	if prm.buildResponse(0, func(responseBuilder *responsebuilder.ResponseBuilder) {
+		responseBuilder.AddExtensionData(requestID, extension)
+	}) {
+		prm.signalWork()
+	}
 }
 
 // SendResponse sends a given link for a given

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -52,6 +52,22 @@ func TestMessageBuilding(t *testing.T) {
 	if rb.BlockSize() != 300 {
 		t.Fatal("did not calculate block size correctly")
 	}
+
+	extensionData1 := testutil.RandomBytes(100)
+	extensionName1 := graphsync.ExtensionName("AppleSauce/McGee")
+	extension1 := graphsync.ExtensionData{
+		Name: extensionName1,
+		Data: extensionData1,
+	}
+	extensionData2 := testutil.RandomBytes(100)
+	extensionName2 := graphsync.ExtensionName("HappyLand/Happenstance")
+	extension2 := graphsync.ExtensionData{
+		Name: extensionName2,
+		Data: extensionData2,
+	}
+	rb.AddExtensionData(requestID1, extension1)
+	rb.AddExtensionData(requestID3, extension2)
+
 	responses, sentBlocks, err := rb.Build(ipldBridge)
 
 	if err != nil {
@@ -78,6 +94,11 @@ func TestMessageBuilding(t *testing.T) {
 		metadata.Item{Link: links[2], BlockPresent: true},
 	}) {
 		t.Fatal("Metadata did not match expected")
+	}
+
+	response1ReturnedExtensionData, found := response1.Extension(extensionName1)
+	if !found || !reflect.DeepEqual(extensionData1, response1ReturnedExtensionData) {
+		t.Fatal("Failed to encode first extension")
 	}
 
 	response2, err := findResponseForRequestID(responses, requestID2)
@@ -111,6 +132,11 @@ func TestMessageBuilding(t *testing.T) {
 		metadata.Item{Link: links[1], BlockPresent: true},
 	}) {
 		t.Fatal("Metadata did not match expected")
+	}
+
+	response3ReturnedExtensionData, found := response3.Extension(extensionName2)
+	if !found || !reflect.DeepEqual(extensionData2, response3ReturnedExtensionData) {
+		t.Fatal("Failed to encode second extension")
 	}
 
 	response4, err := findResponseForRequestID(responses, requestID4)

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -2,6 +2,7 @@ package responsemanager
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -87,9 +88,19 @@ type sentResponse struct {
 	data      []byte
 }
 
+type sentExtension struct {
+	requestID graphsync.RequestID
+	extension graphsync.ExtensionData
+}
+
+type completedRequest struct {
+	requestID graphsync.RequestID
+	result    graphsync.ResponseStatusCode
+}
 type fakePeerResponseSender struct {
 	sentResponses        chan sentResponse
-	lastCompletedRequest chan graphsync.RequestID
+	sentExtensions       chan sentExtension
+	lastCompletedRequest chan completedRequest
 }
 
 func (fprs *fakePeerResponseSender) Startup()  {}
@@ -103,12 +114,19 @@ func (fprs *fakePeerResponseSender) SendResponse(
 	fprs.sentResponses <- sentResponse{requestID, link, data}
 }
 
+func (fprs *fakePeerResponseSender) SendExtensionData(
+	requestID graphsync.RequestID,
+	extension graphsync.ExtensionData,
+) {
+	fprs.sentExtensions <- sentExtension{requestID, extension}
+}
+
 func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID) {
-	fprs.lastCompletedRequest <- requestID
+	fprs.lastCompletedRequest <- completedRequest{requestID, graphsync.RequestCompletedFull}
 }
 
 func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode) {
-	fprs.lastCompletedRequest <- requestID
+	fprs.lastCompletedRequest <- completedRequest{requestID, status}
 }
 
 func TestIncomingQuery(t *testing.T) {
@@ -118,9 +136,10 @@ func TestIncomingQuery(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID, 1)
+	requestIDChan := make(chan completedRequest, 1)
 	sentResponses := make(chan sentResponse, len(blks))
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
@@ -173,9 +192,10 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID)
+	requestIDChan := make(chan completedRequest)
 	sentResponses := make(chan sentResponse)
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
@@ -260,9 +280,10 @@ func TestEarlyCancellation(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID)
+	requestIDChan := make(chan completedRequest)
 	sentResponses := make(chan sentResponse)
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	queryQueue.popWait.Add(1)
@@ -304,4 +325,165 @@ func TestEarlyCancellation(t *testing.T) {
 	case <-requestIDChan:
 		t.Fatal("should not send have completed response")
 	}
+}
+
+func TestValidationAndExtensions(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	blks := testutil.GenerateBlocksOfSize(5, 20)
+	loader := testbridge.NewMockLoader(blks)
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	completedRequestChan := make(chan completedRequest, 1)
+	sentResponses := make(chan sentResponse, 100)
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: completedRequestChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
+	peerManager := &fakePeerManager{peerResponseSender: fprs}
+	queryQueue := &fakeQueryQueue{}
+
+	cids := make([]cid.Cid, 0, 5)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+
+	extensionData := testutil.RandomBytes(100)
+	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
+	extension := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionData,
+	}
+	extensionResponseData := testutil.RandomBytes(100)
+	extensionResponse := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionResponseData,
+	}
+
+	t.Run("with invalid selector", func(t *testing.T) {
+		selectorSpec := testbridge.NewInvalidSelectorSpec(cids)
+		selector, err := ipldBridge.EncodeNode(selectorSpec)
+		if err != nil {
+			t.Fatal("error encoding selector")
+		}
+		requestID := graphsync.RequestID(rand.Int31())
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(requestID, cids[0], selector, graphsync.Priority(math.MaxInt32), extension),
+		}
+		p := testutil.GeneratePeers(1)[0]
+
+		t.Run("on its own, should fail validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have failed but didn't")
+				}
+			}
+		})
+
+		t.Run("if non validating hook succeeds, does not pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(false, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, nil
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+
+		t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(true, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, nil
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalSuccessCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+	})
+
+	t.Run("with valid selector", func(t *testing.T) {
+		selectorSpec := testbridge.NewMockSelectorSpec(cids)
+		selector, err := ipldBridge.EncodeNode(selectorSpec)
+		if err != nil {
+			t.Fatal("error encoding selector")
+		}
+		requestID := graphsync.RequestID(rand.Int31())
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(requestID, cids[0], selector, graphsync.Priority(math.MaxInt32), extension),
+		}
+		p := testutil.GeneratePeers(1)[0]
+
+		t.Run("on its own, should pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalSuccessCode(lastRequest.result) {
+					t.Fatal("Request should have failed but didn't")
+				}
+			}
+		})
+
+		t.Run("if any hook fails, should fail", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(false, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, fmt.Errorf("everything went to crap")
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+	})
 }

--- a/testbridge/mocknodes.go
+++ b/testbridge/mocknodes.go
@@ -8,29 +8,35 @@ import (
 )
 
 type mockSelectorSpec struct {
-	cidsVisited    []cid.Cid
-	failValidation bool
-	failEncode     bool
+	CidsVisited    []cid.Cid
+	FalseParse     bool
+	FailEncode     bool
+	FailValidation bool
 }
 
 // NewMockSelectorSpec returns a new mock selector that will visit the given
 // cids.
 func NewMockSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, false, false}
+	return &mockSelectorSpec{cidsVisited, false, false, false}
+}
+
+// NewUnparsableSelectorSpec returns a spec that will fail when you attempt to
+// validate it or decompose to a node + selector.
+func NewUnparsableSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
+	return &mockSelectorSpec{cidsVisited, true, false, false}
 }
 
 // NewInvalidSelectorSpec returns a spec that will fail when you attempt to
-// validate it or decompose to a node + selector.
+// encode it.
 func NewInvalidSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, true, false}
+	return &mockSelectorSpec{cidsVisited, false, false, true}
 }
 
 // NewUnencodableSelectorSpec returns a spec that will fail when you attempt to
 // encode it.
 func NewUnencodableSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, false, true}
+	return &mockSelectorSpec{cidsVisited, false, true, false}
 }
-
 func (mss *mockSelectorSpec) ReprKind() ipld.ReprKind { return ipld.ReprKind_Null }
 func (mss *mockSelectorSpec) Lookup(key ipld.Node) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")

--- a/testbridge/mockselector.go
+++ b/testbridge/mockselector.go
@@ -11,7 +11,7 @@ type mockSelector struct {
 }
 
 func newMockSelector(mss *mockSelectorSpec) ipldbridge.Selector {
-	return &mockSelector{mss.cidsVisited}
+	return &mockSelector{mss.CidsVisited}
 }
 
 func (ms *mockSelector) Explore(ipld.Node, ipld.PathSegment) ipldbridge.Selector {

--- a/testbridge/testbridge_test.go
+++ b/testbridge/testbridge_test.go
@@ -65,6 +65,7 @@ func TestEncodeParseSelector(t *testing.T) {
 	spec := NewMockSelectorSpec(cids)
 	bridge := NewMockIPLDBridge()
 	data, err := bridge.EncodeNode(spec)
+	fmt.Println(string(data))
 	if err != nil {
 		t.Fatal("error encoding selector spec")
 	}
@@ -76,17 +77,17 @@ func TestEncodeParseSelector(t *testing.T) {
 	if !ok {
 		t.Fatal("did not decode a selector")
 	}
-	if len(returnedSpec.cidsVisited) != 5 {
+	if len(returnedSpec.CidsVisited) != 5 {
 		t.Fatal("did not decode enough cids")
 	}
-	if !reflect.DeepEqual(cids, returnedSpec.cidsVisited) {
+	if !reflect.DeepEqual(cids, returnedSpec.CidsVisited) {
 		t.Fatal("did not decode correct cids")
 	}
 }
 
-func TestFailValidationSelectorSpec(t *testing.T) {
+func TestFailParseSelectorSpec(t *testing.T) {
 	cids := testutil.GenerateCids(5)
-	spec := NewInvalidSelectorSpec(cids)
+	spec := NewUnparsableSelectorSpec(cids)
 	bridge := NewMockIPLDBridge()
 	_, err := bridge.ParseSelector(spec)
 	if err == nil {


### PR DESCRIPTION
# Goals

Allow users of Graphsync to setup their own Graphsync protocol extensions!

How it works:
User register an extension handler via GraphExchange.RegisterExtension
Users can send extension data when making a Graphsync request
Users register one or both handlers: OnRequestReceived and OnResponseReceived
OnRequestReceived should process the data and return some kind of response data for that extension
OnResponseReceived simply receives the response and can evaluate the extension data
Either hook can return an error which will terminate the request
If PerformsValidation is set to true on the extension config, the extension returning NO ERROR will super-cede and short cut a default validation policy (say to permit an unbounded selector)

# Implementation

- Plumb response data to the network for responses
- Improved test bridge mocking
- Modify IPLDBridge to only have methods that might need mock implementation - IPLDBridge was originally designed to stub go-ipld-prime which wasn't ready. However, go-ipld-prime has somewhat stabilized for many aspects. It's time to only use this bridge when there is a specific need to mock behavior. Will remove type aliases in a future PR.

# For Discussion

The code is here is messy -- I need to clean it up before a merge I know -- just to be clear.

I am really only seeking feedback on the top level interfaces because I need to unblock data transfer. See /graphsync.go for the interfaces
