### PR TITLE
Send user extensions in request

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -2,7 +2,6 @@ package graphsync
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ipld/go-ipld-prime"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -83,11 +82,6 @@ const (
 	RequestFailedContentNotFound = ResponseStatusCode(34)
 )
 
-var (
-	// ErrExtensionNotPresent means the looked up extension was not found
-	ErrExtensionNotPresent = errors.New("Extension is missing from this message")
-)
-
 // ResponseProgress is the fundamental unit of responses making progress in Graphsync.
 type ResponseProgress struct {
 	Node      ipld.Node // a node which matched the graphsync query
@@ -100,5 +94,6 @@ type ResponseProgress struct {
 
 // GraphExchange is a protocol that can exchange IPLD graphs based on a selector
 type GraphExchange interface {
-	Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node) (<-chan ResponseProgress, <-chan error)
+	// Request initiates a new GraphSync request to the given peer using the given selector spec.
+	Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node, extensions ...ExtensionData) (<-chan ResponseProgress, <-chan error)
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -82,8 +82,8 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 }
 
 // Request initiates a new GraphSync request to the given peer using the given selector spec.
-func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node) (<-chan graphsync.ResponseProgress, <-chan error) {
-	return gs.requestManager.SendRequest(ctx, p, root, selector)
+func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node, extensions ...graphsync.ExtensionData) (<-chan graphsync.ResponseProgress, <-chan error) {
+	return gs.requestManager.SendRequest(ctx, p, root, selector, extensions...)
 }
 
 type graphSyncReceiver GraphSync

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -175,9 +175,17 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed creating selector")
 	}
+
+	extensionData := testutil.RandomBytes(100)
+	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
+	extension := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionData,
+	}
+
 	requestCtx, requestCancel := context.WithCancel(ctx)
 	defer requestCancel()
-	graphSync.Request(requestCtx, host2.ID(), blockChain.tipLink, spec)
+	graphSync.Request(requestCtx, host2.ID(), blockChain.tipLink, spec, extension)
 
 	var message receivedMessage
 	select {
@@ -207,6 +215,11 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	_, err = bridge.ParseSelector(receivedSpec)
 	if err != nil {
 		t.Fatal("did not receive parsible selector on other side")
+	}
+
+	returnedData, found := receivedRequest.Extension(extensionName)
+	if !found || !reflect.DeepEqual(extensionData, returnedData) {
+		t.Fatal("Failed to encode extension")
 	}
 }
 


### PR DESCRIPTION
# Goals

Allow Graphsync users to pass extensions data of their own in a Graphsync request.

# Implementation

- Add variadic args to request to allow passing an arbitrary set of extension data in a Graphsync request.
- Pass args to request manager and into outgoing graphsync request message
