### PR TITLE
Request hooks

### DIFF
--- a/docs/go-graphsync.puml
+++ b/docs/go-graphsync.puml
@@ -395,7 +395,6 @@ package "go-graphsync" {
 
   package ipldbridge {
     interface IPLDBridge {
-      BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
 	    EncodeNode(ipld.Node) ([]byte, error)
 	    DecodeNode([]byte) (ipld.Node, error)
 	    ParseSelector(selector ipld.Node) (Selector, error)

--- a/graphsync.go
+++ b/graphsync.go
@@ -115,12 +115,20 @@ type RequestData interface {
 	IsCancel() bool
 }
 
+// RequestReceivedHookActions are actions that a request hook can take to change
+// behavior for the response
+type RequestReceivedHookActions interface {
+	SendExtensionData(ExtensionData)
+	TerminateWithError(error)
+	ValidateRequest()
+}
+
 // OnRequestReceivedHook is a hook that runs each time a request is received.
 // It receives the peer that sent the request and all data about the request.
 // It should return:
 // extensionData - any extension data to add to the outgoing response
 // err - error - if not nil, halt request and return RequestRejected with the responseData
-type OnRequestReceivedHook func(p peer.ID, request RequestData) (extensionData []ExtensionData, err error)
+type OnRequestReceivedHook func(p peer.ID, request RequestData, hookActions RequestReceivedHookActions)
 
 // GraphExchange is a protocol that can exchange IPLD graphs based on a selector
 type GraphExchange interface {
@@ -131,5 +139,5 @@ type GraphExchange interface {
 	// If overrideDefaultValidation is set to true, then if the hook does not error,
 	// it is considered to have "validated" the request -- and that validation supersedes
 	// the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
-	RegisterRequestReceivedHook(overrideDefaultValidation bool, hook OnRequestReceivedHook) error
+	RegisterRequestReceivedHook(hook OnRequestReceivedHook) error
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -91,6 +91,8 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 // it is considered to have "validated" the request -- and that validation supersedes
 // the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
 func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	gs.responseManager.RegisterHook(overrideDefaultValidation, hook)
+	// may be a need to return errors here in the future...
 	return nil
 }
 

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -90,8 +90,8 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 // If overrideDefaultValidation is set to true, then if the hook does not error,
 // it is considered to have "validated" the request -- and that validation supersedes
 // the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
-func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
-	gs.responseManager.RegisterHook(overrideDefaultValidation, hook)
+func (gs *GraphSync) RegisterRequestReceivedHook(hook graphsync.OnRequestReceivedHook) error {
+	gs.responseManager.RegisterHook(hook)
 	// may be a need to return errors here in the future...
 	return nil
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -86,6 +86,14 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 	return gs.requestManager.SendRequest(ctx, p, root, selector, extensions...)
 }
 
+// RegisterRequestReceivedHook adds a hook that runs when a request is received
+// If overrideDefaultValidation is set to true, then if the hook does not error,
+// it is considered to have "validated" the request -- and that validation supersedes
+// the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
+func (gs *GraphSync) RegisterRequestReceivedHook(overrideDefaultValidation bool, hook graphsync.OnRequestReceivedHook) error {
+	return nil
+}
+
 type graphSyncReceiver GraphSync
 
 func (gsr *graphSyncReceiver) graphSync() *GraphSync {

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -278,14 +278,14 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	var receivedRequestData []byte
 	// initialize graphsync on second node to response to requests
 	gsnet := New(ctx, gsnet2, bridge, loader, storer)
-	err = gsnet.RegisterRequestReceivedHook(false,
-		func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+	err = gsnet.RegisterRequestReceivedHook(
+		func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 			var has bool
 			receivedRequestData, has = requestData.Extension(extensionName)
 			if !has {
 				t.Fatal("did not have expected extension")
 			}
-			return []graphsync.ExtensionData{extensionResponse}, nil
+			hookActions.SendExtensionData(extensionResponse)
 		},
 	)
 	if err != nil {

--- a/ipldbridge/ipld_impl.go
+++ b/ipldbridge/ipld_impl.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 
-	"github.com/ipld/go-ipld-prime/fluent"
-
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/ipld/go-ipld-prime/encoding/dagcbor"
 	free "github.com/ipld/go-ipld-prime/impl/free"
@@ -22,30 +20,6 @@ type ipldBridge struct {
 // NewIPLDBridge returns an IPLD Bridge.
 func NewIPLDBridge() IPLDBridge {
 	return &ipldBridge{}
-}
-
-func (rb *ipldBridge) ExtractData(node ipld.Node, buildFn func(SimpleNode) interface{}) (interface{}, error) {
-	var value interface{}
-	err := fluent.Recover(func() {
-		simpleNode := fluent.WrapNode(node)
-		value = buildFn(simpleNode)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return value, nil
-}
-
-func (rb *ipldBridge) BuildNode(buildFn func(NodeBuilder) ipld.Node) (ipld.Node, error) {
-	var node ipld.Node
-	err := fluent.Recover(func() {
-		nb := fluent.WrapNodeBuilder(free.NodeBuilder())
-		node = buildFn(nb)
-	})
-	if err != nil {
-		return nil, err
-	}
-	return node, nil
 }
 
 func (rb *ipldBridge) Traverse(ctx context.Context, loader Loader, root ipld.Link, s Selector, fn AdvVisitFn) error {

--- a/ipldbridge/ipldbridge.go
+++ b/ipldbridge/ipldbridge.go
@@ -72,14 +72,6 @@ type SimpleNode = fluent.Node
 // replaced with alternative implementations
 type IPLDBridge interface {
 
-	// ExtractData provides an efficient mechanism for reading nodes w/ fluent
-	// interface
-	ExtractData(ipld.Node, func(SimpleNode) interface{}) (interface{}, error)
-
-	// BuildNode provides an efficient mechanism for assembling nodes w/ fluent
-	// interface
-	BuildNode(func(NodeBuilder) ipld.Node) (ipld.Node, error)
-
 	// EncodeNode encodes an IPLD Node to bytes for network transfer.
 	EncodeNode(ipld.Node) ([]byte, error)
 

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -57,6 +57,7 @@ type PeerResponseSender interface {
 		link ipld.Link,
 		data []byte,
 	)
+	SendExtensionData(graphsync.RequestID, graphsync.ExtensionData)
 	FinishRequest(requestID graphsync.RequestID)
 	FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode)
 }
@@ -84,6 +85,14 @@ func (prm *peerResponseSender) Startup() {
 // Shutdown stops sending messages for a peer
 func (prm *peerResponseSender) Shutdown() {
 	prm.cancel()
+}
+
+func (prm *peerResponseSender) SendExtensionData(requestID graphsync.RequestID, extension graphsync.ExtensionData) {
+	if prm.buildResponse(0, func(responseBuilder *responsebuilder.ResponseBuilder) {
+		responseBuilder.AddExtensionData(requestID, extension)
+	}) {
+		prm.signalWork()
+	}
 }
 
 // SendResponse sends a given link for a given

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -52,6 +52,22 @@ func TestMessageBuilding(t *testing.T) {
 	if rb.BlockSize() != 300 {
 		t.Fatal("did not calculate block size correctly")
 	}
+
+	extensionData1 := testutil.RandomBytes(100)
+	extensionName1 := graphsync.ExtensionName("AppleSauce/McGee")
+	extension1 := graphsync.ExtensionData{
+		Name: extensionName1,
+		Data: extensionData1,
+	}
+	extensionData2 := testutil.RandomBytes(100)
+	extensionName2 := graphsync.ExtensionName("HappyLand/Happenstance")
+	extension2 := graphsync.ExtensionData{
+		Name: extensionName2,
+		Data: extensionData2,
+	}
+	rb.AddExtensionData(requestID1, extension1)
+	rb.AddExtensionData(requestID3, extension2)
+
 	responses, sentBlocks, err := rb.Build(ipldBridge)
 
 	if err != nil {
@@ -78,6 +94,11 @@ func TestMessageBuilding(t *testing.T) {
 		metadata.Item{Link: links[2], BlockPresent: true},
 	}) {
 		t.Fatal("Metadata did not match expected")
+	}
+
+	response1ReturnedExtensionData, found := response1.Extension(extensionName1)
+	if !found || !reflect.DeepEqual(extensionData1, response1ReturnedExtensionData) {
+		t.Fatal("Failed to encode first extension")
 	}
 
 	response2, err := findResponseForRequestID(responses, requestID2)
@@ -111,6 +132,11 @@ func TestMessageBuilding(t *testing.T) {
 		metadata.Item{Link: links[1], BlockPresent: true},
 	}) {
 		t.Fatal("Metadata did not match expected")
+	}
+
+	response3ReturnedExtensionData, found := response3.Extension(extensionName2)
+	if !found || !reflect.DeepEqual(extensionData2, response3ReturnedExtensionData) {
+		t.Fatal("Failed to encode second extension")
 	}
 
 	response4, err := findResponseForRequestID(responses, requestID4)

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -40,8 +39,7 @@ type responseTaskData struct {
 }
 
 type requestHook struct {
-	overrideDefaultValidation bool
-	hook                      graphsync.OnRequestReceivedHook
+	hook graphsync.OnRequestReceivedHook
 }
 
 // QueryQueue is an interface that can receive new selector query tasks
@@ -116,11 +114,9 @@ func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, reque
 }
 
 // RegisterHook registers an extension to process new incoming requests
-func (rm *ResponseManager) RegisterHook(
-	overrideDefaultValidation bool,
-	hook graphsync.OnRequestReceivedHook) {
+func (rm *ResponseManager) RegisterHook(hook graphsync.OnRequestReceivedHook) {
 	select {
-	case rm.messages <- &requestHook{overrideDefaultValidation, hook}:
+	case rm.messages <- &requestHook{hook}:
 	case <-rm.ctx.Done():
 	}
 }
@@ -195,14 +191,50 @@ func noopVisitor(tp ipldbridge.TraversalProgress, n ipld.Node, tr ipldbridge.Tra
 	return nil
 }
 
+type hookActions struct {
+	isValidated        bool
+	requestID          graphsync.RequestID
+	peerResponseSender peerresponsemanager.PeerResponseSender
+	err                error
+}
+
+func (ha *hookActions) SendExtensionData(ext graphsync.ExtensionData) {
+	ha.peerResponseSender.SendExtensionData(ha.requestID, ext)
+}
+
+func (ha *hookActions) TerminateWithError(err error) {
+	ha.err = err
+	ha.peerResponseSender.FinishWithError(ha.requestID, graphsync.RequestFailedUnknown)
+}
+
+func (ha *hookActions) ValidateRequest() {
+	ha.isValidated = true
+}
+
 func (rm *ResponseManager) executeQuery(ctx context.Context,
 	p peer.ID,
 	request gsmsg.GraphSyncRequest) {
 	peerResponseSender := rm.peerManager.SenderForPeer(p)
-	extensionData, selector, err := rm.validateRequest(p, request)
-	for _, datum := range extensionData {
-		peerResponseSender.SendExtensionData(request.ID(), datum)
+	selectorSpec, err := rm.ipldBridge.DecodeNode(request.Selector())
+	if err != nil {
+		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
+		return
 	}
+	ha := &hookActions{false, request.ID(), peerResponseSender, nil}
+	for _, requestHook := range rm.requestHooks {
+		requestHook.hook(p, request, ha)
+		if ha.err != nil {
+			return
+		}
+	}
+	if !ha.isValidated {
+		err = selectorvalidator.ValidateSelector(rm.ipldBridge, selectorSpec, maxRecursionDepth)
+		if err != nil {
+			peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
+			return
+		}
+	}
+	selector, err := rm.ipldBridge.ParseSelector(selectorSpec)
 	if err != nil {
 		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
 		return
@@ -215,33 +247,6 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 		return
 	}
 	peerResponseSender.FinishRequest(request.ID())
-}
-
-func (rm *ResponseManager) validateRequest(p peer.ID, request graphsync.RequestData) ([]graphsync.ExtensionData, selector.Selector, error) {
-	selectorSpec, err := rm.ipldBridge.DecodeNode(request.Selector())
-	if err != nil {
-		return nil, nil, err
-	}
-	var isValidated bool
-	var allExtensionData []graphsync.ExtensionData
-	for _, requestHook := range rm.requestHooks {
-		extensionData, err := requestHook.hook(p, request)
-		allExtensionData = append(allExtensionData, extensionData...)
-		if err != nil {
-			return allExtensionData, nil, err
-		}
-		if requestHook.overrideDefaultValidation {
-			isValidated = true
-		}
-	}
-	if !isValidated {
-		err = selectorvalidator.ValidateSelector(rm.ipldBridge, selectorSpec, maxRecursionDepth)
-		if err != nil {
-			return allExtensionData, nil, err
-		}
-	}
-	selector, err := rm.ipldBridge.ParseSelector(selectorSpec)
-	return allExtensionData, selector, err
 }
 
 // Startup starts processing for the WantManager.

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -2,6 +2,7 @@ package responsemanager
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"math/rand"
 	"reflect"
@@ -87,9 +88,19 @@ type sentResponse struct {
 	data      []byte
 }
 
+type sentExtension struct {
+	requestID graphsync.RequestID
+	extension graphsync.ExtensionData
+}
+
+type completedRequest struct {
+	requestID graphsync.RequestID
+	result    graphsync.ResponseStatusCode
+}
 type fakePeerResponseSender struct {
 	sentResponses        chan sentResponse
-	lastCompletedRequest chan graphsync.RequestID
+	sentExtensions       chan sentExtension
+	lastCompletedRequest chan completedRequest
 }
 
 func (fprs *fakePeerResponseSender) Startup()  {}
@@ -103,12 +114,19 @@ func (fprs *fakePeerResponseSender) SendResponse(
 	fprs.sentResponses <- sentResponse{requestID, link, data}
 }
 
+func (fprs *fakePeerResponseSender) SendExtensionData(
+	requestID graphsync.RequestID,
+	extension graphsync.ExtensionData,
+) {
+	fprs.sentExtensions <- sentExtension{requestID, extension}
+}
+
 func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID) {
-	fprs.lastCompletedRequest <- requestID
+	fprs.lastCompletedRequest <- completedRequest{requestID, graphsync.RequestCompletedFull}
 }
 
 func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode) {
-	fprs.lastCompletedRequest <- requestID
+	fprs.lastCompletedRequest <- completedRequest{requestID, status}
 }
 
 func TestIncomingQuery(t *testing.T) {
@@ -118,9 +136,10 @@ func TestIncomingQuery(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID, 1)
+	requestIDChan := make(chan completedRequest, 1)
 	sentResponses := make(chan sentResponse, len(blks))
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
@@ -173,9 +192,10 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID)
+	requestIDChan := make(chan completedRequest)
 	sentResponses := make(chan sentResponse)
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
@@ -260,9 +280,10 @@ func TestEarlyCancellation(t *testing.T) {
 	blks := testutil.GenerateBlocksOfSize(5, 20)
 	loader := testbridge.NewMockLoader(blks)
 	ipldBridge := testbridge.NewMockIPLDBridge()
-	requestIDChan := make(chan graphsync.RequestID)
+	requestIDChan := make(chan completedRequest)
 	sentResponses := make(chan sentResponse)
-	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses}
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: requestIDChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
 	peerManager := &fakePeerManager{peerResponseSender: fprs}
 	queryQueue := &fakeQueryQueue{}
 	queryQueue.popWait.Add(1)
@@ -304,4 +325,165 @@ func TestEarlyCancellation(t *testing.T) {
 	case <-requestIDChan:
 		t.Fatal("should not send have completed response")
 	}
+}
+
+func TestValidationAndExtensions(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 40*time.Millisecond)
+	defer cancel()
+	blks := testutil.GenerateBlocksOfSize(5, 20)
+	loader := testbridge.NewMockLoader(blks)
+	ipldBridge := testbridge.NewMockIPLDBridge()
+	completedRequestChan := make(chan completedRequest, 1)
+	sentResponses := make(chan sentResponse, 100)
+	sentExtensions := make(chan sentExtension, 1)
+	fprs := &fakePeerResponseSender{lastCompletedRequest: completedRequestChan, sentResponses: sentResponses, sentExtensions: sentExtensions}
+	peerManager := &fakePeerManager{peerResponseSender: fprs}
+	queryQueue := &fakeQueryQueue{}
+
+	cids := make([]cid.Cid, 0, 5)
+	for _, block := range blks {
+		cids = append(cids, block.Cid())
+	}
+
+	extensionData := testutil.RandomBytes(100)
+	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
+	extension := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionData,
+	}
+	extensionResponseData := testutil.RandomBytes(100)
+	extensionResponse := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionResponseData,
+	}
+
+	t.Run("with invalid selector", func(t *testing.T) {
+		selectorSpec := testbridge.NewInvalidSelectorSpec(cids)
+		selector, err := ipldBridge.EncodeNode(selectorSpec)
+		if err != nil {
+			t.Fatal("error encoding selector")
+		}
+		requestID := graphsync.RequestID(rand.Int31())
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(requestID, cids[0], selector, graphsync.Priority(math.MaxInt32), extension),
+		}
+		p := testutil.GeneratePeers(1)[0]
+
+		t.Run("on its own, should fail validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have failed but didn't")
+				}
+			}
+		})
+
+		t.Run("if non validating hook succeeds, does not pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(false, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, nil
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+
+		t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(true, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, nil
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalSuccessCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+	})
+
+	t.Run("with valid selector", func(t *testing.T) {
+		selectorSpec := testbridge.NewMockSelectorSpec(cids)
+		selector, err := ipldBridge.EncodeNode(selectorSpec)
+		if err != nil {
+			t.Fatal("error encoding selector")
+		}
+		requestID := graphsync.RequestID(rand.Int31())
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(requestID, cids[0], selector, graphsync.Priority(math.MaxInt32), extension),
+		}
+		p := testutil.GeneratePeers(1)[0]
+
+		t.Run("on its own, should pass validation", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalSuccessCode(lastRequest.result) {
+					t.Fatal("Request should have failed but didn't")
+				}
+			}
+		})
+
+		t.Run("if any hook fails, should fail", func(t *testing.T) {
+			responseManager := New(ctx, loader, ipldBridge, peerManager, queryQueue)
+			responseManager.Startup()
+			responseManager.RegisterHook(false, func(p peer.ID, requestData graphsync.RequestData) ([]graphsync.ExtensionData, error) {
+				return []graphsync.ExtensionData{extensionResponse}, fmt.Errorf("everything went to crap")
+			})
+			responseManager.ProcessRequests(ctx, p, requests)
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have completed request but didn't")
+			case lastRequest := <-completedRequestChan:
+				if !gsmsg.IsTerminalFailureCode(lastRequest.result) {
+					t.Fatal("Request should have succeeded but didn't")
+				}
+			}
+			select {
+			case <-ctx.Done():
+				t.Fatal("Should have sent extension response but didn't")
+			case receivedExtension := <-sentExtensions:
+				if !reflect.DeepEqual(receivedExtension.extension, extensionResponse) {
+					t.Fatal("Proper Extension response should have been sent but wasn't")
+				}
+			}
+		})
+	})
 }

--- a/testbridge/mocknodes.go
+++ b/testbridge/mocknodes.go
@@ -8,29 +8,35 @@ import (
 )
 
 type mockSelectorSpec struct {
-	cidsVisited    []cid.Cid
-	failValidation bool
-	failEncode     bool
+	CidsVisited    []cid.Cid
+	FalseParse     bool
+	FailEncode     bool
+	FailValidation bool
 }
 
 // NewMockSelectorSpec returns a new mock selector that will visit the given
 // cids.
 func NewMockSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, false, false}
+	return &mockSelectorSpec{cidsVisited, false, false, false}
+}
+
+// NewUnparsableSelectorSpec returns a spec that will fail when you attempt to
+// validate it or decompose to a node + selector.
+func NewUnparsableSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
+	return &mockSelectorSpec{cidsVisited, true, false, false}
 }
 
 // NewInvalidSelectorSpec returns a spec that will fail when you attempt to
-// validate it or decompose to a node + selector.
+// encode it.
 func NewInvalidSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, true, false}
+	return &mockSelectorSpec{cidsVisited, false, false, true}
 }
 
 // NewUnencodableSelectorSpec returns a spec that will fail when you attempt to
 // encode it.
 func NewUnencodableSelectorSpec(cidsVisited []cid.Cid) ipld.Node {
-	return &mockSelectorSpec{cidsVisited, false, true}
+	return &mockSelectorSpec{cidsVisited, false, true, false}
 }
-
 func (mss *mockSelectorSpec) ReprKind() ipld.ReprKind { return ipld.ReprKind_Null }
 func (mss *mockSelectorSpec) Lookup(key ipld.Node) (ipld.Node, error) {
 	return nil, fmt.Errorf("404")

--- a/testbridge/mockselector.go
+++ b/testbridge/mockselector.go
@@ -11,7 +11,7 @@ type mockSelector struct {
 }
 
 func newMockSelector(mss *mockSelectorSpec) ipldbridge.Selector {
-	return &mockSelector{mss.cidsVisited}
+	return &mockSelector{mss.CidsVisited}
 }
 
 func (ms *mockSelector) Explore(ipld.Node, ipld.PathSegment) ipldbridge.Selector {

--- a/testbridge/testbridge_test.go
+++ b/testbridge/testbridge_test.go
@@ -65,6 +65,7 @@ func TestEncodeParseSelector(t *testing.T) {
 	spec := NewMockSelectorSpec(cids)
 	bridge := NewMockIPLDBridge()
 	data, err := bridge.EncodeNode(spec)
+	fmt.Println(string(data))
 	if err != nil {
 		t.Fatal("error encoding selector spec")
 	}
@@ -76,17 +77,17 @@ func TestEncodeParseSelector(t *testing.T) {
 	if !ok {
 		t.Fatal("did not decode a selector")
 	}
-	if len(returnedSpec.cidsVisited) != 5 {
+	if len(returnedSpec.CidsVisited) != 5 {
 		t.Fatal("did not decode enough cids")
 	}
-	if !reflect.DeepEqual(cids, returnedSpec.cidsVisited) {
+	if !reflect.DeepEqual(cids, returnedSpec.CidsVisited) {
 		t.Fatal("did not decode correct cids")
 	}
 }
 
-func TestFailValidationSelectorSpec(t *testing.T) {
+func TestFailParseSelectorSpec(t *testing.T) {
 	cids := testutil.GenerateCids(5)
-	spec := NewInvalidSelectorSpec(cids)
+	spec := NewUnparsableSelectorSpec(cids)
 	bridge := NewMockIPLDBridge()
 	_, err := bridge.ParseSelector(spec)
 	if err == nil {


### PR DESCRIPTION
# Goals

Adds the ability to add hooks that run when processing requests

# Implementation

- Remove methods from IPLD bridge that don't have to do with tests
- Add methods to register response hooks
- Add processing of response hooks as part of request validation
- Add plumbing of extension data through on responses
