### PR TITLE
Option to Reject requests by default

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -154,6 +154,9 @@ type OnRequestReceivedHook func(p peer.ID, request RequestData, hookActions Requ
 // If it returns an error processing is halted and the original request is cancelled.
 type OnResponseReceivedHook func(p peer.ID, responseData ResponseData) error
 
+// UnregisterHookFunc is a function call to unregister a hook that was previously registered
+type UnregisterHookFunc func()
+
 // GraphExchange is a protocol that can exchange IPLD graphs based on a selector
 type GraphExchange interface {
 	// Request initiates a new GraphSync request to the given peer using the given selector spec.
@@ -163,8 +166,8 @@ type GraphExchange interface {
 	// If overrideDefaultValidation is set to true, then if the hook does not error,
 	// it is considered to have "validated" the request -- and that validation supersedes
 	// the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
-	RegisterRequestReceivedHook(hook OnRequestReceivedHook) error
+	RegisterRequestReceivedHook(hook OnRequestReceivedHook) UnregisterHookFunc
 
 	// RegisterResponseReceivedHook adds a hook that runs when a response is received
-	RegisterResponseReceivedHook(OnResponseReceivedHook) error
+	RegisterResponseReceivedHook(OnResponseReceivedHook) UnregisterHookFunc
 }

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -99,7 +99,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	var receivedRequestData []byte
 	// initialize graphsync on second node to response to requests
 	gsnet := td.GraphSyncHost2()
-	err := gsnet.RegisterRequestReceivedHook(
+	gsnet.RegisterRequestReceivedHook(
 		func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 			var has bool
 			receivedRequestData, has = requestData.Extension(td.extensionName)
@@ -107,7 +107,6 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 			hookActions.SendExtensionData(td.extensionResponse)
 		},
 	)
-	require.NoError(t, err, "error registering extension")
 
 	blockChainLength := 100
 	blockChain := testutil.SetupBlockChain(ctx, t, td.loader2, td.storer2, 100, blockChainLength)
@@ -117,7 +116,7 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	message := gsmsg.New()
 	message.AddRequest(gsmsg.NewRequest(requestID, blockChain.TipLink.(cidlink.Link).Cid, blockChain.Selector(), graphsync.Priority(math.MaxInt32), td.extension))
 	// send request across network
-	err = td.gsnet1.SendMessage(ctx, td.host2.ID(), message)
+	err := td.gsnet1.SendMessage(ctx, td.host2.ID(), message)
 	require.NoError(t, err)
 	// read the values sent back to requestor
 	var received gsmsg.GraphSyncMessage
@@ -170,7 +169,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	var receivedResponseData []byte
 	var receivedRequestData []byte
 
-	err := requestor.RegisterResponseReceivedHook(
+	requestor.RegisterResponseReceivedHook(
 		func(p peer.ID, responseData graphsync.ResponseData) error {
 			data, has := responseData.Extension(td.extensionName)
 			if has {
@@ -178,9 +177,8 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			}
 			return nil
 		})
-	require.NoError(t, err, "Error setting up extension")
 
-	err = responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+	responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 		var has bool
 		receivedRequestData, has = requestData.Extension(td.extensionName)
 		if !has {
@@ -189,7 +187,6 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			hookActions.SendExtensionData(td.extensionResponse)
 		}
 	})
-	require.NoError(t, err, "Error setting up extension")
 
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
@@ -342,15 +339,14 @@ func TestUnixFSFetch(t *testing.T) {
 	requestor := New(ctx, td.gsnet1, loader1, storer1)
 	responder := New(ctx, td.gsnet2, loader2, storer2)
 	extensionName := graphsync.ExtensionName("Free for all")
-	err = responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+	responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
 		hookActions.ValidateRequest()
 		hookActions.SendExtensionData(graphsync.ExtensionData{
 			Name: extensionName,
 			Data: nil,
 		})
 	})
-	require.NoError(t, err)
-	
+
 	// make a go-ipld-prime link for the root UnixFS node
 	clink := cidlink.Link{Cid: nd.Cid()}
 

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -234,6 +234,7 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 	for _, requestHook := range rm.requestHooks {
 		requestHook.hook(p, request, ha)
 		if ha.err != nil {
+			rm.requestHooksLk.RUnlock()
 			return
 		}
 	}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -2,6 +2,7 @@ package responsemanager
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/ipfs/go-graphsync"
@@ -9,7 +10,6 @@ import (
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/responsemanager/loader"
 	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
-	"github.com/ipfs/go-graphsync/responsemanager/selectorvalidator"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
@@ -19,7 +19,6 @@ import (
 
 const (
 	maxInProcessRequests = 6
-	maxRecursionDepth    = 100
 	thawSpeed            = time.Millisecond * 100
 )
 
@@ -40,6 +39,7 @@ type responseTaskData struct {
 }
 
 type requestHook struct {
+	key  uint64
 	hook graphsync.OnRequestReceivedHook
 }
 
@@ -75,6 +75,8 @@ type ResponseManager struct {
 	workSignal          chan struct{}
 	ticker              *time.Ticker
 	inProgressResponses map[responseKey]inProgressResponseStatus
+	requestHooksLk      sync.RWMutex
+	requestHookNextKey  uint64
 	requestHooks        []requestHook
 }
 
@@ -113,10 +115,21 @@ func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, reque
 }
 
 // RegisterHook registers an extension to process new incoming requests
-func (rm *ResponseManager) RegisterHook(hook graphsync.OnRequestReceivedHook) {
-	select {
-	case rm.messages <- &requestHook{hook}:
-	case <-rm.ctx.Done():
+func (rm *ResponseManager) RegisterHook(hook graphsync.OnRequestReceivedHook) graphsync.UnregisterHookFunc {
+	rm.requestHooksLk.Lock()
+	rh := requestHook{rm.requestHookNextKey, hook}
+	rm.requestHookNextKey++
+	rm.requestHooks = append(rm.requestHooks, rh)
+	rm.requestHooksLk.Unlock()
+	return func() {
+		rm.requestHooksLk.Lock()
+		defer rm.requestHooksLk.Unlock()
+		for i, matchHook := range rm.requestHooks {
+			if rh.key == matchHook.key {
+				rm.requestHooks = append(rm.requestHooks[:i], rm.requestHooks[i+1:]...)
+				return
+			}
+		}
 	}
 }
 
@@ -217,18 +230,17 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 	peerResponseSender := rm.peerManager.SenderForPeer(p)
 	selectorSpec := request.Selector()
 	ha := &hookActions{false, request.ID(), peerResponseSender, nil}
+	rm.requestHooksLk.RLock()
 	for _, requestHook := range rm.requestHooks {
 		requestHook.hook(p, request, ha)
 		if ha.err != nil {
 			return
 		}
 	}
+	rm.requestHooksLk.RUnlock()
 	if !ha.isValidated {
-		err := selectorvalidator.ValidateSelector(selectorSpec, maxRecursionDepth)
-		if err != nil {
-			peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
-			return
-		}
+		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
+		return
 	}
 	selector, err := ipldutil.ParseSelector(selectorSpec)
 	if err != nil {
@@ -302,10 +314,6 @@ func (prm *processRequestMessage) handle(rm *ResponseManager) {
 			}
 		}
 	}
-}
-
-func (rh *requestHook) handle(rm *ResponseManager) {
-	rm.requestHooks = append(rm.requestHooks, *rh)
 }
 
 func (rdr *responseDataRequest) handle(rm *ResponseManager) {

--- a/selectorvalidator/selectorvalidator_test.go
+++ b/selectorvalidator/selectorvalidator_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 )
 
-func TestValidateSelector(t *testing.T) {
+func TestValidateMaxRecusionDepth(t *testing.T) {
 	ssb := builder.NewSelectorSpecBuilder(ipldfree.NodeBuilder())
 
 	successBase := ssb.ExploreRecursive(selector.RecursionLimitDepth(80), ssb.ExploreRecursiveEdge())
@@ -19,11 +19,11 @@ func TestValidateSelector(t *testing.T) {
 	failNoneBase := ssb.ExploreRecursive(selector.RecursionLimitNone(), ssb.ExploreRecursiveEdge())
 
 	verifyOutcomes := func(t *testing.T, success ipld.Node, fail ipld.Node, failNone ipld.Node) {
-		err := ValidateSelector(success, 100)
+		err := ValidateMaxRecursionDepth(success, 100)
 		require.NoError(t, err, "valid selector should validate")
-		err = ValidateSelector(fail, 100)
+		err = ValidateMaxRecursionDepth(fail, 100)
 		require.Equal(t, ErrInvalidLimit, err, "selector should fail on invalid limit")
-		err = ValidateSelector(failNone, 100)
+		err = ValidateMaxRecursionDepth(failNone, 100)
 		require.Equal(t, ErrInvalidLimit, err, "selector should fail on no limit")
 	}
 


### PR DESCRIPTION
# Goals

Some graphsync operators may want to operate a graphsync node which is more locked down, rejecting all requests by default, and only authorizing requests through hooks.

# Implementation

- modify hook registrations to return an unregister function (so hooks can be removed)
- setup default validation as simply a validating hook
- add a configurable functional options pattern to graphsync constructor
- add an option to reject all requests by default -- just unregisters default validation
- fix a potential race condition with list of request hooks in ResponseManager