### PR TITLE
Add response hooks

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -96,7 +96,8 @@ func (gs *GraphSync) RegisterRequestReceivedHook(hook graphsync.OnRequestReceive
 }
 
 // RegisterResponseReceivedHook adds a hook that runs when a response is received
-func (gs *GraphSync) RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
+func (gs *GraphSync) RegisterResponseReceivedHook(hook graphsync.OnResponseReceivedHook) error {
+        gs.requestManager.RegisterHook(hook)
 	return nil
 }
 

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -92,7 +92,11 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 // the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
 func (gs *GraphSync) RegisterRequestReceivedHook(hook graphsync.OnRequestReceivedHook) error {
 	gs.responseManager.RegisterHook(hook)
-	// may be a need to return errors here in the future...
+	return nil
+}
+
+// RegisterResponseReceivedHook adds a hook that runs when a response is received
+func (gs *GraphSync) RegisterResponseReceivedHook(graphsync.OnResponseReceivedHook) error {
 	return nil
 }
 

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -97,7 +97,7 @@ func (gs *GraphSync) RegisterRequestReceivedHook(hook graphsync.OnRequestReceive
 
 // RegisterResponseReceivedHook adds a hook that runs when a response is received
 func (gs *GraphSync) RegisterResponseReceivedHook(hook graphsync.OnResponseReceivedHook) error {
-        gs.requestManager.RegisterHook(hook)
+	gs.requestManager.RegisterHook(hook)
 	return nil
 }
 

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -2,6 +2,7 @@ package graphsync
 
 import (
 	"context"
+	"errors"
 	"math"
 	"math/rand"
 	"reflect"
@@ -403,7 +404,49 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	blockChain := setupBlockChain(ctx, t, storer2, bridge2, 100, blockChainLength)
 
 	// initialize graphsync on second node to response to requests
-	New(ctx, gsnet2, bridge2, loader2, storer2)
+	responder := New(ctx, gsnet2, bridge2, loader2, storer2)
+
+	// setup extension handlers
+	extensionData := testutil.RandomBytes(100)
+	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
+	extension := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionData,
+	}
+	extensionResponseData := testutil.RandomBytes(100)
+	extensionResponse := graphsync.ExtensionData{
+		Name: extensionName,
+		Data: extensionResponseData,
+	}
+
+	var receivedResponseData []byte
+	var receivedRequestData []byte
+
+	err = requestor.RegisterResponseReceivedHook(
+		func(p peer.ID, responseData graphsync.ResponseData) error {
+			data, has := responseData.Extension(extensionName)
+			if has {
+				receivedResponseData = data
+			}
+			return nil
+		})
+	if err != nil {
+		t.Fatal("Error setting up extension")
+	}
+
+	err = responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		var has bool
+		receivedRequestData, has = requestData.Extension(extensionName)
+		if !has {
+			hookActions.TerminateWithError(errors.New("Missing extension"))
+		} else {
+			hookActions.SendExtensionData(extensionResponse)
+		}
+	})
+
+	if err != nil {
+		t.Fatal("Error setting up extension")
+	}
 
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
 	spec := ssb.ExploreRecursive(ipldselector.RecursionLimitDepth(blockChainLength),
@@ -412,7 +455,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 				ssb.ExploreRecursiveEdge()))
 		})).Node()
 
-	progressChan, errChan := requestor.Request(ctx, host2.ID(), blockChain.tipLink, spec)
+	progressChan, errChan := requestor.Request(ctx, host2.ID(), blockChain.tipLink, spec, extension)
 
 	responses := testutil.CollectResponses(ctx, t, progressChan)
 	errs := testutil.CollectErrors(ctx, t, errChan)
@@ -441,6 +484,15 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 		} else {
 			expectedPath = expectedPath + "/0"
 		}
+	}
+
+	// verify extension roundtrip
+	if !reflect.DeepEqual(receivedRequestData, extensionData) {
+		t.Fatal("did not receive correct extension request data")
+	}
+
+	if !reflect.DeepEqual(receivedResponseData, extensionResponseData) {
+		t.Fatal("did not receive correct extension response data")
 	}
 }
 


### PR DESCRIPTION
# Goals

Add ability to process incoming responses and halt requests as neccesary

# Implementation

- define interface for adding response hooks
- process response hooks when responses are received
- refactor integration tests to simplify them