### PR TITLE
Testify refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.12
 
 require (
 	github.com/gogo/protobuf v1.3.1
-	github.com/ipfs/go-bitswap v0.1.8
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.5

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/gogo/protobuf v1.3.1
+	github.com/ipfs/go-bitswap v0.1.8
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-blockservice v0.1.3
 	github.com/ipfs/go-cid v0.0.5
@@ -26,4 +27,5 @@ require (
 	github.com/libp2p/go-libp2p-core v0.5.0
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multihash v0.0.13
+	github.com/stretchr/testify v1.4.0
 )

--- a/graphsync.go
+++ b/graphsync.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
 )
 
 // RequestID is a unique identifier for a GraphSync request.

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	gsnet "github.com/ipfs/go-graphsync/network"
-	"github.com/ipfs/go-graphsync/storeutil"
 	"github.com/ipfs/go-graphsync/testutil"
 	ipld "github.com/ipld/go-ipld-prime"
 	ipldselector "github.com/ipld/go-ipld-prime/traversal/selector"
@@ -67,14 +66,14 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	graphSync.Request(requestCtx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
 	var message receivedMessage
-	testutil.AssertReceive(ctx, t, r.messageReceived, &message, "did not receive message")
+	testutil.AssertReceive(ctx, t, r.messageReceived, &message, "did not receive message sent")
 
 	sender := message.sender
-	require.Equal(t, sender, td.host1.ID(), "did not receive message from correct node")
+	require.Equal(t, td.host1.ID(), sender, "received message from wrong node")
 
 	received := message.message
 	receivedRequests := received.Requests()
-	require.Len(t, receivedRequests, 1, "did not add request to received message")
+	require.Len(t, receivedRequests, 1, "Did not add request to received message")
 	receivedRequest := receivedRequests[0]
 	receivedSpec := receivedRequest.Selector()
 	require.Equal(t, blockChain.Selector(), receivedSpec, "did not transmit selector spec correctly")
@@ -83,7 +82,7 @@ func TestMakeRequestToNetwork(t *testing.T) {
 
 	returnedData, found := receivedRequest.Extension(td.extensionName)
 	require.True(t, found)
-	require.Equal(t, td.extensionData, returnedData, "did not encode extension")
+	require.Equal(t, td.extensionData, returnedData, "Failed to encode extension")
 }
 
 func TestSendResponseToIncomingRequest(t *testing.T) {
@@ -108,7 +107,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 			hookActions.SendExtensionData(td.extensionResponse)
 		},
 	)
-	require.NoError(t, err, "did not register extension")
+	require.NoError(t, err, "error registering extension")
 
 	blockChainLength := 100
 	blockChain := testutil.SetupBlockChain(ctx, t, td.loader2, td.storer2, 100, blockChainLength)
@@ -129,7 +128,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		testutil.AssertReceive(ctx, t, r.messageReceived, &message, "did not receive complete response")
 
 		sender := message.sender
-		require.Equal(t, sender, td.host2.ID(), "did not receive message from correct node")
+		require.Equal(t, td.host2.ID(), sender, "received message from wrong node")
 
 		received = message.message
 		receivedBlocks = append(receivedBlocks, received.Blocks()...)
@@ -138,17 +137,17 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		if found {
 			receivedExtensions = append(receivedExtensions, receivedExtension)
 		}
-		require.Len(t, receivedResponses, 1, "did not receive sresponse")
-		require.Equal(t, receivedResponses[0].RequestID(), requestID, "did not receive response for correct request id")
+		require.Len(t, receivedResponses, 1, "Did not receive response")
+		require.Equal(t, requestID, receivedResponses[0].RequestID(), "Sent response for incorrect request id")
 		if receivedResponses[0].Status() != graphsync.PartialResponse {
 			break
 		}
 	}
 
-	require.Len(t, receivedBlocks, blockChainLength, "did not receive correct number of blocks")
+	require.Len(t, receivedBlocks, blockChainLength, "Send incorrect number of blocks or there were duplicate blocks")
 	require.Equal(t, td.extensionData, receivedRequestData, "did not receive correct request extension data")
-	require.Len(t, receivedExtensions, 1, "did not receive extension responses")
-	require.Equal(t, receivedExtensions[0], td.extensionResponseData, "did not receive correct response extension data")
+	require.Len(t, receivedExtensions, 1, "should have sent extension responses but didn't")
+	require.Equal(t, td.extensionResponseData, receivedExtensions[0], "did not return correct extension data")
 }
 
 func TestGraphsyncRoundTrip(t *testing.T) {
@@ -179,7 +178,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			}
 			return nil
 		})
-	require.NoError(t, err)
+	require.NoError(t, err, "Error setting up extension")
 
 	err = responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 		var has bool
@@ -190,7 +189,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			hookActions.SendExtensionData(td.extensionResponse)
 		}
 	})
-	require.NoError(t, err)
+	require.NoError(t, err, "Error setting up extension")
 
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
@@ -199,8 +198,8 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
 
 	// verify extension roundtrip
-	require.Equal(t, receivedRequestData, td.extensionData, "did not receive correct extension request data")
-	require.Equal(t, receivedResponseData, td.extensionResponseData, "did not receive correct extension response data")
+	require.Equal(t, td.extensionData, receivedRequestData, "did not receive correct extension request data")
+	require.Equal(t, td.extensionResponseData, receivedResponseData, "did not receive correct extension response data")
 }
 
 // TestRoundTripLargeBlocksSlowNetwork test verifies graphsync continues to work
@@ -259,6 +258,38 @@ func TestUnixFSFetch(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
+	makeLoader := func(bs bstore.Blockstore) ipld.Loader {
+		return func(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
+			c, ok := lnk.(cidlink.Link)
+			if !ok {
+				return nil, errors.New("Incorrect Link Type")
+			}
+			// read block from one store
+			block, err := bs.Get(c.Cid)
+			if err != nil {
+				return nil, err
+			}
+			return bytes.NewReader(block.RawData()), nil
+		}
+	}
+
+	makeStorer := func(bs bstore.Blockstore) ipld.Storer {
+		return func(lnkCtx ipld.LinkContext) (io.Writer, ipld.StoreCommitter, error) {
+			var buf bytes.Buffer
+			var committer ipld.StoreCommitter = func(lnk ipld.Link) error {
+				c, ok := lnk.(cidlink.Link)
+				if !ok {
+					return errors.New("Incorrect Link Type")
+				}
+				block, err := blocks.NewBlockWithCid(buf.Bytes(), c.Cid)
+				if err != nil {
+					return err
+				}
+				return bs.Put(block)
+			}
+			return &buf, committer, nil
+		}
+	}
 	// make a blockstore and dag service
 	bs1 := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 
@@ -268,10 +299,10 @@ func TestUnixFSFetch(t *testing.T) {
 
 	// read in a fixture file
 	path, err := filepath.Abs(filepath.Join("fixtures", "lorem.txt"))
-	require.NoError(t, err)
+	require.NoError(t, err, "unable to create path for fixture file")
 
 	f, err := os.Open(path)
-	require.NoError(t, err)
+	require.NoError(t, err, "unable to open fixture file")
 
 	var buf bytes.Buffer
 	tr := io.TeeReader(f, &buf)
@@ -288,24 +319,24 @@ func TestUnixFSFetch(t *testing.T) {
 	}
 
 	db, err := params.New(chunker.NewSizeSplitter(file, int64(unixfsChunkSize)))
-	require.NoError(t, err)
+	require.NoError(t, err, "unable to setup dag builder")
 
 	nd, err := balanced.Layout(db)
-	require.NoError(t, err)
+	require.NoError(t, err, "unable to create unix fs node")
 
 	err = bufferedDS.Commit()
-	require.NoError(t, err)
+	require.NoError(t, err, "unable to commit unix fs node")
 
 	// save the original files bytes
 	origBytes := buf.Bytes()
 
 	// setup an IPLD loader/storer for blockstore 1
-	loader1 := storeutil.LoaderForBlockstore(bs1)
-	storer1 := storeutil.StorerForBlockstore(bs1)
+	loader1 := makeLoader(bs1)
+	storer1 := makeStorer(bs1)
 
 	// setup an IPLD loader/storer for blockstore 2
-	loader2 := storeutil.LoaderForBlockstore(bs2)
-	storer2 := storeutil.StorerForBlockstore(bs2)
+	loader2 := makeLoader(bs2)
+	storer2 := makeStorer(bs2)
 
 	td := newGsTestData(ctx, t)
 	requestor := New(ctx, td.gsnet1, loader1, storer1)
@@ -344,21 +375,21 @@ func TestUnixFSFetch(t *testing.T) {
 
 	// load the root of the UnixFS DAG from the new blockstore
 	otherNode, err := dagService1.Get(ctx, nd.Cid())
-	require.NoError(t, err)
+	require.NoError(t, err, "should have been able to read received root node but didn't")
 
 	// Setup a UnixFS file reader
 	n, err := unixfile.NewUnixfsFile(ctx, dagService1, otherNode)
-	require.NoError(t, err)
+	require.NoError(t, err, "should have been able to setup UnixFS file but wasn't")
 
 	fn, ok := n.(files.File)
-	require.True(t, ok)
+	require.True(t, ok, "file should be a regular file, but wasn't")
 
 	// Read the bytes for the UnixFS File
 	finalBytes, err := ioutil.ReadAll(fn)
-	require.NoError(t, err, "not able to read all of Unix file")
+	require.NoError(t, err, "should have been able to read all of unix FS file but wasn't")
 
 	// verify original bytes match final bytes!
-	require.Equal(t, origBytes, finalBytes, "same bytes were not written to destination as read from source")
+	require.Equal(t, origBytes, finalBytes, "should have gotten same bytes written as read but didn't")
 }
 
 type gsTestData struct {
@@ -384,11 +415,11 @@ func newGsTestData(ctx context.Context, t *testing.T) *gsTestData {
 	var err error
 	// setup network
 	td.host1, err = td.mn.GenPeer()
-	require.NoError(t, err)
+	require.NoError(t, err, "error generating host")
 	td.host2, err = td.mn.GenPeer()
-	require.NoError(t, err)
+	require.NoError(t, err, "error generating host")
 	err = td.mn.LinkAll()
-	require.NoError(t, err)
+	require.NoError(t, err, "error linking hosts")
 
 	td.gsnet1 = gsnet.NewFromLibp2pHost(td.host1)
 	td.gsnet2 = gsnet.NewFromLibp2pHost(td.host2)

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -10,11 +10,11 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
-	"reflect"
 	"testing"
 	"time"
 
 	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
+	"github.com/stretchr/testify/require"
 
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 
@@ -66,36 +66,23 @@ func TestMakeRequestToNetwork(t *testing.T) {
 	graphSync.Request(requestCtx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
 	var message receivedMessage
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not receive message sent")
-	case message = <-r.messageReceived:
-	}
+	testutil.AssertReceive(ctx, t, r.messageReceived, &message, "did not receive message sent")
 
 	sender := message.sender
-	if sender != td.host1.ID() {
-		t.Fatal("received message from wrong node")
-	}
+	require.Equal(t, sender, td.host1.ID(), "received message from wrong node")
 
 	received := message.message
 	receivedRequests := received.Requests()
-	if len(receivedRequests) != 1 {
-		t.Fatal("Did not add request to received message")
-	}
+	require.Len(t, receivedRequests, 1, "Did not add request to received message")
 	receivedRequest := receivedRequests[0]
 	receivedSpec := receivedRequest.Selector()
-	if !reflect.DeepEqual(blockChain.Selector(), receivedSpec) {
-		t.Fatal("did not transmit selector spec correctly")
-	}
+	require.Equal(t, blockChain.Selector(), receivedSpec, "did not transmit selector spec correctly")
 	_, err := ipldutil.ParseSelector(receivedSpec)
-	if err != nil {
-		t.Fatal("did not receive parsible selector on other side")
-	}
+	require.NoError(t, err, "did not receive parsible selector on other side")
 
 	returnedData, found := receivedRequest.Extension(td.extensionName)
-	if !found || !reflect.DeepEqual(td.extensionData, returnedData) {
-		t.Fatal("Failed to encode extension")
-	}
+	require.True(t, found)
+	require.Equal(t, td.extensionData, returnedData, "Failed to encode extension")
 }
 
 func TestSendResponseToIncomingRequest(t *testing.T) {
@@ -116,15 +103,11 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 		func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 			var has bool
 			receivedRequestData, has = requestData.Extension(td.extensionName)
-			if !has {
-				t.Fatal("did not have expected extension")
-			}
+			require.True(t, has, "did not have expected extension")
 			hookActions.SendExtensionData(td.extensionResponse)
 		},
 	)
-	if err != nil {
-		t.Fatal("error registering extension")
-	}
+	require.NoError(t, err, "error registering extension")
 
 	blockChainLength := 100
 	blockChain := testutil.SetupBlockChain(ctx, t, td.loader2, td.storer2, 100, blockChainLength)
@@ -135,58 +118,36 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.TipLink.(cidlink.Link).Cid, blockChain.Selector(), graphsync.Priority(math.MaxInt32), td.extension))
 	// send request across network
 	err = td.gsnet1.SendMessage(ctx, td.host2.ID(), message)
-	if err != nil {
-		t.Fatal("Unable to send message")
-	}
+	require.NoError(t, err)
 	// read the values sent back to requestor
 	var received gsmsg.GraphSyncMessage
 	var receivedBlocks []blocks.Block
 	var receivedExtensions [][]byte
-readAllMessages:
 	for {
-		select {
-		case <-ctx.Done():
-			t.Fatal("did not receive complete response")
-		case message := <-r.messageReceived:
-			sender := message.sender
-			if sender != td.host2.ID() {
-				t.Fatal("received message from wrong node")
-			}
+		var message receivedMessage
+		testutil.AssertReceive(ctx, t, r.messageReceived, &message, "did not receive complete response")
 
-			received = message.message
-			receivedBlocks = append(receivedBlocks, received.Blocks()...)
-			receivedResponses := received.Responses()
-			receivedExtension, found := receivedResponses[0].Extension(td.extensionName)
-			if found {
-				receivedExtensions = append(receivedExtensions, receivedExtension)
-			}
-			if len(receivedResponses) != 1 {
-				t.Fatal("Did not receive response")
-			}
-			if receivedResponses[0].RequestID() != requestID {
-				t.Fatal("Sent response for incorrect request id")
-			}
-			if receivedResponses[0].Status() != graphsync.PartialResponse {
-				break readAllMessages
-			}
+		sender := message.sender
+		require.Equal(t, sender, td.host2.ID(), "received message from wrong node")
+
+		received = message.message
+		receivedBlocks = append(receivedBlocks, received.Blocks()...)
+		receivedResponses := received.Responses()
+		receivedExtension, found := receivedResponses[0].Extension(td.extensionName)
+		if found {
+			receivedExtensions = append(receivedExtensions, receivedExtension)
+		}
+		require.Len(t, receivedResponses, 1, "Did not receive response")
+		require.Equal(t, receivedResponses[0].RequestID(), requestID, "Sent response for incorrect request id")
+		if receivedResponses[0].Status() != graphsync.PartialResponse {
+			break
 		}
 	}
 
-	if len(receivedBlocks) != blockChainLength {
-		t.Fatal("Send incorrect number of blocks or there were duplicate blocks")
-	}
-
-	if !reflect.DeepEqual(td.extensionData, receivedRequestData) {
-		t.Fatal("did not receive correct request extension data")
-	}
-
-	if len(receivedExtensions) != 1 {
-		t.Fatal("should have sent extension responses but didn't")
-	}
-
-	if !reflect.DeepEqual(receivedExtensions[0], td.extensionResponseData) {
-		t.Fatal("did not return correct extension data")
-	}
+	require.Len(t, receivedBlocks, blockChainLength, "Send incorrect number of blocks or there were duplicate blocks")
+	require.Equal(t, td.extensionData, receivedRequestData, "did not receive correct request extension data")
+	require.Len(t, receivedExtensions, 1, "should have sent extension responses but didn't")
+	require.Equal(t, receivedExtensions[0], td.extensionResponseData, "did not return correct extension data")
 }
 
 func TestGraphsyncRoundTrip(t *testing.T) {
@@ -217,9 +178,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			}
 			return nil
 		})
-	if err != nil {
-		t.Fatal("Error setting up extension")
-	}
+	require.NoError(t, err, "Error setting up extension")
 
 	err = responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 		var has bool
@@ -230,50 +189,17 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			hookActions.SendExtensionData(td.extensionResponse)
 		}
 	})
-
-	if err != nil {
-		t.Fatal("Error setting up extension")
-	}
+	require.NoError(t, err, "Error setting up extension")
 
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
-	responses := testutil.CollectResponses(ctx, t, progressChan)
-	errs := testutil.CollectErrors(ctx, t, errChan)
-
-	if len(responses) != blockChainLength*2 {
-		t.Fatal("did not traverse all nodes")
-	}
-	if len(errs) != 0 {
-		t.Fatal("errors during traverse")
-	}
-	if len(td.blockStore1) != blockChainLength {
-		t.Fatal("did not store all blocks")
-	}
-
-	expectedPath := ""
-	for i, response := range responses {
-		if response.Path.String() != expectedPath {
-			t.Fatal("incorrect path")
-		}
-		if i%2 == 0 {
-			if expectedPath == "" {
-				expectedPath = "Parents"
-			} else {
-				expectedPath = expectedPath + "/Parents"
-			}
-		} else {
-			expectedPath = expectedPath + "/0"
-		}
-	}
+	blockChain.VerifyWholeChain(ctx, progressChan)
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
+	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
 
 	// verify extension roundtrip
-	if !reflect.DeepEqual(receivedRequestData, td.extensionData) {
-		t.Fatal("did not receive correct extension request data")
-	}
-
-	if !reflect.DeepEqual(receivedResponseData, td.extensionResponseData) {
-		t.Fatal("did not receive correct extension response data")
-	}
+	require.Equal(t, receivedRequestData, td.extensionData, "did not receive correct extension request data")
+	require.Equal(t, receivedResponseData, td.extensionResponseData, "did not receive correct extension response data")
 }
 
 // TestRoundTripLargeBlocksSlowNetwork test verifies graphsync continues to work
@@ -307,15 +233,8 @@ func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
 
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector())
 
-	responses := testutil.CollectResponses(ctx, t, progressChan)
-	errs := testutil.CollectErrors(ctx, t, errChan)
-
-	if len(responses) != blockChainLength*2 {
-		t.Fatal("did not traverse all nodes")
-	}
-	if len(errs) != 0 {
-		t.Fatal("errors during traverse")
-	}
+	blockChain.VerifyWholeChain(ctx, progressChan)
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
 }
 
 // What this test does:
@@ -380,14 +299,11 @@ func TestUnixFSFetch(t *testing.T) {
 
 	// read in a fixture file
 	path, err := filepath.Abs(filepath.Join("fixtures", "lorem.txt"))
-	if err != nil {
-		t.Fatal("unable to create path for fixture file")
-	}
+	require.NoError(t, err, "unable to create path for fixture file")
 
 	f, err := os.Open(path)
-	if err != nil {
-		t.Fatal("unable to open fixture file")
-	}
+	require.NoError(t, err, "unable to open fixture file")
+
 	var buf bytes.Buffer
 	tr := io.TeeReader(f, &buf)
 	file := files.NewReaderFile(tr)
@@ -403,17 +319,13 @@ func TestUnixFSFetch(t *testing.T) {
 	}
 
 	db, err := params.New(chunker.NewSizeSplitter(file, int64(unixfsChunkSize)))
-	if err != nil {
-		t.Fatal("unable to setup dag builder")
-	}
+	require.NoError(t, err, "unable to setup dag builder")
+
 	nd, err := balanced.Layout(db)
-	if err != nil {
-		t.Fatal("unable to create unix fs node")
-	}
+	require.NoError(t, err, "unable to create unix fs node")
+
 	err = bufferedDS.Commit()
-	if err != nil {
-		t.Fatal("unable to commit unix fs node")
-	}
+	require.NoError(t, err, "unable to commit unix fs node")
 
 	// save the original files bytes
 	origBytes := buf.Bytes()
@@ -437,9 +349,7 @@ func TestUnixFSFetch(t *testing.T) {
 			Data: nil,
 		})
 	})
-	if err != nil {
-		t.Fatal("unable to register extension")
-	}
+	require.NoError(t, err)
 	
 	// make a go-ipld-prime link for the root UnixFS node
 	clink := cidlink.Link{Cid: nd.Cid()}
@@ -458,44 +368,28 @@ func TestUnixFSFetch(t *testing.T) {
 		})
 
 	_ = testutil.CollectResponses(ctx, t, progressChan)
-	responseErrors := testutil.CollectErrors(ctx, t, errChan)
-
-	// verify traversal was successful
-	if len(responseErrors) != 0 {
-		t.Fatal("Response should be successful but wasn't")
-	}
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
 
 	// setup a DagService for the second block store
 	dagService1 := merkledag.NewDAGService(blockservice.New(bs1, offline.Exchange(bs1)))
 
 	// load the root of the UnixFS DAG from the new blockstore
 	otherNode, err := dagService1.Get(ctx, nd.Cid())
-	if err != nil {
-		t.Fatal("should have been able to read received root node but didn't")
-	}
+	require.NoError(t, err, "should have been able to read received root node but didn't")
 
 	// Setup a UnixFS file reader
 	n, err := unixfile.NewUnixfsFile(ctx, dagService1, otherNode)
-	if err != nil {
-		t.Fatal("should have been able to setup UnixFS file but wasn't")
-	}
+	require.NoError(t, err, "should have been able to setup UnixFS file but wasn't")
 
 	fn, ok := n.(files.File)
-	if !ok {
-		t.Fatal("file should be a regular file, but wasn't")
-	}
+	require.True(t, ok, "file should be a regular file, but wasn't")
 
 	// Read the bytes for the UnixFS File
 	finalBytes, err := ioutil.ReadAll(fn)
-	if err != nil {
-		t.Fatal("should have been able to read all of unix FS file but wasn't")
-	}
+	require.NoError(t, err, "should have been able to read all of unix FS file but wasn't")
 
 	// verify original bytes match final bytes!
-	if !reflect.DeepEqual(origBytes, finalBytes) {
-		t.Fatal("should have gotten same bytes written as read but didn't")
-	}
-
+	require.Equal(t, origBytes, finalBytes, "should have gotten same bytes written as read but didn't")
 }
 
 type gsTestData struct {
@@ -521,17 +415,11 @@ func newGsTestData(ctx context.Context, t *testing.T) *gsTestData {
 	var err error
 	// setup network
 	td.host1, err = td.mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
+	require.NoError(t, err, "error generating host")
 	td.host2, err = td.mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
+	require.NoError(t, err, "error generating host")
 	err = td.mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
+	require.NoError(t, err, "error linking hosts")
 
 	td.gsnet1 = gsnet.NewFromLibp2pHost(td.host1)
 	td.gsnet2 = gsnet.NewFromLibp2pHost(td.host2)

--- a/linktracker/linktracker_test.go
+++ b/linktracker/linktracker_test.go
@@ -81,7 +81,7 @@ func TestBlockRefCount(t *testing.T) {
 					linkTracker.FinishRequest(requestID)
 				}
 			}
-			require.Equal(t, linkTracker.BlockRefCount(link), data.expectedRefCount)
+			require.Equal(t, data.expectedRefCount, linkTracker.BlockRefCount(link))
 		})
 	}
 }
@@ -119,7 +119,7 @@ func TestFinishRequest(t *testing.T) {
 			for _, lt := range data.linksTraversed {
 				linkTracker.RecordLinkTraversal(requestID, lt.link, lt.blockPresent)
 			}
-			require.Equal(t, linkTracker.FinishRequest(requestID), data.allBlocksPresent)
+			require.Equal(t, data.allBlocksPresent, linkTracker.FinishRequest(requestID))
 		})
 	}
 }
@@ -154,7 +154,7 @@ func TestIsKnownMissingLink(t *testing.T) {
 			for _, present := range data.traversals {
 				linkTracker.RecordLinkTraversal(requestID, link, present)
 			}
-			require.Equal(t, linkTracker.IsKnownMissingLink(requestID, link), data.isKnownMissingLink)
+			require.Equal(t, data.isKnownMissingLink, linkTracker.IsKnownMissingLink(requestID, link))
 		})
 	}
 }

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -34,11 +34,11 @@ func TestAppendingRequests(t *testing.T) {
 	require.Len(t, requests, 1, "did not add request to message")
 	request := requests[0]
 	extensionData, found := request.Extension(extensionName)
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.False(t, request.IsCancel())
-	require.Equal(t, request.Priority(), priority)
-	require.Equal(t, request.Root().String(), root.String())
-	require.Equal(t, request.Selector(), selector)
+	require.Equal(t, priority, request.Priority())
+	require.Equal(t, root.String(), request.Root().String())
+	require.Equal(t, selector, request.Selector())
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 
@@ -48,12 +48,12 @@ func TestAppendingRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	pbRequest := pbMessage.Requests[0]
-	require.Equal(t, pbRequest.Id, int32(id))
-	require.Equal(t, pbRequest.Priority, int32(priority))
+	require.Equal(t, int32(id), pbRequest.Id)
+	require.Equal(t, int32(priority), pbRequest.Priority)
 	require.False(t, pbRequest.Cancel)
-	require.Equal(t, pbRequest.Root, root.Bytes())
-	require.Equal(t, pbRequest.Selector, selectorEncoded)
-	require.Equal(t, pbRequest.Extensions, map[string][]byte{"graphsync/awesome": extension.Data})
+	require.Equal(t, root.Bytes(), pbRequest.Root)
+	require.Equal(t, selectorEncoded, pbRequest.Selector)
+	require.Equal(t, map[string][]byte{"graphsync/awesome": extension.Data}, pbRequest.Extensions)
 
 	deserialized, err := newMessageFromProto(*pbMessage)
 	require.NoError(t, err, "deserializing protobuf message errored")
@@ -62,11 +62,11 @@ func TestAppendingRequests(t *testing.T) {
 
 	deserializedRequest := deserializedRequests[0]
 	extensionData, found = deserializedRequest.Extension(extensionName)
-	require.Equal(t, deserializedRequest.ID(), id)
+	require.Equal(t, id, deserializedRequest.ID())
 	require.False(t, deserializedRequest.IsCancel())
-	require.Equal(t, deserializedRequest.Priority(), priority)
-	require.Equal(t, deserializedRequest.Root().String(), root.String())
-	require.Equal(t, deserializedRequest.Selector(), selector)
+	require.Equal(t, priority, deserializedRequest.Priority())
+	require.Equal(t, root.String(), deserializedRequest.Root().String())
+	require.Equal(t, selector, deserializedRequest.Selector())
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 }
@@ -86,17 +86,17 @@ func TestAppendingResponses(t *testing.T) {
 	require.Len(t, responses, 1, "did not add response to message")
 	response := responses[0]
 	extensionData, found := response.Extension(extensionName)
-	require.Equal(t, response.RequestID(), requestID)
-	require.Equal(t, response.Status(), status)
+	require.Equal(t, requestID, response.RequestID())
+	require.Equal(t, status, response.Status())
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 
 	pbMessage, err := gsm.ToProto()
 	require.NoError(t, err, "serialize to protobuf errored")
 	pbResponse := pbMessage.Responses[0]
-	require.Equal(t, pbResponse.Id, int32(requestID))
-	require.Equal(t, pbResponse.Status, int32(status))
-	require.Equal(t, pbResponse.Extensions, map[string][]byte{"graphsync/awesome": extension.Data})
+	require.Equal(t, int32(requestID), pbResponse.Id)
+	require.Equal(t, int32(status), pbResponse.Status)
+	require.Equal(t, map[string][]byte{"graphsync/awesome": extension.Data}, pbResponse.Extensions)
 
 	deserialized, err := newMessageFromProto(*pbMessage)
 	require.NoError(t, err, "deserializing protobuf message errored")
@@ -104,10 +104,10 @@ func TestAppendingResponses(t *testing.T) {
 	require.Len(t, deserializedResponses, 1, "did not add response to deserialized message")
 	deserializedResponse := deserializedResponses[0]
 	extensionData, found = deserializedResponse.Extension(extensionName)
-	require.Equal(t, deserializedResponse.RequestID(), response.RequestID())
-	require.Equal(t, deserializedResponse.Status(), response.Status())
+	require.Equal(t, response.RequestID(), deserializedResponse.RequestID())
+	require.Equal(t, response.Status(), deserializedResponse.Status())
 	require.True(t, found)
-	require.Equal(t, extensionData, extension.Data)
+	require.Equal(t, extension.Data, extensionData)
 }
 
 func TestAppendBlock(t *testing.T) {
@@ -156,7 +156,7 @@ func TestRequestCancel(t *testing.T) {
 	requests := gsm.Requests()
 	require.Len(t, requests, 1, "did not add cancel request")
 	request := requests[0]
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.True(t, request.IsCancel())
 }
 
@@ -195,11 +195,11 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 	require.Len(t, deserializedRequests, 1, "did not add request to deserialized message")
 	deserializedRequest := deserializedRequests[0]
 	extensionData, found := deserializedRequest.Extension(extensionName)
-	require.Equal(t, deserializedRequest.ID(), request.ID())
+	require.Equal(t, request.ID(), deserializedRequest.ID())
 	require.False(t, deserializedRequest.IsCancel())
-	require.Equal(t, deserializedRequest.Priority(), request.Priority())
-	require.Equal(t, deserializedRequest.Root().String(), request.Root().String())
-	require.Equal(t, deserializedRequest.Selector(), request.Selector())
+	require.Equal(t, request.Priority(), deserializedRequest.Priority())
+	require.Equal(t, request.Root().String(), deserializedRequest.Root().String())
+	require.Equal(t, request.Selector(), deserializedRequest.Selector())
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 
@@ -210,10 +210,10 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 	require.Len(t, deserializedResponses, 1, "did not add response to message")
 	deserializedResponse := deserializedResponses[0]
 	extensionData, found = deserializedResponse.Extension(extensionName)
-	require.Equal(t, deserializedResponse.RequestID(), response.RequestID())
-	require.Equal(t, deserializedResponse.Status(), response.Status())
+	require.Equal(t, response.RequestID(), deserializedResponse.RequestID())
+	require.Equal(t, response.Status(), deserializedResponse.Status())
 	require.True(t, found)
-	require.Equal(t, extensionData, extension.Data)
+	require.Equal(t, extension.Data, extensionData)
 
 	keys := make(map[cid.Cid]bool)
 	for _, b := range deserialized.Blocks() {

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -31,7 +31,7 @@ func TestAppendingRequests(t *testing.T) {
 	gsm := New()
 	gsm.AddRequest(NewRequest(id, root, selector, priority, extension))
 	requests := gsm.Requests()
-	require.Len(t, requests, 1, "request added to message")
+	require.Len(t, requests, 1, "did not add request to message")
 	request := requests[0]
 	extensionData, found := request.Extension(extensionName)
 	require.Equal(t, request.ID(), id)
@@ -43,7 +43,7 @@ func TestAppendingRequests(t *testing.T) {
 	require.Equal(t, extension.Data, extensionData)
 
 	pbMessage, err := gsm.ToProto()
-	require.NoError(t, err, "serialize to protobuf does not error")
+	require.NoError(t, err, "serialize to protobuf errored")
 	selectorEncoded, err := ipldutil.EncodeNode(selector)
 	require.NoError(t, err)
 
@@ -56,9 +56,9 @@ func TestAppendingRequests(t *testing.T) {
 	require.Equal(t, pbRequest.Extensions, map[string][]byte{"graphsync/awesome": extension.Data})
 
 	deserialized, err := newMessageFromProto(*pbMessage)
-	require.NoError(t, err, "deserializing protobuf message does not error")
+	require.NoError(t, err, "deserializing protobuf message errored")
 	deserializedRequests := deserialized.Requests()
-	require.Len(t, deserializedRequests, 1, "request added to deserialized message")
+	require.Len(t, deserializedRequests, 1, "did not add request to deserialized message")
 
 	deserializedRequest := deserializedRequests[0]
 	extensionData, found = deserializedRequest.Extension(extensionName)
@@ -83,7 +83,7 @@ func TestAppendingResponses(t *testing.T) {
 	gsm := New()
 	gsm.AddResponse(NewResponse(requestID, status, extension))
 	responses := gsm.Responses()
-	require.Len(t, responses, 1, "response added to message")
+	require.Len(t, responses, 1, "did not add response to message")
 	response := responses[0]
 	extensionData, found := response.Extension(extensionName)
 	require.Equal(t, response.RequestID(), requestID)
@@ -92,16 +92,16 @@ func TestAppendingResponses(t *testing.T) {
 	require.Equal(t, extension.Data, extensionData)
 
 	pbMessage, err := gsm.ToProto()
-	require.NoError(t, err, "serialize to protobuf does not error")
+	require.NoError(t, err, "serialize to protobuf errored")
 	pbResponse := pbMessage.Responses[0]
 	require.Equal(t, pbResponse.Id, int32(requestID))
 	require.Equal(t, pbResponse.Status, int32(status))
 	require.Equal(t, pbResponse.Extensions, map[string][]byte{"graphsync/awesome": extension.Data})
 
 	deserialized, err := newMessageFromProto(*pbMessage)
-	require.NoError(t, err, "deserializing protobuf message does not error")
+	require.NoError(t, err, "deserializing protobuf message errored")
 	deserializedResponses := deserialized.Responses()
-	require.Len(t, deserializedResponses, 1, "response added to deserialized message")
+	require.Len(t, deserializedResponses, 1, "did not add response to deserialized message")
 	deserializedResponse := deserializedResponses[0]
 	extensionData, found = deserializedResponse.Extension(extensionName)
 	require.Equal(t, deserializedResponse.RequestID(), response.RequestID())
@@ -123,7 +123,7 @@ func TestAppendBlock(t *testing.T) {
 	}
 
 	pbMessage, err := m.ToProto()
-	require.NoError(t, err, "Did not serialize to protobuf correctly")
+	require.NoError(t, err, "serializing to protobuf errored")
 
 	// assert strings are in proto message
 	for _, block := range pbMessage.GetData() {
@@ -154,7 +154,7 @@ func TestRequestCancel(t *testing.T) {
 	gsm.AddRequest(CancelRequest(id))
 
 	requests := gsm.Requests()
-	require.Len(t, requests, 1, "added cancel request")
+	require.Len(t, requests, 1, "did not add cancel request")
 	request := requests[0]
 	require.Equal(t, request.ID(), id)
 	require.True(t, request.IsCancel())
@@ -184,15 +184,15 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 
 	buf := new(bytes.Buffer)
 	err := gsm.ToNet(buf)
-	require.NoError(t, err, "Unable to serialize GraphSyncMessage")
+	require.NoError(t, err, "did not serialize protobuf message")
 	deserialized, err := FromNet(buf)
-	require.NoError(t, err, "Error deserializing protobuf message")
+	require.NoError(t, err, "did not deserialize protobuf message")
 
 	requests := gsm.Requests()
-	require.Len(t, requests, 1, "Did not add request to message")
+	require.Len(t, requests, 1, "did not add request to message")
 	request := requests[0]
 	deserializedRequests := deserialized.Requests()
-	require.Len(t, deserializedRequests, 1, "Did not add request to deserialized message")
+	require.Len(t, deserializedRequests, 1, "did not add request to deserialized message")
 	deserializedRequest := deserializedRequests[0]
 	extensionData, found := deserializedRequest.Extension(extensionName)
 	require.Equal(t, deserializedRequest.ID(), request.ID())
@@ -204,10 +204,10 @@ func TestToNetFromNetEquivalency(t *testing.T) {
 	require.Equal(t, extension.Data, extensionData)
 
 	responses := gsm.Responses()
-	require.Len(t, responses, 1, "Did not add response to message")
+	require.Len(t, responses, 1, "did not add response to message")
 	response := responses[0]
 	deserializedResponses := deserialized.Responses()
-	require.Len(t, deserializedResponses, 1, "Did not add response to message")
+	require.Len(t, deserializedResponses, 1, "did not add response to message")
 	deserializedResponse := deserializedResponses[0]
 	extensionData, found = deserializedResponse.Extension(extensionName)
 	require.Equal(t, deserializedResponse.RequestID(), response.RequestID())

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -12,6 +11,7 @@ import (
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
+	"github.com/stretchr/testify/require"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	gsnet "github.com/ipfs/go-graphsync/network"
@@ -76,21 +76,11 @@ func TestStartupAndShutdown(t *testing.T) {
 	waitGroup.Add(1)
 	messageQueue.AddRequest(gsmsg.NewRequest(id, root, selector, priority))
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("message was not sent")
-	case <-messagesSent:
-	}
+	testutil.AssertDoesReceive(ctx, t, messagesSent, "message was not sent")
 
 	messageQueue.Shutdown()
 
-	select {
-	case <-resetChan:
-		t.Fatal("message sender should have been closed but was reset")
-	case <-fullClosedChan:
-	case <-ctx.Done():
-		t.Fatal("message sender should have been closed but wasn't")
-	}
+	testutil.AssertDoesReceiveFirst(t, fullClosedChan, "message sender should be closed", resetChan, ctx.Done())
 }
 
 func TestShutdownDuringMessageSend(t *testing.T) {
@@ -128,20 +118,10 @@ func TestShutdownDuringMessageSend(t *testing.T) {
 
 	// let the message send attempt complete and fail (as it would if
 	// the connection were closed)
-	select {
-	case <-ctx.Done():
-		t.Fatal("message send not attempted")
-	case <-messagesSent:
-	}
+	testutil.AssertDoesReceive(ctx, t, messagesSent, "message send not attempted")
 
 	// verify the connection is reset after a failed send attempt
-	select {
-	case <-resetChan:
-	case <-fullClosedChan:
-		t.Fatal("message sender should have been reset but was closed")
-	case <-ctx.Done():
-		t.Fatal("message sender should have been closed but wasn't")
-	}
+	testutil.AssertDoesReceiveFirst(t, resetChan, "message sender should be reset", fullClosedChan, ctx.Done())
 
 	// now verify after it's reset, no further retries, connection
 	// resets, or attempts to close the connection, cause the queue
@@ -149,15 +129,7 @@ func TestShutdownDuringMessageSend(t *testing.T) {
 	// FIXME: this relies on time passing -- 100 ms to be exact
 	// and we should instead mock out time as a dependency
 	waitGroup.Add(1)
-	select {
-	case <-messagesSent:
-		t.Fatal("should not have attempted to send second message")
-	case <-resetChan:
-		t.Fatal("message sender should not have been reset again")
-	case <-fullClosedChan:
-		t.Fatal("message sender should not have been closed closed")
-	case <-ctx.Done():
-	}
+	testutil.AssertDoesReceiveFirst(t, ctx.Done(), "no further message operations occur", messagesSent, resetChan, fullClosedChan)
 }
 
 func TestProcessingNotification(t *testing.T) {
@@ -187,40 +159,25 @@ func TestProcessingNotification(t *testing.T) {
 	status := graphsync.RequestCompletedFull
 	newMessage.AddResponse(gsmsg.NewResponse(responseID, status, extension))
 	processing := messageQueue.AddResponses(newMessage.Responses(), blks)
-	select {
-	case <-processing:
-		t.Fatal("Message should not be processing but already received notification")
-	default:
-	}
+	testutil.AssertChannelEmpty(t, processing, "no processing notification while queue is shutdown")
 
 	// wait for send attempt
 	messageQueue.Startup()
 	waitGroup.Wait()
-	select {
-	case <-processing:
-	case <-ctx.Done():
-		t.Fatal("Message should have been processed but were not")
-	}
+	testutil.AssertDoesReceive(ctx, t, processing, "Message should be processed")
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("no messages were sent")
-	case message := <-messagesSent:
-		receivedBlocks := message.Blocks()
-		for _, block := range receivedBlocks {
-			if !testutil.ContainsBlock(blks, block) {
-				t.Fatal("sent incorrect block")
-			}
-		}
-		firstResponse := message.Responses()[0]
-		extensionData, found := firstResponse.Extension(extensionName)
-		if responseID != firstResponse.RequestID() ||
-			status != firstResponse.Status() ||
-			!found ||
-			!reflect.DeepEqual(extension.Data, extensionData) {
-			t.Fatal("Send incorrect response")
-		}
+	var message gsmsg.GraphSyncMessage
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message is sent")
+	receivedBlocks := message.Blocks()
+	for _, block := range receivedBlocks {
+		testutil.AssertContainsBlock(t, blks, block)
 	}
+	firstResponse := message.Responses()[0]
+	extensionData, found := firstResponse.Extension(extensionName)
+	require.Equal(t, responseID, firstResponse.RequestID())
+	require.Equal(t, status, firstResponse.Status())
+	require.True(t, found)
+	require.Equal(t, extension.Data, extensionData)
 }
 
 func TestDedupingMessages(t *testing.T) {
@@ -260,46 +217,32 @@ func TestDedupingMessages(t *testing.T) {
 	messageQueue.AddRequest(gsmsg.NewRequest(id2, root2, selector2, priority2))
 	messageQueue.AddRequest(gsmsg.NewRequest(id3, root3, selector3, priority3))
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("no messages were sent")
-	case message := <-messagesSent:
-		requests := message.Requests()
-		if len(requests) != 1 {
-			t.Fatal("Incorrect number of requests in first message")
-		}
-		request := requests[0]
-		if request.ID() != id ||
-			request.IsCancel() != false ||
-			request.Priority() != priority ||
-			!reflect.DeepEqual(request.Selector(), selector) {
-			t.Fatal("Did not properly add request to message")
-		}
-	}
-	select {
-	case <-ctx.Done():
-		t.Fatal("no messages were sent")
-	case message := <-messagesSent:
-		requests := message.Requests()
-		if len(requests) != 2 {
-			t.Fatal("Incorrect number of requests in second message")
-		}
-		for _, request := range requests {
-			if request.ID() == id2 {
-				if request.IsCancel() != false ||
-					request.Priority() != priority2 ||
-					!reflect.DeepEqual(request.Selector(), selector2) {
-					t.Fatal("Did not properly add request to message")
-				}
-			} else if request.ID() == id3 {
-				if request.IsCancel() != false ||
-					request.Priority() != priority3 ||
-					!reflect.DeepEqual(request.Selector(), selector3) {
-					t.Fatal("Did not properly add request to message")
-				}
-			} else {
-				t.Fatal("incorrect request added to message")
-			}
+	var message gsmsg.GraphSyncMessage
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message is sent")
+
+	requests := message.Requests()
+	require.Len(t, requests, 1, "number of requests in first message is 1")
+	request := requests[0]
+	require.Equal(t, request.ID(), id)
+	require.False(t, request.IsCancel())
+	require.Equal(t, request.Priority(), priority)
+	require.Equal(t, request.Selector(), selector)
+
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message is sent")
+
+	requests = message.Requests()
+	require.Len(t, requests, 2, "number of requests in second message is 2")
+	for _, request := range requests {
+		if request.ID() == id2 {
+			require.False(t, request.IsCancel())
+			require.Equal(t, request.Priority(), priority2)
+			require.Equal(t, request.Selector(), selector2)
+		} else if request.ID() == id3 {
+			require.False(t, request.IsCancel())
+			require.Equal(t, request.Priority(), priority3)
+			require.Equal(t, request.Selector(), selector3)
+		} else {
+			t.Fatal("incorrect request added to message")
 		}
 	}
 }

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -223,10 +223,10 @@ func TestDedupingMessages(t *testing.T) {
 	requests := message.Requests()
 	require.Len(t, requests, 1, "number of requests in first message was not 1")
 	request := requests[0]
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.False(t, request.IsCancel())
-	require.Equal(t, request.Priority(), priority)
-	require.Equal(t, request.Selector(), selector)
+	require.Equal(t, priority, request.Priority())
+	require.Equal(t, selector, request.Selector())
 
 	testutil.AssertReceive(ctx, t, messagesSent, &message, "message did not senf")
 
@@ -235,12 +235,12 @@ func TestDedupingMessages(t *testing.T) {
 	for _, request := range requests {
 		if request.ID() == id2 {
 			require.False(t, request.IsCancel())
-			require.Equal(t, request.Priority(), priority2)
-			require.Equal(t, request.Selector(), selector2)
+			require.Equal(t, priority2, request.Priority())
+			require.Equal(t, selector2, request.Selector())
 		} else if request.ID() == id3 {
 			require.False(t, request.IsCancel())
-			require.Equal(t, request.Priority(), priority3)
-			require.Equal(t, request.Selector(), selector3)
+			require.Equal(t, priority3, request.Priority())
+			require.Equal(t, selector3, request.Selector())
 		} else {
 			t.Fatal("incorrect request added to message")
 		}

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -2,10 +2,10 @@ package metadata
 
 import (
 	"math/rand"
-	"reflect"
 	"testing"
 
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync/testutil"
 )
@@ -19,14 +19,8 @@ func TestDecodeEncodeMetadata(t *testing.T) {
 		initialMetadata = append(initialMetadata, Item{link, blockPresent})
 	}
 	encoded, err := EncodeMetadata(initialMetadata)
-	if err != nil {
-		t.Fatal("Error encoding")
-	}
+	require.NoError(t, err, "Error encoding")
 	decodedMetadata, err := DecodeMetadata(encoded)
-	if err != nil {
-		t.Fatal("Error decoding")
-	}
-	if !reflect.DeepEqual(initialMetadata, decodedMetadata) {
-		t.Fatal("Metadata changed during encoding and decoding")
-	}
+	require.NoError(t, err, "Error decoding")
+	require.Equal(t, initialMetadata, decodedMetadata, "Metadata changed during encoding and decoding")
 }

--- a/metadata/metadata_test.go
+++ b/metadata/metadata_test.go
@@ -19,8 +19,8 @@ func TestDecodeEncodeMetadata(t *testing.T) {
 		initialMetadata = append(initialMetadata, Item{link, blockPresent})
 	}
 	encoded, err := EncodeMetadata(initialMetadata)
-	require.NoError(t, err, "Error encoding")
+	require.NoError(t, err, "encode errored")
 	decodedMetadata, err := DecodeMetadata(encoded)
-	require.NoError(t, err, "Error decoding")
-	require.Equal(t, initialMetadata, decodedMetadata, "Metadata changed during encoding and decoding")
+	require.NoError(t, err, "decode errored")
+	require.Equal(t, initialMetadata, decodedMetadata, "metadata changed during encoding and decoding")
 }

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -54,11 +54,11 @@ func TestMessageSendAndReceive(t *testing.T) {
 	mn := mocknet.New(ctx)
 
 	host1, err := mn.GenPeer()
-	require.NoError(t, err, "error generating host")
+	require.NoError(t, err)
 	host2, err := mn.GenPeer()
-	require.NoError(t, err, "error generating host")
+	require.NoError(t, err)
 	err = mn.LinkAll()
-	require.NoError(t, err, "error linking hosts")
+	require.NoError(t, err)
 	gsnet1 := NewFromLibp2pHost(host1)
 	gsnet2 := NewFromLibp2pHost(host2)
 	r := &receiver{
@@ -85,22 +85,22 @@ func TestMessageSendAndReceive(t *testing.T) {
 	sent.AddResponse(gsmsg.NewResponse(id, status, extension))
 
 	err = gsnet1.ConnectTo(ctx, host2.ID())
-	require.NoError(t, err, "Unable to connect peers")
+	require.NoError(t, err, "did not connect peers")
 
 	err = gsnet1.SendMessage(ctx, host2.ID(), sent)
 	require.NoError(t, err)
 
-	testutil.AssertDoesReceive(ctx, t, r.messageReceived, "message is sent")
+	testutil.AssertDoesReceive(ctx, t, r.messageReceived, "message did not send")
 
-	require.Equal(t, r.lastSender, host1.ID(), "corrent host sent message")
+	require.Equal(t, r.lastSender, host1.ID(), "incorrect host sent message")
 
 	received := r.lastMessage
 
 	sentRequests := sent.Requests()
-	require.Len(t, sentRequests, 1, "Did not add request to sent message")
+	require.Len(t, sentRequests, 1, "did not add request to sent message")
 	sentRequest := sentRequests[0]
 	receivedRequests := received.Requests()
-	require.Len(t, receivedRequests, 1, "Did not add request to received message")
+	require.Len(t, receivedRequests, 1, "did not add request to received message")
 	receivedRequest := receivedRequests[0]
 	require.Equal(t, receivedRequest.ID(), sentRequest.ID())
 	require.Equal(t, receivedRequest.IsCancel(), sentRequest.IsCancel())
@@ -109,10 +109,10 @@ func TestMessageSendAndReceive(t *testing.T) {
 	require.Equal(t, receivedRequest.Selector(), sentRequest.Selector())
 
 	sentResponses := sent.Responses()
-	require.Len(t, sentResponses, 1, "Did not add response to sent message")
+	require.Len(t, sentResponses, 1, "did not add response to sent message")
 	sentResponse := sentResponses[0]
 	receivedResponses := received.Responses()
-	require.Len(t, receivedResponses, 1, "Did not add response to received message")
+	require.Len(t, receivedResponses, 1, "did not add response to received message")
 	receivedResponse := receivedResponses[0]
 	extensionData, found := receivedResponse.Extension(extensionName)
 	require.Equal(t, receivedResponse.RequestID(), sentResponse.RequestID())
@@ -121,7 +121,7 @@ func TestMessageSendAndReceive(t *testing.T) {
 	require.Equal(t, extension.Data, extensionData)
 
 	for i := 0; i < 2; i++ {
-		testutil.AssertDoesReceive(ctx, t, r.connectedPeers, "peers notified")
+		testutil.AssertDoesReceive(ctx, t, r.connectedPeers, "peers were not notified")
 	}
 
 }

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -92,7 +92,7 @@ func TestMessageSendAndReceive(t *testing.T) {
 
 	testutil.AssertDoesReceive(ctx, t, r.messageReceived, "message did not send")
 
-	require.Equal(t, r.lastSender, host1.ID(), "incorrect host sent message")
+	require.Equal(t, host1.ID(), r.lastSender, "incorrect host sent message")
 
 	received := r.lastMessage
 
@@ -102,11 +102,11 @@ func TestMessageSendAndReceive(t *testing.T) {
 	receivedRequests := received.Requests()
 	require.Len(t, receivedRequests, 1, "did not add request to received message")
 	receivedRequest := receivedRequests[0]
-	require.Equal(t, receivedRequest.ID(), sentRequest.ID())
-	require.Equal(t, receivedRequest.IsCancel(), sentRequest.IsCancel())
-	require.Equal(t, receivedRequest.Priority(), sentRequest.Priority())
-	require.Equal(t, receivedRequest.Root().String(), sentRequest.Root().String())
-	require.Equal(t, receivedRequest.Selector(), sentRequest.Selector())
+	require.Equal(t, sentRequest.ID(), receivedRequest.ID())
+	require.Equal(t, sentRequest.IsCancel(), receivedRequest.IsCancel())
+	require.Equal(t, sentRequest.Priority(), receivedRequest.Priority())
+	require.Equal(t, sentRequest.Root().String(), receivedRequest.Root().String())
+	require.Equal(t, sentRequest.Selector(), receivedRequest.Selector())
 
 	sentResponses := sent.Responses()
 	require.Len(t, sentResponses, 1, "did not add response to sent message")
@@ -115,8 +115,8 @@ func TestMessageSendAndReceive(t *testing.T) {
 	require.Len(t, receivedResponses, 1, "did not add response to received message")
 	receivedResponse := receivedResponses[0]
 	extensionData, found := receivedResponse.Extension(extensionName)
-	require.Equal(t, receivedResponse.RequestID(), sentResponse.RequestID())
-	require.Equal(t, receivedResponse.Status(), sentResponse.Status())
+	require.Equal(t, sentResponse.RequestID(), receivedResponse.RequestID())
+	require.Equal(t, sentResponse.Status(), receivedResponse.Status())
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -3,7 +3,6 @@ package network
 import (
 	"context"
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	"github.com/libp2p/go-libp2p-core/peer"
 	mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // Receiver is an interface for receiving messages from the GraphSyncNetwork.
@@ -54,17 +54,11 @@ func TestMessageSendAndReceive(t *testing.T) {
 	mn := mocknet.New(ctx)
 
 	host1, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
+	require.NoError(t, err, "error generating host")
 	host2, err := mn.GenPeer()
-	if err != nil {
-		t.Fatal("error generating host")
-	}
+	require.NoError(t, err, "error generating host")
 	err = mn.LinkAll()
-	if err != nil {
-		t.Fatal("error linking hosts")
-	}
+	require.NoError(t, err, "error linking hosts")
 	gsnet1 := NewFromLibp2pHost(host1)
 	gsnet2 := NewFromLibp2pHost(host2)
 	r := &receiver{
@@ -91,69 +85,43 @@ func TestMessageSendAndReceive(t *testing.T) {
 	sent.AddResponse(gsmsg.NewResponse(id, status, extension))
 
 	err = gsnet1.ConnectTo(ctx, host2.ID())
-	if err != nil {
-		t.Fatal("Unable to connect peers")
-	}
+	require.NoError(t, err, "Unable to connect peers")
 
 	err = gsnet1.SendMessage(ctx, host2.ID(), sent)
-	if err != nil {
-		t.Fatal("Unable to send message")
-	}
+	require.NoError(t, err)
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("did not receive message sent")
-	case <-r.messageReceived:
-	}
+	testutil.AssertDoesReceive(ctx, t, r.messageReceived, "message is sent")
 
-	sender := r.lastSender
-	if sender != host1.ID() {
-		t.Fatal("received message from wrong node")
-	}
+	require.Equal(t, r.lastSender, host1.ID(), "corrent host sent message")
 
 	received := r.lastMessage
 
 	sentRequests := sent.Requests()
-	if len(sentRequests) != 1 {
-		t.Fatal("Did not add request to sent message")
-	}
+	require.Len(t, sentRequests, 1, "Did not add request to sent message")
 	sentRequest := sentRequests[0]
 	receivedRequests := received.Requests()
-	if len(receivedRequests) != 1 {
-		t.Fatal("Did not add request to received message")
-	}
+	require.Len(t, receivedRequests, 1, "Did not add request to received message")
 	receivedRequest := receivedRequests[0]
-	if receivedRequest.ID() != sentRequest.ID() ||
-		receivedRequest.IsCancel() != sentRequest.IsCancel() ||
-		receivedRequest.Priority() != sentRequest.Priority() ||
-		receivedRequest.Root().String() != sentRequest.Root().String() ||
-		!reflect.DeepEqual(receivedRequest.Selector(), sentRequest.Selector()) {
-		t.Fatal("Sent message requests did not match received message requests")
-	}
+	require.Equal(t, receivedRequest.ID(), sentRequest.ID())
+	require.Equal(t, receivedRequest.IsCancel(), sentRequest.IsCancel())
+	require.Equal(t, receivedRequest.Priority(), sentRequest.Priority())
+	require.Equal(t, receivedRequest.Root().String(), sentRequest.Root().String())
+	require.Equal(t, receivedRequest.Selector(), sentRequest.Selector())
+
 	sentResponses := sent.Responses()
-	if len(sentResponses) != 1 {
-		t.Fatal("Did not add response to sent message")
-	}
+	require.Len(t, sentResponses, 1, "Did not add response to sent message")
 	sentResponse := sentResponses[0]
 	receivedResponses := received.Responses()
-	if len(receivedResponses) != 1 {
-		t.Fatal("Did not add response to received message")
-	}
+	require.Len(t, receivedResponses, 1, "Did not add response to received message")
 	receivedResponse := receivedResponses[0]
 	extensionData, found := receivedResponse.Extension(extensionName)
-	if receivedResponse.RequestID() != sentResponse.RequestID() ||
-		receivedResponse.Status() != sentResponse.Status() ||
-		!found ||
-		!reflect.DeepEqual(extension.Data, extensionData) {
-		t.Fatal("Sent message responses did not match received message responses")
-	}
+	require.Equal(t, receivedResponse.RequestID(), sentResponse.RequestID())
+	require.Equal(t, receivedResponse.Status(), sentResponse.Status())
+	require.True(t, found)
+	require.Equal(t, extension.Data, extensionData)
 
 	for i := 0; i < 2; i++ {
-		select {
-		case <-ctx.Done():
-			t.Fatal("did notify of all peer connections")
-		case <-r.connectedPeers:
-		}
+		testutil.AssertDoesReceive(ctx, t, r.connectedPeers, "peers notified")
 	}
 
 }

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -30,31 +30,23 @@ func TestAddingAndRemovingPeers(t *testing.T) {
 
 	connectedPeers := peerManager.ConnectedPeers()
 
-	if !testutil.ContainsPeer(connectedPeers, peer1) ||
-		!testutil.ContainsPeer(connectedPeers, peer2) ||
-		!testutil.ContainsPeer(connectedPeers, peer3) {
-		t.Fatal("Peers not connected that should be connected")
-	}
+	testutil.AssertContainsPeer(t, connectedPeers, peer1)
+	testutil.AssertContainsPeer(t, connectedPeers, peer2)
+	testutil.AssertContainsPeer(t, connectedPeers, peer3)
 
-	if testutil.ContainsPeer(connectedPeers, peer4) ||
-		testutil.ContainsPeer(connectedPeers, peer5) {
-		t.Fatal("Peers connected that shouldn't be connected")
-	}
+	testutil.RefuteContainsPeer(t, connectedPeers, peer4)
+	testutil.RefuteContainsPeer(t, connectedPeers, peer5)
 
 	// removing a peer with only one reference
 	peerManager.Disconnected(peer1)
 	connectedPeers = peerManager.ConnectedPeers()
 
-	if testutil.ContainsPeer(connectedPeers, peer1) {
-		t.Fatal("Peer should have been disconnected but was not")
-	}
+	testutil.RefuteContainsPeer(t, connectedPeers, peer1)
 
 	// connecting a peer twice, then disconnecting once, should stay in queue
 	peerManager.Connected(peer2)
 	peerManager.Disconnected(peer2)
 	connectedPeers = peerManager.ConnectedPeers()
 
-	if !testutil.ContainsPeer(connectedPeers, peer2) {
-		t.Fatal("Peer was disconnected but should not have been")
-	}
+	testutil.AssertContainsPeer(t, connectedPeers, peer2)
 }

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -73,28 +73,28 @@ func TestSendingMessagesToPeers(t *testing.T) {
 
 	var firstMessage messageSent
 	testutil.AssertReceive(ctx, t, messagesSent, &firstMessage, "first message did not send")
-	require.Equal(t, firstMessage.p, tp[0], "first message sent to incorrect peer")
+	require.Equal(t, tp[0], firstMessage.p, "first message sent to incorrect peer")
 	request = firstMessage.message.Requests()[0]
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.False(t, request.IsCancel())
-	require.Equal(t, request.Priority(), priority)
-	require.Equal(t, request.Selector(), selector)
+	require.Equal(t, priority, request.Priority())
+	require.Equal(t, selector, request.Selector())
 
 	var secondMessage messageSent
 	testutil.AssertReceive(ctx, t, messagesSent, &secondMessage, "second message did not send")
-	require.Equal(t, secondMessage.p, tp[1], "second message sent to incorrect peer")
+	require.Equal(t, tp[1], secondMessage.p, "second message sent to incorrect peer")
 	request = secondMessage.message.Requests()[0]
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.False(t, request.IsCancel())
-	require.Equal(t, request.Priority(), priority)
-	require.Equal(t, request.Selector(), selector)
+	require.Equal(t, priority, request.Priority())
+	require.Equal(t, selector, request.Selector())
 
 	var thirdMessage messageSent
 	testutil.AssertReceive(ctx, t, messagesSent, &thirdMessage, "third message did not send")
 
-	require.Equal(t, thirdMessage.p, tp[0], "third message sent to incorrect peer")
+	require.Equal(t, tp[0], thirdMessage.p, "third message sent to incorrect peer")
 	request = thirdMessage.message.Requests()[0]
-	require.Equal(t, request.ID(), id)
+	require.Equal(t, id, request.ID())
 	require.True(t, request.IsCancel())
 
 	connectedPeers := peerManager.ConnectedPeers()

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -72,8 +72,8 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	peerManager.SendRequest(tp[0], cancelRequest)
 
 	var firstMessage messageSent
-	testutil.AssertReceive(ctx, t, messagesSent, &firstMessage, "first message sent")
-	require.Equal(t, firstMessage.p, tp[0], "First message sent to wrong peer")
+	testutil.AssertReceive(ctx, t, messagesSent, &firstMessage, "first message did not send")
+	require.Equal(t, firstMessage.p, tp[0], "first message sent to incorrect peer")
 	request = firstMessage.message.Requests()[0]
 	require.Equal(t, request.ID(), id)
 	require.False(t, request.IsCancel())
@@ -81,8 +81,8 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	require.Equal(t, request.Selector(), selector)
 
 	var secondMessage messageSent
-	testutil.AssertReceive(ctx, t, messagesSent, &secondMessage, "first message sent")
-	require.Equal(t, secondMessage.p, tp[1], "Second message sent to correct peer")
+	testutil.AssertReceive(ctx, t, messagesSent, &secondMessage, "second message did not send")
+	require.Equal(t, secondMessage.p, tp[1], "second message sent to incorrect peer")
 	request = secondMessage.message.Requests()[0]
 	require.Equal(t, request.ID(), id)
 	require.False(t, request.IsCancel())
@@ -90,9 +90,9 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	require.Equal(t, request.Selector(), selector)
 
 	var thirdMessage messageSent
-	testutil.AssertReceive(ctx, t, messagesSent, &thirdMessage, "first message sent")
+	testutil.AssertReceive(ctx, t, messagesSent, &thirdMessage, "third message did not send")
 
-	require.Equal(t, thirdMessage.p, tp[0], "Third message sent to wrong peer")
+	require.Equal(t, thirdMessage.p, tp[0], "third message sent to incorrect peer")
 	request = thirdMessage.message.Requests()[0]
 	require.Equal(t, request.ID(), id)
 	require.True(t, request.IsCancel())

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -90,7 +90,7 @@ func TestAsyncLoadInitialLoadSucceedsResponsePresent(t *testing.T) {
 	require.Nil(t, result.Err, "should not send error")
 
 	require.Zero(t, callCount, "should not attempt to load link from local store")
-	require.Equal(t, blockStore[link], block.RawData(), "should store block")
+	require.Equal(t, block.RawData(), blockStore[link], "should store block")
 }
 
 func TestAsyncLoadInitialLoadFails(t *testing.T) {
@@ -200,9 +200,9 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 	require.NotNil(t, result.Data, "should send response")
 	require.Nil(t, result.Err, "should not send error")
 
-	require.Equal(t, callCount, 1, "should attempt to load from local store exactly once")
+	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
 
-	require.Equal(t, blockStore[link], block.RawData(), "should store block")
+	require.Equal(t, block.RawData(), blockStore[link], "should store block")
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
@@ -243,7 +243,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.Nil(t, result.Data, "should not send responses")
 	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, callCount, 1, "should attempt to load from local store exactly once")
+	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
@@ -276,7 +276,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.Nil(t, result.Data, "should not send responses")
 	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, callCount, 1, "should attempt to load from local store exactly once")
+	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
 }
 
 func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
@@ -317,7 +317,7 @@ func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
 	require.Nil(t, result.Err, "should not send error")
 
 	require.Zero(t, callCount, "should not attempt to load link from local store")
-	require.Equal(t, blockStore[link], block.RawData(), "should store block")
+	require.Equal(t, block.RawData(), blockStore[link], "should store block")
 
 	resultChan = asyncLoader.AsyncLoad(requestID, link)
 
@@ -325,5 +325,5 @@ func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
 	require.NotNil(t, result.Data, "should send response")
 	require.Nil(t, result.Err, "should not send error")
 	require.NotZero(t, callCount, "should attempt to load link from local store")
-	require.Equal(t, blockStore[link], block.RawData(), "should store block")
+	require.Equal(t, block.RawData(), blockStore[link], "should store block")
 }

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -126,8 +126,8 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.Zero(t, callCount, "should not attempt to load link from local store")
 }
 
@@ -153,8 +153,8 @@ func TestAsyncLoadInitialLoadIndeterminateWhenRequestNotInProgress(t *testing.T)
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.NotZero(t, callCount, "should attempt to load link from local store")
 }
 
@@ -183,7 +183,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	testutil.AssertDoesReceiveFirst(t, called, "attemps load with no result", resultChan, ctx.Done())
+	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
 
 	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
@@ -228,7 +228,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	testutil.AssertDoesReceiveFirst(t, called, "attemps load with no result", resultChan, ctx.Done())
+	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
 	responses := map[graphsync.RequestID]metadata.Metadata{
 		requestID: metadata.Metadata{
 			metadata.Item{
@@ -241,8 +241,8 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.Equal(t, callCount, 1, "should attempt to load from local store exactly once")
 }
 
@@ -269,13 +269,13 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	asyncLoader.StartRequest(requestID)
 	resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	testutil.AssertDoesReceiveFirst(t, called, "attemps load with no result", resultChan, ctx.Done())
+	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
 	asyncLoader.CompleteResponsesFor(requestID)
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.Equal(t, callCount, 1, "should attempt to load from local store exactly once")
 }
 

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
@@ -90,7 +90,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryFalse(t *testing.T) {
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.Nil(t, result.Data, "should not send responses")
 	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, callCount, 1, "should attempt to load once and then not retry")
+	require.Equal(t, 1, callCount, "should attempt to load once and then not retry")
 }
 
 func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing.T) {
@@ -123,7 +123,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.NotNil(t, result.Data, "should send response")
 	require.Nil(t, result.Err, "should not send error")
-	require.Equal(t, callCount, 2, "should attempt to load multiple times till success")
+	require.Equal(t, 2, callCount, "should attempt to load multiple times till success")
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
@@ -157,5 +157,5 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.Nil(t, result.Data, "should not send responses")
 	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, callCount, 1, "should attempt to load only once because request is finised")
+	require.Equal(t, 1, callCount, "should attempt to load only once because request is finised")
 }

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
@@ -59,8 +59,8 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.NotZero(t, callCount, "should attempt to load link from local store")
 }
 
@@ -88,8 +88,8 @@ func TestAsyncLoadInitialLoadIndeterminateRetryFalse(t *testing.T) {
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.Equal(t, callCount, 1, "should attempt to load once and then not retry")
 }
 
@@ -116,7 +116,7 @@ func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, true)
 
-	testutil.AssertDoesReceiveFirst(t, called, "attemps load with no result", resultChan, ctx.Done())
+	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
 	loadAttemptQueue.RetryLoads()
 
 	var result types.AsyncLoadResult
@@ -149,13 +149,13 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	lr := NewLoadRequest(requestID, link, resultChan)
 	loadAttemptQueue.AttemptLoad(lr, true)
 
-	testutil.AssertDoesReceiveFirst(t, called, "attemps load with no result", resultChan, ctx.Done())
+	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
 	loadAttemptQueue.ClearRequest(requestID)
 	loadAttemptQueue.RetryLoads()
 
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not have sent responses")
-	require.NotNil(t, result.Err, "should have sent an error")
+	require.Nil(t, result.Data, "should not send responses")
+	require.NotNil(t, result.Err, "should send an error")
 	require.Equal(t, callCount, 1, "should attempt to load only once because request is finised")
 }

--- a/requestmanager/asyncloader/responsecache/responsecache_test.go
+++ b/requestmanager/asyncloader/responsecache/responsecache_test.go
@@ -105,7 +105,7 @@ func TestResponseCacheManagingLinks(t *testing.T) {
 	// should load block from unverified block store
 	data, err := responseCache.AttemptLoad(requestID2, cidlink.Link{Cid: blks[4].Cid()})
 	require.NoError(t, err)
-	require.Equal(t, data, blks[4].RawData(), "load correct block")
+	require.Equal(t, data, blks[4].RawData(), "did not load correct block")
 
 	// which will remove block
 	require.Len(t, fubs.blocks(), len(blks)-2, "should prune block once verified")

--- a/requestmanager/asyncloader/responsecache/responsecache_test.go
+++ b/requestmanager/asyncloader/responsecache/responsecache_test.go
@@ -105,7 +105,7 @@ func TestResponseCacheManagingLinks(t *testing.T) {
 	// should load block from unverified block store
 	data, err := responseCache.AttemptLoad(requestID2, cidlink.Link{Cid: blks[4].Cid()})
 	require.NoError(t, err)
-	require.Equal(t, data, blks[4].RawData(), "did not load correct block")
+	require.Equal(t, blks[4].RawData(), data, "did not load correct block")
 
 	// which will remove block
 	require.Len(t, fubs.blocks(), len(blks)-2, "should prune block once verified")
@@ -119,7 +119,7 @@ func TestResponseCacheManagingLinks(t *testing.T) {
 	// should succeed for request 2 where it's not a missing block
 	data, err = responseCache.AttemptLoad(requestID2, cidlink.Link{Cid: blks[1].Cid()})
 	require.NoError(t, err)
-	require.Equal(t, data, blks[1].RawData())
+	require.Equal(t, blks[1].RawData(), data)
 
 	// which will remove block
 	require.Len(t, fubs.blocks(), len(blks)-3, "should prune block once verified")

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
@@ -33,14 +33,14 @@ func TestVerifyBlockPresent(t *testing.T) {
 
 	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
 	require.NoError(t, err)
-	require.Equal(t, data, block.RawData(), "block should be returned on verification if added")
+	require.Equal(t, block.RawData(), data, "block should be returned on verification if added")
 
 	reader, err = loader(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
 	require.NoError(t, err)
 	var buffer bytes.Buffer
 	_, err = io.Copy(&buffer, reader)
 	require.NoError(t, err)
-	require.Equal(t, buffer.Bytes(), block.RawData(), "block should be stored and loadable after verification")
+	require.Equal(t, block.RawData(), buffer.Bytes(), "block should be stored and loadable after verification")
 	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
 	require.Nil(t, data)
 	require.Error(t, err, "block cannot be verified twice")

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
@@ -3,10 +3,10 @@ package unverifiedblockstore
 import (
 	"bytes"
 	"io"
-	"reflect"
 	"testing"
 
 	"github.com/ipld/go-ipld-prime"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync/testutil"
 
@@ -19,36 +19,29 @@ func TestVerifyBlockPresent(t *testing.T) {
 	unverifiedBlockStore := New(storer)
 	block := testutil.GenerateBlocksOfSize(1, 100)[0]
 	reader, err := loader(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
-	if reader != nil || err == nil {
-		t.Fatal("block should not be loadable till it's verified and stored")
-	}
+	require.Nil(t, reader)
+	require.Error(t, err, "block should not be loadable till it's verified and stored")
+
 	data, err := unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
-	if data != nil || err == nil {
-		t.Fatal("block should not be verifiable till it's added as an unverifiable block")
-	}
+	require.Nil(t, data)
+	require.Error(t, err, "block should not be verifiable till it's added as an unverifiable block")
+
 	unverifiedBlockStore.AddUnverifiedBlock(cidlink.Link{Cid: block.Cid()}, block.RawData())
 	reader, err = loader(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
-	if reader != nil || err == nil {
-		t.Fatal("block should not be loadable till it's verified and stored")
-	}
+	require.Nil(t, reader)
+	require.Error(t, err, "block should not be loadable till it's verified")
+
 	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
-	if !reflect.DeepEqual(data, block.RawData()) || err != nil {
-		t.Fatal("block should be returned on verification if added")
-	}
+	require.NoError(t, err)
+	require.Equal(t, data, block.RawData(), "block should be returned on verification if added")
+
 	reader, err = loader(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
-	if err != nil {
-		t.Fatal("error loading block")
-	}
+	require.NoError(t, err)
 	var buffer bytes.Buffer
 	_, err = io.Copy(&buffer, reader)
-	if err != nil {
-		t.Fatal("error occurred copying data")
-	}
-	if !reflect.DeepEqual(buffer.Bytes(), block.RawData()) || err != nil {
-		t.Fatal("block should be stored after verification and therefore loadable")
-	}
+	require.NoError(t, err)
+	require.Equal(t, buffer.Bytes(), block.RawData(), "block should be stored and loadable after verification")
 	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
-	if data != nil || err == nil {
-		t.Fatal("block cannot be verified twice")
-	}
+	require.Nil(t, data)
+	require.Error(t, err, "block cannot be verified twice")
 }

--- a/requestmanager/loader/loader_test.go
+++ b/requestmanager/loader/loader_test.go
@@ -6,13 +6,13 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"reflect"
 	"testing"
 	"time"
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime"
@@ -46,16 +46,10 @@ func TestWrappedAsyncLoaderReturnsValues(t *testing.T) {
 	data := testutil.RandomBytes(100)
 	responseChan <- types.AsyncLoadResult{Data: data, Err: nil}
 	stream, err := loader(link, ipld.LinkContext{})
-	if err != nil {
-		t.Fatal("Should not have errored on load")
-	}
+	require.NoError(t, err, "should load")
 	returnedData, err := ioutil.ReadAll(stream)
-	if err != nil {
-		t.Fatal("error in return stream")
-	}
-	if !reflect.DeepEqual(data, returnedData) {
-		t.Fatal("returned data did not match expected")
-	}
+	require.NoError(t, err, "stream reads")
+	require.Equal(t, data, returnedData, "should return correct data")
 }
 
 func TestWrappedAsyncLoaderSideChannelsErrors(t *testing.T) {
@@ -73,17 +67,11 @@ func TestWrappedAsyncLoaderSideChannelsErrors(t *testing.T) {
 	err := errors.New("something went wrong")
 	responseChan <- types.AsyncLoadResult{Data: nil, Err: err}
 	stream, loadErr := loader(link, ipld.LinkContext{})
-	if stream != nil || loadErr != ipldutil.ErrDoNotFollow() {
-		t.Fatal("Should have errored on load")
-	}
-	select {
-	case <-ctx.Done():
-		t.Fatal("should have returned an error on side channel but didn't")
-	case returnedErr := <-errChan:
-		if returnedErr != err {
-			t.Fatal("returned wrong error on side channel")
-		}
-	}
+	require.Nil(t, stream, "return reader is nil")
+	require.EqualError(t, loadErr, ipldutil.ErrDoNotFollow().Error())
+	var returnedErr error
+	testutil.AssertReceive(ctx, t, errChan, &returnedErr, "should return an error on side channel")
+	require.EqualError(t, returnedErr, err.Error())
 }
 
 func TestWrappedAsyncLoaderContextCancels(t *testing.T) {
@@ -111,12 +99,11 @@ func TestWrappedAsyncLoaderContextCancels(t *testing.T) {
 	}()
 	subCancel()
 
-	select {
-	case <-ctx.Done():
-		t.Fatal("should have returned from context cancelling but didn't")
-	case result := <-resultsChan:
-		if result.Reader != nil || result.error == nil {
-			t.Fatal("should have errored from context cancelling but didn't")
-		}
+	var result struct {
+		io.Reader
+		error
 	}
+	testutil.AssertReceive(ctx, t, resultsChan, &result, "should return from sub context cancelling")
+	require.Nil(t, result.Reader)
+	require.Error(t, result.error, "should error from sub context cancelling")
 }

--- a/requestmanager/loader/loader_test.go
+++ b/requestmanager/loader/loader_test.go
@@ -48,7 +48,7 @@ func TestWrappedAsyncLoaderReturnsValues(t *testing.T) {
 	stream, err := loader(link, ipld.LinkContext{})
 	require.NoError(t, err, "should load")
 	returnedData, err := ioutil.ReadAll(stream)
-	require.NoError(t, err, "stream reads")
+	require.NoError(t, err, "stream did not read")
 	require.Equal(t, data, returnedData, "should return correct data")
 }
 
@@ -67,7 +67,7 @@ func TestWrappedAsyncLoaderSideChannelsErrors(t *testing.T) {
 	err := errors.New("something went wrong")
 	responseChan <- types.AsyncLoadResult{Data: nil, Err: err}
 	stream, loadErr := loader(link, ipld.LinkContext{})
-	require.Nil(t, stream, "return reader is nil")
+	require.Nil(t, stream, "should return nil reader")
 	require.EqualError(t, loadErr, ipldutil.ErrDoNotFollow().Error())
 	var returnedErr error
 	testutil.AssertReceive(ctx, t, errChan, &returnedErr, "should return an error on side channel")

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -70,14 +70,14 @@ func (fal *fakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]me
 func (fal *fakeAsyncLoader) verifyLastProcessedBlocks(ctx context.Context, t *testing.T, expectedBlocks []blocks.Block) {
 	var processedBlocks []blocks.Block
 	testutil.AssertReceive(ctx, t, fal.blks, &processedBlocks, "did not process blocks")
-	require.Equal(t, processedBlocks, expectedBlocks, "did not process correct blocks")
+	require.Equal(t, expectedBlocks, processedBlocks, "did not process correct blocks")
 }
 
 func (fal *fakeAsyncLoader) verifyLastProcessedResponses(ctx context.Context, t *testing.T,
 	expectedResponses map[graphsync.RequestID]metadata.Metadata) {
 	var responses map[graphsync.RequestID]metadata.Metadata
 	testutil.AssertReceive(ctx, t, fal.responses, &responses, "did not process responses")
-	require.Equal(t, responses, expectedResponses, "did not process correct responses")
+	require.Equal(t, expectedResponses, responses, "did not process correct responses")
 }
 
 func (fal *fakeAsyncLoader) verifyNoRemainingData(t *testing.T, requestID graphsync.RequestID) {
@@ -182,12 +182,12 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 
 	requestRecords := readNNetworkRequests(requestCtx, t, requestRecordChan, 2)
 
-	require.Equal(t, requestRecords[0].p, peers[0])
-	require.Equal(t, requestRecords[1].p, peers[0])
+	require.Equal(t, peers[0], requestRecords[0].p)
+	require.Equal(t, peers[0], requestRecords[1].p)
 	require.False(t, requestRecords[0].gsr.IsCancel())
 	require.False(t, requestRecords[1].gsr.IsCancel())
-	require.Equal(t, requestRecords[0].gsr.Priority(), maxPriority)
-	require.Equal(t, requestRecords[1].gsr.Priority(), maxPriority)
+	require.Equal(t, maxPriority, requestRecords[0].gsr.Priority())
+	require.Equal(t, maxPriority, requestRecords[1].gsr.Priority())
 
 	require.Equal(t, blockChain1.Selector(), requestRecords[0].gsr.Selector(), "did not encode selector properly")
 	require.Equal(t, blockChain2.Selector(), requestRecords[1].gsr.Selector(), "did not encode selector properly")
@@ -286,7 +286,7 @@ func TestCancelRequestInProgress(t *testing.T) {
 	rr := readNNetworkRequests(requestCtx, t, requestRecordChan, 1)[0]
 
 	require.True(t, rr.gsr.IsCancel())
-	require.Equal(t, rr.gsr.ID(), requestRecords[0].gsr.ID())
+	require.Equal(t, requestRecords[0].gsr.ID(), rr.gsr.ID())
 
 	moreBlocks := blockChain.RemainderBlocks(3)
 	moreMetadata := encodedMetadataForBlocks(t, moreBlocks, true)
@@ -570,7 +570,7 @@ func TestEncodingExtensions(t *testing.T) {
 		requestManager.ProcessResponses(peers[0], firstResponses, nil)
 		var received []byte
 		testutil.AssertReceive(ctx, t, receivedExtensionData, &received, "did not receive extension data")
-		require.Equal(t, received, expectedData, "did not receive correct extension data from resposne")
+		require.Equal(t, expectedData, received, "did not receive correct extension data from resposne")
 		nextExpectedData := testutil.RandomBytes(100)
 
 		secondResponses := []gsmsg.GraphSyncResponse{
@@ -588,7 +588,7 @@ func TestEncodingExtensions(t *testing.T) {
 		expectedError <- errors.New("a terrible thing happened")
 		requestManager.ProcessResponses(peers[0], secondResponses, nil)
 		testutil.AssertReceive(ctx, t, receivedExtensionData, &received, "did not receive extension data")
-		require.Equal(t, received, nextExpectedData, "did not receive correct extension data from resposne")
+		require.Equal(t, nextExpectedData, received, "did not receive correct extension data from resposne")
 		testutil.VerifySingleTerminalError(requestCtx, t, returnedErrorChan)
 		testutil.VerifyEmptyResponse(requestCtx, t, returnedResponseChan)
 	})

--- a/requestmanager/responsecollector_test.go
+++ b/requestmanager/responsecollector_test.go
@@ -39,27 +39,27 @@ func TestBufferingResponseProgress(t *testing.T) {
 				Path ipld.Path
 				Link ipld.Link
 			}{ipld.Path{}, cidlink.Link{Cid: block.Cid()}},
-		}, "writes block to channel")
+		}, "did not write block to channel")
 	}
 
 	interimError := fmt.Errorf("A block was missing")
 	terminalError := fmt.Errorf("Something terrible happened")
-	testutil.AssertSends(ctx, t, incomingErrors, interimError, "writes error to channel")
-	testutil.AssertSends(ctx, t, incomingErrors, terminalError, "writes error to channel")
+	testutil.AssertSends(ctx, t, incomingErrors, interimError, "did not write error to channel")
+	testutil.AssertSends(ctx, t, incomingErrors, terminalError, "did not write error to channel")
 
 	for _, block := range blocks {
 		var testResponse graphsync.ResponseProgress
 		testutil.AssertReceive(ctx, t, outgoingResponses, &testResponse, "should read from outgoing responses")
-		require.Equal(t, testResponse.LastBlock.Link.(cidlink.Link).Cid, block.Cid(), "stores blocks correctly")
+		require.Equal(t, testResponse.LastBlock.Link.(cidlink.Link).Cid, block.Cid(), "did not store block correctly")
 	}
 
 	for i := 0; i < 2; i++ {
 		var testErr error
 		testutil.AssertReceive(ctx, t, outgoingErrors, &testErr, "should have read from channel but couldn't")
 		if i == 0 {
-			require.Equal(t, testErr, interimError, "correct error message sent")
+			require.Equal(t, testErr, interimError, "incorrect error message sent")
 		} else {
-			require.Equal(t, testErr, terminalError, "correct error message sent")
+			require.Equal(t, testErr, terminalError, "incorrect error message sent")
 		}
 	}
 }

--- a/requestmanager/responsecollector_test.go
+++ b/requestmanager/responsecollector_test.go
@@ -50,16 +50,16 @@ func TestBufferingResponseProgress(t *testing.T) {
 	for _, block := range blocks {
 		var testResponse graphsync.ResponseProgress
 		testutil.AssertReceive(ctx, t, outgoingResponses, &testResponse, "should read from outgoing responses")
-		require.Equal(t, testResponse.LastBlock.Link.(cidlink.Link).Cid, block.Cid(), "did not store block correctly")
+		require.Equal(t, block.Cid(), testResponse.LastBlock.Link.(cidlink.Link).Cid, "did not store block correctly")
 	}
 
 	for i := 0; i < 2; i++ {
 		var testErr error
 		testutil.AssertReceive(ctx, t, outgoingErrors, &testErr, "should have read from channel but couldn't")
 		if i == 0 {
-			require.Equal(t, testErr, interimError, "incorrect error message sent")
+			require.Equal(t, interimError, testErr, "incorrect error message sent")
 		} else {
-			require.Equal(t, testErr, terminalError, "incorrect error message sent")
+			require.Equal(t, terminalError, testErr, "incorrect error message sent")
 		}
 	}
 }

--- a/responsemanager/loader/loader_test.go
+++ b/responsemanager/loader/loader_test.go
@@ -54,18 +54,18 @@ func TestWrappedLoaderSendsResponses(t *testing.T) {
 	require.NoError(t, err, "Should not have error if underlying loader returns valid buffer and no error")
 	result, err := ioutil.ReadAll(reader)
 	require.NoError(t, err)
-	require.Equal(t, result, sourceBytes, "Should return reader that functions identical to source reader")
-	require.Equal(t, frs.lastRequestID, requestID, "should send block to response sender with correct params")
-	require.Equal(t, frs.lastLink, link1, "should send block to response sender with correct params")
-	require.Equal(t, frs.lastData, sourceBytes, "should send block to response sender with correct params")
+	require.Equal(t, sourceBytes, result, "Should return reader that functions identical to source reader")
+	require.Equal(t, requestID, frs.lastRequestID, "should send block to response sender with correct params")
+	require.Equal(t, link1, frs.lastLink, "should send block to response sender with correct params")
+	require.Equal(t, sourceBytes, frs.lastData, "should send block to response sender with correct params")
 
 	reader, err = wrappedLoader(link2, ipld.LinkContext{})
 
 	require.Nil(t, reader, "should return empty reader")
 	require.Error(t, err, "should return an error")
 
-	require.Equal(t, err, ipldutil.ErrDoNotFollow(), "Should convert error to a do not follow error")
-	require.Equal(t, frs.lastRequestID, requestID)
-	require.Equal(t, frs.lastLink, link2, "Should send metadata")
+	require.Equal(t, ipldutil.ErrDoNotFollow(), err, "Should convert error to a do not follow error")
+	require.Equal(t, requestID, frs.lastRequestID)
+	require.Equal(t, link2, frs.lastLink, "Should send metadata")
 	require.Nil(t, frs.lastData, "Should not send block")
 }

--- a/responsemanager/loader/loader_test.go
+++ b/responsemanager/loader/loader_test.go
@@ -7,12 +7,12 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
-	"reflect"
 	"testing"
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/stretchr/testify/require"
 
 	ipld "github.com/ipld/go-ipld-prime"
 )
@@ -51,32 +51,21 @@ func TestWrappedLoaderSendsResponses(t *testing.T) {
 	wrappedLoader := WrapLoader(ctx, loader, requestID, frs)
 
 	reader, err := wrappedLoader(link1, ipld.LinkContext{})
-	if err != nil {
-		t.Fatal("Should not have error if underlying loader returns valid buffer and no error")
-	}
+	require.NoError(t, err, "Should not have error if underlying loader returns valid buffer and no error")
 	result, err := ioutil.ReadAll(reader)
-	if err != nil || !reflect.DeepEqual(result, sourceBytes) {
-		t.Fatal("Should return reader that functions identical to source reader")
-	}
-	if frs.lastRequestID != requestID ||
-		frs.lastLink != link1 ||
-		!reflect.DeepEqual(frs.lastData, sourceBytes) {
-		t.Fatal("Should have sent block to response sender with correct params but did not")
-	}
+	require.NoError(t, err)
+	require.Equal(t, result, sourceBytes, "Should return reader that functions identical to source reader")
+	require.Equal(t, frs.lastRequestID, requestID, "should send block to response sender with correct params")
+	require.Equal(t, frs.lastLink, link1, "should send block to response sender with correct params")
+	require.Equal(t, frs.lastData, sourceBytes, "should send block to response sender with correct params")
 
 	reader, err = wrappedLoader(link2, ipld.LinkContext{})
 
-	if reader != nil || err == nil {
-		t.Fatal("Should return an error and empty reader if underlying loader does")
-	}
+	require.Nil(t, reader, "should return empty reader")
+	require.Error(t, err, "should return an error")
 
-	if err != ipldutil.ErrDoNotFollow() {
-		t.Fatal("Should convert error to a do not follow error")
-	}
-
-	if frs.lastRequestID != requestID ||
-		frs.lastLink != link2 ||
-		frs.lastData != nil {
-		t.Fatal("Should sent metadata for link but no block, but did not")
-	}
+	require.Equal(t, err, ipldutil.ErrDoNotFollow(), "Should convert error to a do not follow error")
+	require.Equal(t, frs.lastRequestID, requestID)
+	require.Equal(t, frs.lastLink, link2, "Should send metadata")
+	require.Nil(t, frs.lastData, "Should not send block")
 }

--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -56,10 +56,10 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 
 	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends first message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "sends correct blocks for first message")
+	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
 	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
@@ -73,18 +73,18 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends second message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[1].Cid(), "dedups blocks correctly on second message")
+	require.Equal(t, fph.lastBlocks[0].Cid(), blks[1].Cid(), "did not dedup blocks correctly on second message")
 
-	require.Len(t, fph.lastResponses, 2, "sends correct number of responses")
+	require.Len(t, fph.lastResponses, 2, "did not send correct number of responses")
 	response1, err := findResponseForRequestID(fph.lastResponses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "send correct response code in second message")
+	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "did not send correct response code in second message")
 	response2, err := findResponseForRequestID(fph.lastResponses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.PartialResponse, "sends corrent response code in second message")
+	require.Equal(t, response2.Status(), graphsync.PartialResponse, "did not send corrent response code in second message")
 
 	peerResponseManager.SendResponse(requestID2, links[3], blks[3].RawData())
 	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
@@ -93,19 +93,19 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends third message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send third message")
 
 	require.Equal(t, len(fph.lastBlocks), 2)
 	testutil.AssertContainsBlock(t, fph.lastBlocks, blks[3])
 	testutil.AssertContainsBlock(t, fph.lastBlocks, blks[4])
 
-	require.Len(t, fph.lastResponses, 2, "sends correct number of responses")
+	require.Len(t, fph.lastResponses, 2, "did not send correct number of responses")
 	response2, err = findResponseForRequestID(fph.lastResponses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "sends correct response code in third message")
+	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "did not send correct response code in third message")
 	response3, err := findResponseForRequestID(fph.lastResponses, requestID3)
 	require.NoError(t, err)
-	require.Equal(t, response3.Status(), graphsync.PartialResponse, "sends correct response code in third message")
+	require.Equal(t, response3.Status(), graphsync.PartialResponse, "did not send correct response code in third message")
 
 	peerResponseManager.SendResponse(requestID3, links[0], blks[0].RawData())
 	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
@@ -113,7 +113,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends fourth message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send fourth message")
 
 	require.Len(t, fph.lastBlocks, 1)
 	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "Should resend block cause there were no in progress requests")
@@ -147,10 +147,10 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 
 	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends first message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "sends correct blocks for first message")
+	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
 	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
@@ -164,7 +164,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends second message ")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message ")
 
 	require.Len(t, fph.lastBlocks, 1)
 	require.Equal(t, fph.lastBlocks[0].Cid(), blks[1].Cid(), "Should break up message")
@@ -178,7 +178,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends third message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send third message")
 
 	require.Len(t, fph.lastBlocks, 1)
 	require.Equal(t, fph.lastBlocks[0].Cid(), blks[2].Cid(), "should break up message")
@@ -188,7 +188,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends fourth message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send fourth message")
 
 	require.Len(t, fph.lastBlocks, 1)
 	require.Equal(t, fph.lastBlocks[0].Cid(), blks[3].Cid(), "should break up message")
@@ -198,7 +198,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends fifth message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send fifth message")
 
 	require.Len(t, fph.lastBlocks, 1)
 	require.Equal(t, fph.lastBlocks[0].Cid(), blks[4].Cid(), "should break up message")
@@ -207,7 +207,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 
 	response, err := findResponseForRequestID(fph.lastResponses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response.Status(), graphsync.RequestCompletedFull, "sends corrent response code in fifth message")
+	require.Equal(t, response.Status(), graphsync.RequestCompletedFull, "did not send corrent response code in fifth message")
 
 }
 
@@ -233,10 +233,10 @@ func TestPeerResponseManagerSendsExtensionData(t *testing.T) {
 
 	peerResponseManager.SendResponse(requestID1, links[0], blks[0].RawData())
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends first message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "sends correct blocks for first message")
+	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
 	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
@@ -260,18 +260,18 @@ func TestPeerResponseManagerSendsExtensionData(t *testing.T) {
 	// let peer reponse manager know last message was sent so message sending can continue
 	done <- struct{}{}
 
-	testutil.AssertDoesReceive(ctx, t, sent, "sends second message")
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message")
 
-	require.Len(t, fph.lastResponses, 1, "sends correct number of responses for second message")
+	require.Len(t, fph.lastResponses, 1, "did not send correct number of responses for second message")
 
 	lastResponse := fph.lastResponses[0]
 	returnedData1, found := lastResponse.Extension(extensionName1)
 	require.True(t, found)
-	require.Equal(t, extensionData1, returnedData1, "encodes first extension")
+	require.Equal(t, extensionData1, returnedData1, "did not encode first extension")
 
 	returnedData2, found := lastResponse.Extension(extensionName2)
 	require.True(t, found)
-	require.Equal(t, extensionData2, returnedData2, "encoded first extension")
+	require.Equal(t, extensionData2, returnedData2, "did not encode first extension")
 }
 
 func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID graphsync.RequestID) (gsmsg.GraphSyncResponse, error) {

--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -59,11 +59,11 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
+	require.Equal(t, blks[0].Cid(), fph.lastBlocks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
-	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
-	require.Equal(t, fph.lastResponses[0].Status(), graphsync.PartialResponse)
+	require.Equal(t, requestID1, fph.lastResponses[0].RequestID())
+	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
 
 	peerResponseManager.SendResponse(requestID2, links[0], blks[0].RawData())
 	peerResponseManager.SendResponse(requestID1, links[1], blks[1].RawData())
@@ -76,15 +76,15 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[1].Cid(), "did not dedup blocks correctly on second message")
+	require.Equal(t, blks[1].Cid(), fph.lastBlocks[0].Cid(), "did not dedup blocks correctly on second message")
 
 	require.Len(t, fph.lastResponses, 2, "did not send correct number of responses")
 	response1, err := findResponseForRequestID(fph.lastResponses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "did not send correct response code in second message")
+	require.Equal(t, graphsync.RequestCompletedPartial, response1.Status(), "did not send correct response code in second message")
 	response2, err := findResponseForRequestID(fph.lastResponses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.PartialResponse, "did not send corrent response code in second message")
+	require.Equal(t, graphsync.PartialResponse, response2.Status(), "did not send corrent response code in second message")
 
 	peerResponseManager.SendResponse(requestID2, links[3], blks[3].RawData())
 	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
@@ -95,17 +95,17 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send third message")
 
-	require.Equal(t, len(fph.lastBlocks), 2)
+	require.Equal(t, 2, len(fph.lastBlocks))
 	testutil.AssertContainsBlock(t, fph.lastBlocks, blks[3])
 	testutil.AssertContainsBlock(t, fph.lastBlocks, blks[4])
 
 	require.Len(t, fph.lastResponses, 2, "did not send correct number of responses")
 	response2, err = findResponseForRequestID(fph.lastResponses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "did not send correct response code in third message")
+	require.Equal(t, graphsync.RequestCompletedFull, response2.Status(), "did not send correct response code in third message")
 	response3, err := findResponseForRequestID(fph.lastResponses, requestID3)
 	require.NoError(t, err)
-	require.Equal(t, response3.Status(), graphsync.PartialResponse, "did not send correct response code in third message")
+	require.Equal(t, graphsync.PartialResponse, response3.Status(), "did not send correct response code in third message")
 
 	peerResponseManager.SendResponse(requestID3, links[0], blks[0].RawData())
 	peerResponseManager.SendResponse(requestID3, links[4], blks[4].RawData())
@@ -116,11 +116,11 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send fourth message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "Should resend block cause there were no in progress requests")
+	require.Equal(t, blks[0].Cid(), fph.lastBlocks[0].Cid(), "Should resend block cause there were no in progress requests")
 
 	require.Len(t, fph.lastResponses, 1)
-	require.Equal(t, fph.lastResponses[0].RequestID(), requestID3)
-	require.Equal(t, fph.lastResponses[0].Status(), graphsync.PartialResponse)
+	require.Equal(t, requestID3, fph.lastResponses[0].RequestID())
+	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
 }
 
 func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
@@ -150,11 +150,11 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
+	require.Equal(t, blks[0].Cid(), fph.lastBlocks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
-	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
-	require.Equal(t, fph.lastResponses[0].Status(), graphsync.PartialResponse)
+	require.Equal(t, requestID1, fph.lastResponses[0].RequestID())
+	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
 
 	// Send 3 very large blocks
 	peerResponseManager.SendResponse(requestID1, links[1], blks[1].RawData())
@@ -167,7 +167,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message ")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[1].Cid(), "Should break up message")
+	require.Equal(t, blks[1].Cid(), fph.lastBlocks[0].Cid(), "Should break up message")
 
 	require.Len(t, fph.lastResponses, 1, "Should break up message")
 
@@ -181,7 +181,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send third message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[2].Cid(), "should break up message")
+	require.Equal(t, blks[2].Cid(), fph.lastBlocks[0].Cid(), "should break up message")
 
 	require.Len(t, fph.lastResponses, 1, "should break up message")
 
@@ -191,7 +191,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send fourth message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[3].Cid(), "should break up message")
+	require.Equal(t, blks[3].Cid(), fph.lastBlocks[0].Cid(), "should break up message")
 
 	require.Len(t, fph.lastResponses, 1, "should break up message")
 
@@ -201,13 +201,13 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send fifth message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[4].Cid(), "should break up message")
+	require.Equal(t, blks[4].Cid(), fph.lastBlocks[0].Cid(), "should break up message")
 
 	require.Len(t, fph.lastResponses, 1, "should break up message")
 
 	response, err := findResponseForRequestID(fph.lastResponses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response.Status(), graphsync.RequestCompletedFull, "did not send corrent response code in fifth message")
+	require.Equal(t, graphsync.RequestCompletedFull, response.Status(), "did not send corrent response code in fifth message")
 
 }
 
@@ -236,11 +236,11 @@ func TestPeerResponseManagerSendsExtensionData(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
 
 	require.Len(t, fph.lastBlocks, 1)
-	require.Equal(t, fph.lastBlocks[0].Cid(), blks[0].Cid(), "did not send correct blocks for first message")
+	require.Equal(t, blks[0].Cid(), fph.lastBlocks[0].Cid(), "did not send correct blocks for first message")
 
 	require.Len(t, fph.lastResponses, 1)
-	require.Equal(t, fph.lastResponses[0].RequestID(), requestID1)
-	require.Equal(t, fph.lastResponses[0].Status(), graphsync.PartialResponse)
+	require.Equal(t, requestID1, fph.lastResponses[0].RequestID())
+	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
 
 	extensionData1 := testutil.RandomBytes(100)
 	extensionName1 := graphsync.ExtensionName("AppleSauce/McGee")

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -66,64 +66,64 @@ func TestMessageBuilding(t *testing.T) {
 
 	responses, sentBlocks, err := rb.Build()
 
-	require.NoError(t, err, "builds responses without error")
+	require.NoError(t, err, "build responses errored")
 
-	require.Len(t, responses, 4, "assembles correct number of responses")
+	require.Len(t, responses, 4, "did not assemble correct number of responses")
 
 	response1, err := findResponseForRequestID(responses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "generates completed partial response")
+	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "did not generate completed partial response")
 
 	response1MetadataRaw, found := response1.Extension(graphsync.ExtensionMetadata)
-	require.True(t, found, "Metadata included in response")
+	require.True(t, found, "Metadata should be included in response")
 	response1Metadata, err := metadata.DecodeMetadata(response1MetadataRaw)
 	require.NoError(t, err)
 	require.Equal(t, response1Metadata, metadata.Metadata{
 		metadata.Item{Link: links[0], BlockPresent: true},
 		metadata.Item{Link: links[1], BlockPresent: false},
 		metadata.Item{Link: links[2], BlockPresent: true},
-	}, "correct metadata include in response")
+	}, "incorrect metadata included in response")
 
 	response1ReturnedExtensionData, found := response1.Extension(extensionName1)
 	require.True(t, found)
-	require.Equal(t, extensionData1, response1ReturnedExtensionData, "encoded first extension")
+	require.Equal(t, extensionData1, response1ReturnedExtensionData, "did not encode first extension")
 
 	response2, err := findResponseForRequestID(responses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "generates completed full response")
+	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "did not generate completed full response")
 
 	response2MetadataRaw, found := response2.Extension(graphsync.ExtensionMetadata)
-	require.True(t, found, "Metadata included in response")
+	require.True(t, found, "Metadata should be included in response")
 	response2Metadata, err := metadata.DecodeMetadata(response2MetadataRaw)
 	require.NoError(t, err)
 	require.Equal(t, response2Metadata, metadata.Metadata{
 		metadata.Item{Link: links[1], BlockPresent: true},
 		metadata.Item{Link: links[2], BlockPresent: true},
 		metadata.Item{Link: links[1], BlockPresent: true},
-	}, "correct metadata include in response")
+	}, "incorrect metadata included in response")
 
 	response3, err := findResponseForRequestID(responses, requestID3)
 	require.NoError(t, err)
-	require.Equal(t, response3.Status(), graphsync.PartialResponse, "generates partial response")
+	require.Equal(t, response3.Status(), graphsync.PartialResponse, "did not generate partial response")
 
 	response3MetadataRaw, found := response3.Extension(graphsync.ExtensionMetadata)
-	require.True(t, found, "Metadata included in response")
+	require.True(t, found, "Metadata should be included in response")
 	response3Metadata, err := metadata.DecodeMetadata(response3MetadataRaw)
 	require.NoError(t, err)
 	require.Equal(t, response3Metadata, metadata.Metadata{
 		metadata.Item{Link: links[0], BlockPresent: true},
 		metadata.Item{Link: links[1], BlockPresent: true},
-	}, "correct metadata include in response")
+	}, "incorrect metadata included in response")
 
 	response3ReturnedExtensionData, found := response3.Extension(extensionName2)
 	require.True(t, found)
-	require.Equal(t, extensionData2, response3ReturnedExtensionData, "encoded second extension")
+	require.Equal(t, extensionData2, response3ReturnedExtensionData, "did not encode second extension")
 
 	response4, err := findResponseForRequestID(responses, requestID4)
 	require.NoError(t, err)
-	require.Equal(t, response4.Status(), graphsync.RequestCompletedFull, "generates completed full response")
+	require.Equal(t, response4.Status(), graphsync.RequestCompletedFull, "did not generate completed full response")
 
-	require.Equal(t, len(sentBlocks), len(blocks), "sends all blocks")
+	require.Equal(t, len(sentBlocks), len(blocks), "did not send all blocks")
 
 	for _, block := range sentBlocks {
 		testutil.AssertContainsBlock(t, blocks, block)

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -47,7 +47,7 @@ func TestMessageBuilding(t *testing.T) {
 		rb.AddBlock(block)
 	}
 
-	require.Equal(t, rb.BlockSize(), 300, "did not calculate block size correctly")
+	require.Equal(t, 300, rb.BlockSize(), "did not calculate block size correctly")
 
 	extensionData1 := testutil.RandomBytes(100)
 	extensionName1 := graphsync.ExtensionName("AppleSauce/McGee")
@@ -72,7 +72,7 @@ func TestMessageBuilding(t *testing.T) {
 
 	response1, err := findResponseForRequestID(responses, requestID1)
 	require.NoError(t, err)
-	require.Equal(t, response1.Status(), graphsync.RequestCompletedPartial, "did not generate completed partial response")
+	require.Equal(t, graphsync.RequestCompletedPartial, response1.Status(), "did not generate completed partial response")
 
 	response1MetadataRaw, found := response1.Extension(graphsync.ExtensionMetadata)
 	require.True(t, found, "Metadata should be included in response")
@@ -90,7 +90,7 @@ func TestMessageBuilding(t *testing.T) {
 
 	response2, err := findResponseForRequestID(responses, requestID2)
 	require.NoError(t, err)
-	require.Equal(t, response2.Status(), graphsync.RequestCompletedFull, "did not generate completed full response")
+	require.Equal(t, graphsync.RequestCompletedFull, response2.Status(), "did not generate completed full response")
 
 	response2MetadataRaw, found := response2.Extension(graphsync.ExtensionMetadata)
 	require.True(t, found, "Metadata should be included in response")
@@ -104,7 +104,7 @@ func TestMessageBuilding(t *testing.T) {
 
 	response3, err := findResponseForRequestID(responses, requestID3)
 	require.NoError(t, err)
-	require.Equal(t, response3.Status(), graphsync.PartialResponse, "did not generate partial response")
+	require.Equal(t, graphsync.PartialResponse, response3.Status(), "did not generate partial response")
 
 	response3MetadataRaw, found := response3.Extension(graphsync.ExtensionMetadata)
 	require.True(t, found, "Metadata should be included in response")
@@ -121,9 +121,9 @@ func TestMessageBuilding(t *testing.T) {
 
 	response4, err := findResponseForRequestID(responses, requestID4)
 	require.NoError(t, err)
-	require.Equal(t, response4.Status(), graphsync.RequestCompletedFull, "did not generate completed full response")
+	require.Equal(t, graphsync.RequestCompletedFull, response4.Status(), "did not generate completed full response")
 
-	require.Equal(t, len(sentBlocks), len(blocks), "did not send all blocks")
+	require.Equal(t, len(blocks), len(sentBlocks), "did not send all blocks")
 
 	for _, block := range sentBlocks {
 		testutil.AssertContainsBlock(t, blocks, block)

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -157,8 +157,8 @@ func TestIncomingQuery(t *testing.T) {
 		k := sentResponse.link.(cidlink.Link)
 		blockIndex := testutil.IndexOf(blks, k.Cid)
 		require.NotEqual(t, blockIndex, -1, "sent incorrect link")
-		require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
-		require.Equal(t, sentResponse.requestID, requestID, "has incorrect response id")
+		require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
+		require.Equal(t, requestID, sentResponse.requestID, "has incorrect response id")
 	}
 }
 
@@ -194,8 +194,8 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	k := sentResponse.link.(cidlink.Link)
 	blockIndex := testutil.IndexOf(blks, k.Cid)
 	require.NotEqual(t, blockIndex, -1, "sent incorrect link")
-	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
-	require.Equal(t, sentResponse.requestID, requestID, "has incorrect response id")
+	require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
+	require.Equal(t, requestID, sentResponse.requestID, "has incorrect response id")
 
 	// send a cancellation
 	requests = []gsmsg.GraphSyncRequest{
@@ -211,8 +211,8 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	k = sentResponse.link.(cidlink.Link)
 	blockIndex = testutil.IndexOf(blks, k.Cid)
 	require.NotEqual(t, blockIndex, -1, "did not send correct link")
-	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
-	require.Equal(t, sentResponse.requestID, requestID, "incorrect response id")
+	require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
+	require.Equal(t, requestID, sentResponse.requestID, "incorrect response id")
 
 	// We should now be done
 	testutil.AssertDoesReceiveFirst(t, requestIDChan, "should complete request", ctx.Done(), sentResponses)
@@ -316,7 +316,7 @@ func TestValidationAndExtensions(t *testing.T) {
 			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 			var receivedExtension sentExtension
 			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
+			require.Equal(t, extensionResponse, receivedExtension.extension, "incorrect extension response sent")
 		})
 
 		t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
@@ -332,7 +332,7 @@ func TestValidationAndExtensions(t *testing.T) {
 			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
 			var receivedExtension sentExtension
 			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
+			require.Equal(t, extensionResponse, receivedExtension.extension, "incorrect extension response sent")
 		})
 	})
 
@@ -365,7 +365,7 @@ func TestValidationAndExtensions(t *testing.T) {
 			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 			var receivedExtension sentExtension
 			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
+			require.Equal(t, extensionResponse, receivedExtension.extension, "incorrect extension response sent")
 		})
 	})
 }

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -153,12 +153,12 @@ func TestIncomingQuery(t *testing.T) {
 	testutil.AssertDoesReceive(ctx, t, requestIDChan, "Should have completed request but didn't")
 	for i := 0; i < len(blks); i++ {
 		var sentResponse sentResponse
-		testutil.AssertReceive(ctx, t, sentResponses, &sentResponse, "sends responses")
+		testutil.AssertReceive(ctx, t, sentResponses, &sentResponse, "did not send responses")
 		k := sentResponse.link.(cidlink.Link)
 		blockIndex := testutil.IndexOf(blks, k.Cid)
-		require.NotEqual(t, blockIndex, -1, "sends correct link")
-		require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sends correct data")
-		require.Equal(t, sentResponse.requestID, requestID, "has correct response id")
+		require.NotEqual(t, blockIndex, -1, "sent incorrect link")
+		require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
+		require.Equal(t, sentResponse.requestID, requestID, "has incorrect response id")
 	}
 }
 
@@ -190,12 +190,12 @@ func TestCancellationQueryInProgress(t *testing.T) {
 
 	// read one block
 	var sentResponse sentResponse
-	testutil.AssertReceive(ctx, t, sentResponses, &sentResponse, "sends response")
+	testutil.AssertReceive(ctx, t, sentResponses, &sentResponse, "did not send response")
 	k := sentResponse.link.(cidlink.Link)
 	blockIndex := testutil.IndexOf(blks, k.Cid)
-	require.NotEqual(t, blockIndex, -1, "sents correct link")
-	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sends correct data")
-	require.Equal(t, sentResponse.requestID, requestID, "has correct response id")
+	require.NotEqual(t, blockIndex, -1, "sent incorrect link")
+	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
+	require.Equal(t, sentResponse.requestID, requestID, "has incorrect response id")
 
 	// send a cancellation
 	requests = []gsmsg.GraphSyncRequest{
@@ -210,12 +210,12 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	testutil.AssertReceiveFirst(t, sentResponses, &sentResponse, "should send one additional response", ctx.Done(), requestIDChan)
 	k = sentResponse.link.(cidlink.Link)
 	blockIndex = testutil.IndexOf(blks, k.Cid)
-	require.NotEqual(t, blockIndex, -1, "sends correct link")
-	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sends correct data")
-	require.Equal(t, sentResponse.requestID, requestID, "correct response id")
+	require.NotEqual(t, blockIndex, -1, "did not send correct link")
+	require.Equal(t, sentResponse.data, blks[blockIndex].RawData(), "sent incorrect data")
+	require.Equal(t, sentResponse.requestID, requestID, "incorrect response id")
 
 	// We should now be done
-	testutil.AssertDoesReceiveFirst(t, requestIDChan, "should complete", ctx.Done(), sentResponses)
+	testutil.AssertDoesReceiveFirst(t, requestIDChan, "should complete request", ctx.Done(), sentResponses)
 }
 
 func TestEarlyCancellation(t *testing.T) {
@@ -256,7 +256,7 @@ func TestEarlyCancellation(t *testing.T) {
 	queryQueue.popWait.Done()
 
 	// verify no responses processed
-	testutil.AssertDoesReceiveFirst(t, ctx.Done(), "no more responses processed", sentResponses, requestIDChan)
+	testutil.AssertDoesReceiveFirst(t, ctx.Done(), "should not process more responses", sentResponses, requestIDChan)
 }
 
 func TestValidationAndExtensions(t *testing.T) {
@@ -300,7 +300,7 @@ func TestValidationAndExtensions(t *testing.T) {
 			responseManager.Startup()
 			responseManager.ProcessRequests(ctx, p, requests)
 			var lastRequest completedRequest
-			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "Should complete request")
+			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 		})
 
@@ -312,11 +312,11 @@ func TestValidationAndExtensions(t *testing.T) {
 			})
 			responseManager.ProcessRequests(ctx, p, requests)
 			var lastRequest completedRequest
-			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "Should complete request")
+			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 			var receivedExtension sentExtension
-			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "Should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "corrent extension response should be sent")
+			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
+			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
 		})
 
 		t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
@@ -328,11 +328,11 @@ func TestValidationAndExtensions(t *testing.T) {
 			})
 			responseManager.ProcessRequests(ctx, p, requests)
 			var lastRequest completedRequest
-			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "Should complete request")
+			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
 			var receivedExtension sentExtension
-			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "Should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "corrent extension response should be sent")
+			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
+			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
 		})
 	})
 
@@ -348,7 +348,7 @@ func TestValidationAndExtensions(t *testing.T) {
 			responseManager.Startup()
 			responseManager.ProcessRequests(ctx, p, requests)
 			var lastRequest completedRequest
-			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "Should complete request")
+			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
 		})
 
@@ -361,11 +361,11 @@ func TestValidationAndExtensions(t *testing.T) {
 			})
 			responseManager.ProcessRequests(ctx, p, requests)
 			var lastRequest completedRequest
-			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "Should complete request")
+			testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 			var receivedExtension sentExtension
-			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "Should send extension response")
-			require.Equal(t, receivedExtension.extension, extensionResponse, "corrent extension response should be sent")
+			testutil.AssertReceive(ctx, t, sentExtensions, &receivedExtension, "should send extension response")
+			require.Equal(t, receivedExtension.extension, extensionResponse, "incorrect extension response sent")
 		})
 	})
 }

--- a/responsemanager/selectorvalidator/selectorvalidator_test.go
+++ b/responsemanager/selectorvalidator/selectorvalidator_test.go
@@ -22,9 +22,9 @@ func TestValidateSelector(t *testing.T) {
 		err := ValidateSelector(success, 100)
 		require.NoError(t, err, "valid selector should validate")
 		err = ValidateSelector(fail, 100)
-		require.Equal(t, err, ErrInvalidLimit, "selector should fail on invalid limit")
+		require.Equal(t, ErrInvalidLimit, err, "selector should fail on invalid limit")
 		err = ValidateSelector(failNone, 100)
-		require.Equal(t, err, ErrInvalidLimit, "selector should fail on no limit")
+		require.Equal(t, ErrInvalidLimit, err, "selector should fail on no limit")
 	}
 
 	t.Run("ExploreRecursive", func(t *testing.T) {

--- a/responsemanager/selectorvalidator/selectorvalidator_test.go
+++ b/responsemanager/selectorvalidator/selectorvalidator_test.go
@@ -20,11 +20,11 @@ func TestValidateSelector(t *testing.T) {
 
 	verifyOutcomes := func(t *testing.T, success ipld.Node, fail ipld.Node, failNone ipld.Node) {
 		err := ValidateSelector(success, 100)
-		require.NoError(t, err, "valid selector returned error")
+		require.NoError(t, err, "valid selector should validate")
 		err = ValidateSelector(fail, 100)
-		require.Equal(t, err, ErrInvalidLimit, "selector should have failed on invalid limit")
+		require.Equal(t, err, ErrInvalidLimit, "selector should fail on invalid limit")
 		err = ValidateSelector(failNone, 100)
-		require.Equal(t, err, ErrInvalidLimit, "selector should have failed on invalid limit")
+		require.Equal(t, err, ErrInvalidLimit, "selector should fail on no limit")
 	}
 
 	t.Run("ExploreRecursive", func(t *testing.T) {

--- a/responsemanager/selectorvalidator/selectorvalidator_test.go
+++ b/responsemanager/selectorvalidator/selectorvalidator_test.go
@@ -5,6 +5,7 @@ import (
 
 	ipld "github.com/ipld/go-ipld-prime"
 	ipldfree "github.com/ipld/go-ipld-prime/impl/free"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
@@ -19,17 +20,11 @@ func TestValidateSelector(t *testing.T) {
 
 	verifyOutcomes := func(t *testing.T, success ipld.Node, fail ipld.Node, failNone ipld.Node) {
 		err := ValidateSelector(success, 100)
-		if err != nil {
-			t.Fatal("valid selector returned error")
-		}
+		require.NoError(t, err, "valid selector returned error")
 		err = ValidateSelector(fail, 100)
-		if err != ErrInvalidLimit {
-			t.Fatal("selector should have failed on invalid limit")
-		}
+		require.Equal(t, err, ErrInvalidLimit, "selector should have failed on invalid limit")
 		err = ValidateSelector(failNone, 100)
-		if err != ErrInvalidLimit {
-			t.Fatal("selector should have failed on invalid limit")
-		}
+		require.Equal(t, err, ErrInvalidLimit, "selector should have failed on invalid limit")
 	}
 
 	t.Run("ExploreRecursive", func(t *testing.T) {

--- a/storeutil/storeutil_test.go
+++ b/storeutil/storeutil_test.go
@@ -10,6 +10,7 @@ import (
 	bstore "github.com/ipfs/go-ipfs-blockstore"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync/testutil"
 )
@@ -18,22 +19,14 @@ func TestLoader(t *testing.T) {
 	store := bstore.NewBlockstore(dss.MutexWrap(datastore.NewMapDatastore()))
 	blk := testutil.GenerateBlocksOfSize(1, 1000)[0]
 	err := store.Put(blk)
-	if err != nil {
-		t.Fatal("Unable to put block to store")
-	}
+	require.NoError(t, err, "Unable to put block to store")
 	loader := LoaderForBlockstore(store)
 	data, err := loader(cidlink.Link{Cid: blk.Cid()}, ipld.LinkContext{})
-	if err != nil {
-		t.Fatal("Unable to load block with loader")
-	}
+	require.NoError(t, err, "Unable to load block with loader")
 	bytes, err := ioutil.ReadAll(data)
-	if err != nil {
-		t.Fatal("Unable to read bytes from reader returned by loader")
-	}
+	require.NoError(t, err, "Unable to read bytes from reader returned by loader")
 	_, err = blocks.NewBlockWithCid(bytes, blk.Cid())
-	if err != nil {
-		t.Fatal("Did not return correct block with loader")
-	}
+	require.NoError(t, err, "Did not return correct block with loader")
 }
 
 func TestStorer(t *testing.T) {
@@ -41,19 +34,11 @@ func TestStorer(t *testing.T) {
 	blk := testutil.GenerateBlocksOfSize(1, 1000)[0]
 	storer := StorerForBlockstore(store)
 	buffer, commit, err := storer(ipld.LinkContext{})
-	if err != nil {
-		t.Fatal("Unable to setup buffer")
-	}
+	require.NoError(t, err, "Unable to setup buffer")
 	_, err = buffer.Write(blk.RawData())
-	if err != nil {
-		t.Fatal("Unable to write data to buffer")
-	}
+	require.NoError(t, err, "Unable to write data to buffer")
 	err = commit(cidlink.Link{Cid: blk.Cid()})
-	if err != nil {
-		t.Fatal("Unable to commit with storer function")
-	}
+	require.NoError(t, err, "Unable to commit with storer function")
 	_, err = store.Get(blk.Cid())
-	if err != nil {
-		t.Fatal("Block not written to store")
-	}
+	require.NoError(t, err, "Block not written to store")
 }

--- a/testutil/channelassertions.go
+++ b/testutil/channelassertions.go
@@ -1,0 +1,112 @@
+package testutil
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// AssertReceive verifies that a channel returns a value before the given context closes, and writes into
+// into out, which should be a pointer to the value type
+func AssertReceive(ctx context.Context, t *testing.T, channel interface{}, out interface{}, errorMessage string) {
+	AssertReceiveFirst(t, channel, out, errorMessage, ctx.Done())
+}
+
+// AssertReceiveFirst verifies that a channel returns a value on the specified channel before the other channels,
+// and writes the value into out, which should be a pointer to the value type
+func AssertReceiveFirst(t *testing.T, channel interface{}, out interface{}, errorMessage string, incorrectChannels ...interface{}) {
+	chanValue := reflect.ValueOf(channel)
+	outValue := reflect.ValueOf(out)
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes a channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "passes a receiving channel")
+	require.Equal(t, outValue.Kind(), reflect.Ptr, "passes a pointer for out value")
+	require.True(t, chanValue.Type().Elem().AssignableTo(outValue.Elem().Type()), "out value is correct type")
+	var incorrectSelectCases []reflect.SelectCase
+	for _, incorrectChannel := range incorrectChannels {
+		incorrectChanValue := reflect.ValueOf(incorrectChannel)
+		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "passes a channel to read from")
+		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "passes a receiving channel")
+		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: incorrectChanValue,
+		})
+	}
+	chosen, recv, recvOk := reflect.Select(append([]reflect.SelectCase{
+		{
+			Dir:  reflect.SelectRecv,
+			Chan: chanValue,
+		},
+	}, incorrectSelectCases...))
+	require.Equal(t, chosen, 0, errorMessage)
+	require.True(t, recvOk, errorMessage)
+	outValue.Elem().Set(recv)
+}
+
+// AssertDoesReceive verifies that a channel returns some value before the given context closes
+func AssertDoesReceive(ctx context.Context, t *testing.T, channel interface{}, errorMessage string) {
+	AssertDoesReceiveFirst(t, channel, errorMessage, ctx.Done())
+}
+
+// AssertDoesReceiveFirst asserts that the given channel receives a value before any of the other channels specified
+func AssertDoesReceiveFirst(t *testing.T, channel interface{}, errorMessage string, incorrectChannels ...interface{}) {
+	chanValue := reflect.ValueOf(channel)
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes a channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "passes a receiving channel")
+	var incorrectSelectCases []reflect.SelectCase
+	for _, incorrectChannel := range incorrectChannels {
+		incorrectChanValue := reflect.ValueOf(incorrectChannel)
+		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "passes channel to read from")
+		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "passes a receiving channel")
+		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
+			Dir:  reflect.SelectRecv,
+			Chan: incorrectChanValue,
+		})
+	}
+	chosen, _, _ := reflect.Select(append([]reflect.SelectCase{
+		{
+			Dir:  reflect.SelectRecv,
+			Chan: chanValue,
+		},
+	}, incorrectSelectCases...))
+	require.Equal(t, chosen, 0, errorMessage)
+}
+
+// AssertChannelEmpty verifies that a channel has no value currently
+func AssertChannelEmpty(t *testing.T, channel interface{}, errorMessage string) {
+	chanValue := reflect.ValueOf(channel)
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "did not pass channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "did not pass a receiving channel")
+	chosen, _, _ := reflect.Select([]reflect.SelectCase{
+		{
+			Dir:  reflect.SelectRecv,
+			Chan: chanValue,
+		},
+		{
+			Dir: reflect.SelectDefault,
+		},
+	})
+	require.NotEqual(t, chosen, 0, errorMessage)
+}
+
+// AssertSends attempts to send the given input value to the given channel before the given context closes
+func AssertSends(ctx context.Context, t *testing.T, channel interface{}, in interface{}, errorMessage string) {
+	chanValue := reflect.ValueOf(channel)
+	inValue := reflect.ValueOf(in)
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes channel to send to")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.SendDir}, chanValue.Type().ChanDir(), "passes a sending channel")
+	require.True(t, inValue.Type().AssignableTo(chanValue.Type().Elem()), "in value is correct type")
+	chosen, _, _ := reflect.Select([]reflect.SelectCase{
+		{
+			Dir:  reflect.SelectSend,
+			Chan: chanValue,
+			Send: inValue,
+		},
+		{
+			Dir:  reflect.SelectRecv,
+			Chan: reflect.ValueOf(ctx.Done()),
+		},
+	})
+	require.Equal(t, chosen, 0, errorMessage)
+}

--- a/testutil/channelassertions.go
+++ b/testutil/channelassertions.go
@@ -19,15 +19,15 @@ func AssertReceive(ctx context.Context, t *testing.T, channel interface{}, out i
 func AssertReceiveFirst(t *testing.T, channel interface{}, out interface{}, errorMessage string, incorrectChannels ...interface{}) {
 	chanValue := reflect.ValueOf(channel)
 	outValue := reflect.ValueOf(out)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes a channel to read from")
-	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "passes a receiving channel")
-	require.Equal(t, outValue.Kind(), reflect.Ptr, "passes a pointer for out value")
-	require.True(t, chanValue.Type().Elem().AssignableTo(outValue.Elem().Type()), "out value is correct type")
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
+	require.Equal(t, outValue.Kind(), reflect.Ptr, "incorrect argument: should pass a pointer for out value")
+	require.True(t, chanValue.Type().Elem().AssignableTo(outValue.Elem().Type()), "incorrect argument: out value is incorrect type")
 	var incorrectSelectCases []reflect.SelectCase
 	for _, incorrectChannel := range incorrectChannels {
 		incorrectChanValue := reflect.ValueOf(incorrectChannel)
-		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "passes a channel to read from")
-		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "passes a receiving channel")
+		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
 			Dir:  reflect.SelectRecv,
 			Chan: incorrectChanValue,
@@ -52,13 +52,13 @@ func AssertDoesReceive(ctx context.Context, t *testing.T, channel interface{}, e
 // AssertDoesReceiveFirst asserts that the given channel receives a value before any of the other channels specified
 func AssertDoesReceiveFirst(t *testing.T, channel interface{}, errorMessage string, incorrectChannels ...interface{}) {
 	chanValue := reflect.ValueOf(channel)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes a channel to read from")
-	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "passes a receiving channel")
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 	var incorrectSelectCases []reflect.SelectCase
 	for _, incorrectChannel := range incorrectChannels {
 		incorrectChanValue := reflect.ValueOf(incorrectChannel)
-		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "passes channel to read from")
-		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "passes a receiving channel")
+		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
 			Dir:  reflect.SelectRecv,
 			Chan: incorrectChanValue,
@@ -76,8 +76,8 @@ func AssertDoesReceiveFirst(t *testing.T, channel interface{}, errorMessage stri
 // AssertChannelEmpty verifies that a channel has no value currently
 func AssertChannelEmpty(t *testing.T, channel interface{}, errorMessage string) {
 	chanValue := reflect.ValueOf(channel)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "did not pass channel to read from")
-	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "did not pass a receiving channel")
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 	chosen, _, _ := reflect.Select([]reflect.SelectCase{
 		{
 			Dir:  reflect.SelectRecv,
@@ -94,9 +94,9 @@ func AssertChannelEmpty(t *testing.T, channel interface{}, errorMessage string) 
 func AssertSends(ctx context.Context, t *testing.T, channel interface{}, in interface{}, errorMessage string) {
 	chanValue := reflect.ValueOf(channel)
 	inValue := reflect.ValueOf(in)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "passes channel to send to")
-	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.SendDir}, chanValue.Type().ChanDir(), "passes a sending channel")
-	require.True(t, inValue.Type().AssignableTo(chanValue.Type().Elem()), "in value is correct type")
+	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to send to")
+	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.SendDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a sending channel")
+	require.True(t, inValue.Type().AssignableTo(chanValue.Type().Elem()), "incorrect argument: in value is incorrect type")
 	chosen, _, _ := reflect.Select([]reflect.SelectCase{
 		{
 			Dir:  reflect.SelectSend,

--- a/testutil/channelassertions.go
+++ b/testutil/channelassertions.go
@@ -19,14 +19,14 @@ func AssertReceive(ctx context.Context, t *testing.T, channel interface{}, out i
 func AssertReceiveFirst(t *testing.T, channel interface{}, out interface{}, errorMessage string, incorrectChannels ...interface{}) {
 	chanValue := reflect.ValueOf(channel)
 	outValue := reflect.ValueOf(out)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
 	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
-	require.Equal(t, outValue.Kind(), reflect.Ptr, "incorrect argument: should pass a pointer for out value")
+	require.Equal(t, reflect.Ptr, outValue.Kind(), "incorrect argument: should pass a pointer for out value")
 	require.True(t, chanValue.Type().Elem().AssignableTo(outValue.Elem().Type()), "incorrect argument: out value is incorrect type")
 	var incorrectSelectCases []reflect.SelectCase
 	for _, incorrectChannel := range incorrectChannels {
 		incorrectChanValue := reflect.ValueOf(incorrectChannel)
-		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+		require.Equal(t, reflect.Chan, incorrectChanValue.Kind(), "incorrect argument: should pass channel to read from")
 		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
 			Dir:  reflect.SelectRecv,
@@ -39,7 +39,7 @@ func AssertReceiveFirst(t *testing.T, channel interface{}, out interface{}, erro
 			Chan: chanValue,
 		},
 	}, incorrectSelectCases...))
-	require.Equal(t, chosen, 0, errorMessage)
+	require.Equal(t, 0, chosen, errorMessage)
 	require.True(t, recvOk, errorMessage)
 	outValue.Elem().Set(recv)
 }
@@ -52,12 +52,12 @@ func AssertDoesReceive(ctx context.Context, t *testing.T, channel interface{}, e
 // AssertDoesReceiveFirst asserts that the given channel receives a value before any of the other channels specified
 func AssertDoesReceiveFirst(t *testing.T, channel interface{}, errorMessage string, incorrectChannels ...interface{}) {
 	chanValue := reflect.ValueOf(channel)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
 	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 	var incorrectSelectCases []reflect.SelectCase
 	for _, incorrectChannel := range incorrectChannels {
 		incorrectChanValue := reflect.ValueOf(incorrectChannel)
-		require.Equal(t, incorrectChanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+		require.Equal(t, reflect.Chan, incorrectChanValue.Kind(), "incorrect argument: should pass channel to read from")
 		require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, incorrectChanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 		incorrectSelectCases = append(incorrectSelectCases, reflect.SelectCase{
 			Dir:  reflect.SelectRecv,
@@ -70,13 +70,13 @@ func AssertDoesReceiveFirst(t *testing.T, channel interface{}, errorMessage stri
 			Chan: chanValue,
 		},
 	}, incorrectSelectCases...))
-	require.Equal(t, chosen, 0, errorMessage)
+	require.Equal(t, 0, chosen, errorMessage)
 }
 
 // AssertChannelEmpty verifies that a channel has no value currently
 func AssertChannelEmpty(t *testing.T, channel interface{}, errorMessage string) {
 	chanValue := reflect.ValueOf(channel)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to read from")
+	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
 	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
 	chosen, _, _ := reflect.Select([]reflect.SelectCase{
 		{
@@ -94,7 +94,7 @@ func AssertChannelEmpty(t *testing.T, channel interface{}, errorMessage string) 
 func AssertSends(ctx context.Context, t *testing.T, channel interface{}, in interface{}, errorMessage string) {
 	chanValue := reflect.ValueOf(channel)
 	inValue := reflect.ValueOf(in)
-	require.Equal(t, chanValue.Kind(), reflect.Chan, "incorrect argument: should pass channel to send to")
+	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to send to")
 	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.SendDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a sending channel")
 	require.True(t, inValue.Type().AssignableTo(chanValue.Type().Elem()), "incorrect argument: in value is incorrect type")
 	chosen, _, _ := reflect.Select([]reflect.SelectCase{
@@ -108,5 +108,5 @@ func AssertSends(ctx context.Context, t *testing.T, channel interface{}, in inte
 			Chan: reflect.ValueOf(ctx.Done()),
 		},
 	})
-	require.Equal(t, chosen, 0, errorMessage)
+	require.Equal(t, 0, chosen, errorMessage)
 }

--- a/testutil/testchain.go
+++ b/testutil/testchain.go
@@ -135,7 +135,7 @@ func (tbc *TestBlockChain) checkResponses(responses []graphsync.ResponseProgress
 		}
 	}
 	for i, response := range responses {
-		require.Equal(tbc.t, response.Path.String(), expectedPath, "response has correct path")
+		require.Equal(tbc.t, expectedPath, response.Path.String(), "response has correct path")
 		if i%2 == 0 {
 			if expectedPath == "" {
 				expectedPath = "Parents"

--- a/testutil/testnodes_test.go
+++ b/testutil/testnodes_test.go
@@ -10,11 +10,11 @@ import (
 func TestFailParseSelectorSpec(t *testing.T) {
 	spec := NewUnparsableSelectorSpec()
 	_, err := ipldutil.ParseSelector(spec)
-	require.NotNil(t, err, "Spec should not decompose to node and selector")
+	require.Error(t, err, "unparsable selector should not parse")
 }
 
 func TestFailEncodingSelectorSpec(t *testing.T) {
 	spec := NewUnencodableSelectorSpec()
 	_, err := ipldutil.EncodeNode(spec)
-	require.NotNil(t, err, "Spec should not be encodable")
+	require.Error(t, err, "unencodable selector should not encode")
 }

--- a/testutil/testnodes_test.go
+++ b/testutil/testnodes_test.go
@@ -4,20 +4,17 @@ import (
 	"testing"
 
 	"github.com/ipfs/go-graphsync/ipldutil"
+	"github.com/stretchr/testify/require"
 )
 
 func TestFailParseSelectorSpec(t *testing.T) {
 	spec := NewUnparsableSelectorSpec()
 	_, err := ipldutil.ParseSelector(spec)
-	if err == nil {
-		t.Fatal("Spec should not decompose to node and selector")
-	}
+	require.NotNil(t, err, "Spec should not decompose to node and selector")
 }
 
 func TestFailEncodingSelectorSpec(t *testing.T) {
 	spec := NewUnencodableSelectorSpec()
 	_, err := ipldutil.EncodeNode(spec)
-	if err == nil {
-		t.Fatal("Spec should not be encodable")
-	}
+	require.NotNil(t, err, "Spec should not be encodable")
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ipfs/go-bitswap/testutil"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
@@ -79,12 +78,12 @@ func ContainsPeer(peers []peer.ID, p peer.ID) bool {
 
 // AssertContainsPeer will fail a test if the peer is not in the given peer list
 func AssertContainsPeer(t *testing.T, peers []peer.ID, p peer.ID) {
-	require.True(t, testutil.ContainsPeer(peers, p), "given peer should be in list")
+	require.True(t, ContainsPeer(peers, p), "given peer should be in list")
 }
 
 // RefuteContainsPeer will fail a test if the peer is in the given peer list
 func RefuteContainsPeer(t *testing.T, peers []peer.ID, p peer.ID) {
-	require.False(t, testutil.ContainsPeer(peers, p), "given peer should not be in list")
+	require.False(t, ContainsPeer(peers, p), "given peer should not be in list")
 }
 
 // IndexOf returns the index of a given cid in an array of blocks
@@ -104,12 +103,12 @@ func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
 
 // AssertContainsBlock will fail a test if the block is not in the given block list
 func AssertContainsBlock(t *testing.T, blks []blocks.Block, block blocks.Block) {
-	require.True(t, testutil.ContainsBlock(blks, block), "given block should be in list")
+	require.True(t, ContainsBlock(blks, block), "given block should be in list")
 }
 
 // RefuteContainsBlock will fail a test if the block is in the given block list
 func RefuteContainsBlock(t *testing.T, blks []blocks.Block, block blocks.Block) {
-	require.False(t, testutil.ContainsBlock(blks, block), "given block should not be in list")
+	require.False(t, ContainsBlock(blks, block), "given block should not be in list")
 }
 
 // CollectResponses is just a utility to convert a graphsync response progress

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/ipfs/go-bitswap/testutil"
 	blocks "github.com/ipfs/go-block-format"
 	cid "github.com/ipfs/go-cid"
 	"github.com/ipfs/go-graphsync"
@@ -12,6 +13,7 @@ import (
 	util "github.com/ipfs/go-ipfs-util"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
 
 	random "github.com/jbenet/go-random"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -75,6 +77,16 @@ func ContainsPeer(peers []peer.ID, p peer.ID) bool {
 	return false
 }
 
+// AssertContainsPeer will fail a test if the peer is not in the given peer list
+func AssertContainsPeer(t *testing.T, peers []peer.ID, p peer.ID) {
+	require.True(t, testutil.ContainsPeer(peers, p), "given peer should be in list")
+}
+
+// RefuteContainsPeer will fail a test if the peer is in the given peer list
+func RefuteContainsPeer(t *testing.T, peers []peer.ID, p peer.ID) {
+	require.False(t, testutil.ContainsPeer(peers, p), "given peer should not be in list")
+}
+
 // IndexOf returns the index of a given cid in an array of blocks
 func IndexOf(blks []blocks.Block, c cid.Cid) int {
 	for i, n := range blks {
@@ -88,6 +100,16 @@ func IndexOf(blks []blocks.Block, c cid.Cid) int {
 // ContainsBlock returns true if a block is found n a list of blocks
 func ContainsBlock(blks []blocks.Block, block blocks.Block) bool {
 	return IndexOf(blks, block.Cid()) != -1
+}
+
+// AssertContainsBlock will fail a test if the block is not in the given block list
+func AssertContainsBlock(t *testing.T, blks []blocks.Block, block blocks.Block) {
+	require.True(t, testutil.ContainsBlock(blks, block), "given block should be in list")
+}
+
+// RefuteContainsBlock will fail a test if the block is in the given block list
+func RefuteContainsBlock(t *testing.T, blks []blocks.Block, block blocks.Block) {
+	require.False(t, testutil.ContainsBlock(blks, block), "given block should not be in list")
 }
 
 // CollectResponses is just a utility to convert a graphsync response progress
@@ -143,9 +165,7 @@ func ReadNResponses(ctx context.Context, t *testing.T, responseChan <-chan graph
 func VerifySingleTerminalError(ctx context.Context, t *testing.T, errChan <-chan error) {
 	select {
 	case err := <-errChan:
-		if err == nil {
-			t.Fatal("should have sent a erminal error but did not")
-		}
+		require.NotNil(t, err, "should have sent a erminal error but did not")
 	case <-ctx.Done():
 		t.Fatal("no errors sent")
 	}


### PR DESCRIPTION
# Goals

Graphsync is big and has lots of tests. Those tests are not very easy to reach particularly because they involve a lot of tests on channels. This PR introduces Testify and a few utility functions to make the tests vastly more readable and clearer in intent.

# Implementation

- Introduce testify, replace standard if -> t.Fatal pattern -- means test that correct conditions are met, rather than that the opposite (incorrect conditions trigger an error) -- makes for more clear, readable code
- Clean up error messages
- Refactor a few tests to switch to simpler table test form, BDD
- Introduce channel assertion utilities. Often we are testing for the fact that a value comes in on a channel before context cancellation, or one channel produces a value before others. We often need to read the value in the process. This produces a confusing pattern of select statements throughout the tests. While the channel assertions have to use some reflect fanciness internally to work for generic parameters (but with some type checking), it makes for vastly more readable assertions in the tests, making the intent clearer and the test way more concise
