### PR TITLE
Support custom loader and nodebuilderchooser through hooks

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/libp2p/go-libp2p-core/peer"
 )
 
@@ -138,6 +139,8 @@ type ResponseData interface {
 // behavior for the response
 type RequestReceivedHookActions interface {
 	SendExtensionData(ExtensionData)
+	UseLoader(ipld.Loader)
+	UseNodeBuilderChooser(traversal.NodeBuilderChooser)
 	TerminateWithError(error)
 	ValidateRequest()
 }

--- a/ipldutil/ipldutil.go
+++ b/ipldutil/ipldutil.go
@@ -28,8 +28,11 @@ var (
 	})
 )
 
-func Traverse(ctx context.Context, loader ipld.Loader, root ipld.Link, s selector.Selector, fn traversal.AdvVisitFn) error {
-	builder := defaultChooser(root, ipld.LinkContext{})
+func Traverse(ctx context.Context, loader ipld.Loader, chooser traversal.NodeBuilderChooser, root ipld.Link, s selector.Selector, fn traversal.AdvVisitFn) error {
+	if chooser == nil {
+		chooser = defaultChooser
+	}
+	builder := chooser(root, ipld.LinkContext{})
 	node, err := root.Load(ctx, ipld.LinkContext{}, builder, loader)
 	if err != nil {
 		return err
@@ -38,7 +41,7 @@ func Traverse(ctx context.Context, loader ipld.Loader, root ipld.Link, s selecto
 		Cfg: &traversal.Config{
 			Ctx:                    ctx,
 			LinkLoader:             loader,
-			LinkNodeBuilderChooser: defaultChooser,
+			LinkNodeBuilderChooser: chooser,
 		},
 	}.WalkAdv(node, s, fn)
 }

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -425,7 +425,7 @@ func (rm *RequestManager) executeTraversal(
 	loaderFn := loader.WrapAsyncLoader(ctx, rm.asyncLoader.AsyncLoad, requestID, inProgressErr)
 	visitor := visitToChannel(ctx, inProgressChan)
 	go func() {
-		_ = ipldutil.Traverse(ctx, loaderFn, root, selector, visitor)
+		_ = ipldutil.Traverse(ctx, loaderFn, nil, root, selector, visitor)
 		select {
 		case networkError := <-networkErrorChan:
 			select {

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -250,7 +250,7 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 	}
 	rootLink := cidlink.Link{Cid: request.Root()}
 	wrappedLoader := loader.WrapLoader(ctx, rm.loader, request.ID(), peerResponseSender)
-	err = ipldutil.Traverse(ctx, wrappedLoader, rootLink, selector, noopVisitor)
+	err = ipldutil.Traverse(ctx, wrappedLoader, nil, rootLink, selector, noopVisitor)
 	if err != nil {
 		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
 		return

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -209,6 +209,8 @@ type hookActions struct {
 	requestID          graphsync.RequestID
 	peerResponseSender peerresponsemanager.PeerResponseSender
 	err                error
+	loader             ipld.Loader
+	chooser            traversal.NodeBuilderChooser
 }
 
 func (ha *hookActions) SendExtensionData(ext graphsync.ExtensionData) {
@@ -224,12 +226,20 @@ func (ha *hookActions) ValidateRequest() {
 	ha.isValidated = true
 }
 
+func (ha *hookActions) UseLoader(loader ipld.Loader) {
+	ha.loader = loader
+}
+
+func (ha *hookActions) UseNodeBuilderChooser(chooser traversal.NodeBuilderChooser) {
+	ha.chooser = chooser
+}
+
 func (rm *ResponseManager) executeQuery(ctx context.Context,
 	p peer.ID,
 	request gsmsg.GraphSyncRequest) {
 	peerResponseSender := rm.peerManager.SenderForPeer(p)
 	selectorSpec := request.Selector()
-	ha := &hookActions{false, request.ID(), peerResponseSender, nil}
+	ha := &hookActions{false, request.ID(), peerResponseSender, nil, rm.loader, nil}
 	rm.requestHooksLk.RLock()
 	for _, requestHook := range rm.requestHooks {
 		requestHook.hook(p, request, ha)
@@ -249,8 +259,8 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 		return
 	}
 	rootLink := cidlink.Link{Cid: request.Root()}
-	wrappedLoader := loader.WrapLoader(ctx, rm.loader, request.ID(), peerResponseSender)
-	err = ipldutil.Traverse(ctx, wrappedLoader, nil, rootLink, selector, noopVisitor)
+	wrappedLoader := loader.WrapLoader(ctx, ha.loader, request.ID(), peerResponseSender)
+	err = ipldutil.Traverse(ctx, wrappedLoader, ha.chooser, rootLink, selector, noopVisitor)
 	if err != nil {
 		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
 		return


### PR DESCRIPTION
# Goals

When extensions are present, we may want the ability to use a different blockstore, and a specialized IPLD node representation for our nodes. For example, in Filecoin, when serving chain syncing requests, we want to be able to load from the chain store as opposed to the blockstore we use for moving around pieces, and for speed, we may want to use an optimized representation fo blocks for speed.

# Implementation

- add passing a nodebuilderchooser to ipldutil.Traverse. If the parameter is nil, go back to the old chooser
- add setting loader and chooser on request hook actions

Note: this is the first of two tickets -- the second will be adding hooks to do this on the other side for outgoing requests.