### PR TITLE
Outgoing Request Hooks, swapping persistence layers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,3 @@
+run:
+  skip-files:
+    - testutil/chaintypes/testchain_gen.go

--- a/graphsync.go
+++ b/graphsync.go
@@ -139,7 +139,7 @@ type ResponseData interface {
 // behavior for the response
 type IncomingRequestHookActions interface {
 	SendExtensionData(ExtensionData)
-	UseLoader(ipld.Loader)
+	UsePersistenceOption(name string)
 	UseNodeBuilderChooser(traversal.NodeBuilderChooser)
 	TerminateWithError(error)
 	ValidateRequest()
@@ -148,8 +148,7 @@ type IncomingRequestHookActions interface {
 // OutgoingRequestHookActions are actions that an outgoing request hook can take
 // to change the execution of this request
 type OutgoingRequestHookActions interface {
-	UseLoader(ipld.Loader)
-	UseStorer(ipld.Storer)
+	UsePersistenceOption(name string)
 	UseNodeBuilderChooser(traversal.NodeBuilderChooser)
 }
 
@@ -175,6 +174,9 @@ type UnregisterHookFunc func()
 type GraphExchange interface {
 	// Request initiates a new GraphSync request to the given peer using the given selector spec.
 	Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node, extensions ...ExtensionData) (<-chan ResponseProgress, <-chan error)
+
+	// RegisterPersistenceOption registers an alternate loader/storer combo that can be substituted for the default
+	RegisterPersistenceOption(name string, loader ipld.Loader, storer ipld.Storer) error
 
 	// RegisterIncomingRequestHook adds a hook that runs when a request is received
 	RegisterIncomingRequestHook(hook OnIncomingRequestHook) UnregisterHookFunc

--- a/graphsync.go
+++ b/graphsync.go
@@ -135,9 +135,9 @@ type ResponseData interface {
 	Extension(name ExtensionName) ([]byte, bool)
 }
 
-// RequestReceivedHookActions are actions that a request hook can take to change
+// IncomingRequestHookActions are actions that a request hook can take to change
 // behavior for the response
-type RequestReceivedHookActions interface {
+type IncomingRequestHookActions interface {
 	SendExtensionData(ExtensionData)
 	UseLoader(ipld.Loader)
 	UseNodeBuilderChooser(traversal.NodeBuilderChooser)
@@ -145,17 +145,28 @@ type RequestReceivedHookActions interface {
 	ValidateRequest()
 }
 
-// OnRequestReceivedHook is a hook that runs each time a request is received.
-// It receives the peer that sent the request and all data about the request.
-// It should return:
-// extensionData - any extension data to add to the outgoing response
-// err - error - if not nil, halt request and return RequestRejected with the responseData
-type OnRequestReceivedHook func(p peer.ID, request RequestData, hookActions RequestReceivedHookActions)
+// OutgoingRequestHookActions are actions that an outgoing request hook can take
+// to change the execution of this request
+type OutgoingRequestHookActions interface {
+	UseLoader(ipld.Loader)
+	UseStorer(ipld.Storer)
+	UseNodeBuilderChooser(traversal.NodeBuilderChooser)
+}
 
-// OnResponseReceivedHook is a hook that runs each time a response is received.
+// OnIncomingRequestHook is a hook that runs each time a new request is received.
+// It receives the peer that sent the request and all data about the request.
+// It receives an interface for customizing the response to this request
+type OnIncomingRequestHook func(p peer.ID, request RequestData, hookActions IncomingRequestHookActions)
+
+// OnIncomingResponseHook is a hook that runs each time a new response is received.
 // It receives the peer that sent the response and all data about the response.
 // If it returns an error processing is halted and the original request is cancelled.
-type OnResponseReceivedHook func(p peer.ID, responseData ResponseData) error
+type OnIncomingResponseHook func(p peer.ID, responseData ResponseData) error
+
+// OnOutgoingRequestHook is a hook that runs immediately prior to sending a request
+// It receives the peer we're sending a request to and all the data aobut the request
+// It receives an interface for customizing how we handle executing this request
+type OnOutgoingRequestHook func(p peer.ID, request RequestData, hookActions OutgoingRequestHookActions)
 
 // UnregisterHookFunc is a function call to unregister a hook that was previously registered
 type UnregisterHookFunc func()
@@ -165,12 +176,12 @@ type GraphExchange interface {
 	// Request initiates a new GraphSync request to the given peer using the given selector spec.
 	Request(ctx context.Context, p peer.ID, root ipld.Link, selector ipld.Node, extensions ...ExtensionData) (<-chan ResponseProgress, <-chan error)
 
-	// RegisterRequestReceivedHook adds a hook that runs when a request is received
-	// If overrideDefaultValidation is set to true, then if the hook does not error,
-	// it is considered to have "validated" the request -- and that validation supersedes
-	// the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
-	RegisterRequestReceivedHook(hook OnRequestReceivedHook) UnregisterHookFunc
+	// RegisterIncomingRequestHook adds a hook that runs when a request is received
+	RegisterIncomingRequestHook(hook OnIncomingRequestHook) UnregisterHookFunc
 
-	// RegisterResponseReceivedHook adds a hook that runs when a response is received
-	RegisterResponseReceivedHook(OnResponseReceivedHook) UnregisterHookFunc
+	// RegisterIncomingResponseHook adds a hook that runs when a response is received
+	RegisterIncomingResponseHook(OnIncomingResponseHook) UnregisterHookFunc
+
+	// RegisterOutgoingRequestHook adds a hook that runs immediately prior to sending a new request
+	RegisterOutgoingRequestHook(hook OnOutgoingRequestHook) UnregisterHookFunc
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -103,17 +103,22 @@ func (gs *GraphSync) Request(ctx context.Context, p peer.ID, root ipld.Link, sel
 	return gs.requestManager.SendRequest(ctx, p, root, selector, extensions...)
 }
 
-// RegisterRequestReceivedHook adds a hook that runs when a request is received
+// RegisterIncomingRequestHook adds a hook that runs when a request is received
 // If overrideDefaultValidation is set to true, then if the hook does not error,
 // it is considered to have "validated" the request -- and that validation supersedes
 // the normal validation of requests Graphsync does (i.e. all selectors can be accepted)
-func (gs *GraphSync) RegisterRequestReceivedHook(hook graphsync.OnRequestReceivedHook) graphsync.UnregisterHookFunc {
+func (gs *GraphSync) RegisterIncomingRequestHook(hook graphsync.OnIncomingRequestHook) graphsync.UnregisterHookFunc {
 	return gs.responseManager.RegisterHook(hook)
 }
 
-// RegisterResponseReceivedHook adds a hook that runs when a response is received
-func (gs *GraphSync) RegisterResponseReceivedHook(hook graphsync.OnResponseReceivedHook) graphsync.UnregisterHookFunc {
+// RegisterIncomingResponseHook adds a hook that runs when a response is received
+func (gs *GraphSync) RegisterIncomingResponseHook(hook graphsync.OnIncomingResponseHook) graphsync.UnregisterHookFunc {
 	return gs.requestManager.RegisterHook(hook)
+}
+
+// RegisterOutgoingRequestHook adds a hook that runs immediately prior to sending a new request
+func (gs *GraphSync) RegisterOutgoingRequestHook(hook graphsync.OnOutgoingRequestHook) graphsync.UnregisterHookFunc {
+	return func() {}
 }
 
 type graphSyncReceiver GraphSync

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -121,6 +121,14 @@ func (gs *GraphSync) RegisterOutgoingRequestHook(hook graphsync.OnOutgoingReques
 	return func() {}
 }
 
+func (gs *GraphSync) RegisterPersistenceOption(name string, loader ipld.Loader, storer ipld.Storer) error {
+	err := gs.asyncLoader.RegisterPersistenceOption(name, loader, storer)
+	if err != nil {
+		return err
+	}
+	return gs.responseManager.RegisterPersistenceOption(name, loader)
+}
+
 type graphSyncReceiver GraphSync
 
 func (gsr *graphSyncReceiver) graphSync() *GraphSync {

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -99,8 +99,8 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 	var receivedRequestData []byte
 	// initialize graphsync on second node to response to requests
 	gsnet := td.GraphSyncHost2()
-	gsnet.RegisterRequestReceivedHook(
-		func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+	gsnet.RegisterIncomingRequestHook(
+		func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			var has bool
 			receivedRequestData, has = requestData.Extension(td.extensionName)
 			require.True(t, has, "did not have expected extension")
@@ -190,7 +190,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	var receivedResponseData []byte
 	var receivedRequestData []byte
 
-	requestor.RegisterResponseReceivedHook(
+	requestor.RegisterIncomingResponseHook(
 		func(p peer.ID, responseData graphsync.ResponseData) error {
 			data, has := responseData.Extension(td.extensionName)
 			if has {
@@ -199,7 +199,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 			return nil
 		})
 
-	responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+	responder.RegisterIncomingRequestHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 		var has bool
 		receivedRequestData, has = requestData.Extension(td.extensionName)
 		if !has {
@@ -360,7 +360,7 @@ func TestUnixFSFetch(t *testing.T) {
 	requestor := New(ctx, td.gsnet1, loader1, storer1)
 	responder := New(ctx, td.gsnet2, loader2, storer2)
 	extensionName := graphsync.ExtensionName("Free for all")
-	responder.RegisterRequestReceivedHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+	responder.RegisterIncomingRequestHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 		hookActions.ValidateRequest()
 		hookActions.SendExtensionData(graphsync.ExtensionData{
 			Name: extensionName,

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -241,8 +241,11 @@ func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
 	altStore2 := make(map[ipld.Link][]byte)
 	altLoader2, altStorer2 := testutil.NewTestStore(altStore2)
 
-	requestor.RegisterPersistenceOption("chainstore", altLoader1, altStorer1)
-	responder.RegisterPersistenceOption("chainstore", altLoader2, altStorer2)
+	err := requestor.RegisterPersistenceOption("chainstore", altLoader1, altStorer1)
+	require.NoError(t, err)
+
+	err = responder.RegisterPersistenceOption("chainstore", altLoader2, altStorer2)
+	require.NoError(t, err)
 
 	blockChainLength := 100
 	blockChain := testutil.SetupBlockChain(ctx, t, altLoader1, altStorer2, 100, blockChainLength)

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/metadata"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
@@ -18,312 +19,342 @@ import (
 )
 
 func TestAsyncLoadInitialLoadSucceedsLocallyPresent(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
 	block := testutil.GenerateBlocksOfSize(1, 100)[0]
-	writer, commit, err := storer(ipld.LinkContext{})
-	require.NoError(t, err)
-	_, err = writer.Write(block.RawData())
-	require.NoError(t, err, "seeds block store")
-	link := cidlink.Link{Cid: block.Cid()}
-	err = commit(link)
-	require.NoError(t, err, "seeds block store")
-
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
-
-	requestID := graphsync.RequestID(rand.Int31())
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.NotNil(t, result.Data, "should send response")
-	require.Nil(t, result.Err, "should not send error")
-
-	require.NotZero(t, callCount, "should attempt to load link from local store")
+	st := newStore()
+	link := st.Store(t, block)
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		requestID := graphsync.RequestID(rand.Int31())
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
+		assertSuccessResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+	})
 }
 
 func TestAsyncLoadInitialLoadSucceedsResponsePresent(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
 	blocks := testutil.GenerateBlocksOfSize(1, 100)
 	block := blocks[0]
-
 	link := cidlink.Link{Cid: block.Cid()}
 
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
-
-	requestID := graphsync.RequestID(rand.Int31())
-	responses := map[graphsync.RequestID]metadata.Metadata{
-		requestID: metadata.Metadata{
-			metadata.Item{
-				Link:         link,
-				BlockPresent: true,
+	st := newStore()
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		requestID := graphsync.RequestID(rand.Int31())
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
 			},
-		},
-	}
-	asyncLoader.ProcessResponse(responses, blocks)
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
+		}
+		asyncLoader.ProcessResponse(responses, blocks)
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.NotNil(t, result.Data, "should send response")
-	require.Nil(t, result.Err, "should not send error")
-
-	require.Zero(t, callCount, "should not attempt to load link from local store")
-	require.Equal(t, block.RawData(), blockStore[link], "should store block")
+		assertSuccessResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 0)
+		st.AssertBlockStored(t, block)
+	})
 }
 
 func TestAsyncLoadInitialLoadFails(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
+	st := newStore()
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		link := testutil.NewTestLink()
+		requestID := graphsync.RequestID(rand.Int31())
 
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
-
-	link := testutil.NewTestLink()
-	requestID := graphsync.RequestID(rand.Int31())
-
-	responses := map[graphsync.RequestID]metadata.Metadata{
-		requestID: metadata.Metadata{
-			metadata.Item{
-				Link:         link,
-				BlockPresent: false,
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: false,
+				},
 			},
-		},
-	}
-	asyncLoader.ProcessResponse(responses, nil)
+		}
+		asyncLoader.ProcessResponse(responses, nil)
 
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not send responses")
-	require.NotNil(t, result.Err, "should send an error")
-	require.Zero(t, callCount, "should not attempt to load link from local store")
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
+		assertFailResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 0)
+	})
 }
 
 func TestAsyncLoadInitialLoadIndeterminateWhenRequestNotInProgress(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
-
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
-
-	link := testutil.NewTestLink()
-	requestID := graphsync.RequestID(rand.Int31())
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not send responses")
-	require.NotNil(t, result.Err, "should send an error")
-	require.NotZero(t, callCount, "should attempt to load link from local store")
+	st := newStore()
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		link := testutil.NewTestLink()
+		requestID := graphsync.RequestID(rand.Int31())
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
+		assertFailResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+	})
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
 	blocks := testutil.GenerateBlocksOfSize(1, 100)
 	block := blocks[0]
-
 	link := cidlink.Link{Cid: block.Cid()}
-	called := make(chan struct{}, 2)
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		called <- struct{}{}
-		callCount++
-		return loader(link, linkContext)
-	}
 
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
+	st := newStore()
 
-	requestID := graphsync.RequestID(rand.Int31())
-	asyncLoader.StartRequest(requestID)
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		requestID := graphsync.RequestID(rand.Int31())
+		err := asyncLoader.StartRequest(requestID, "")
+		require.NoError(t, err)
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
+		st.AssertAttemptLoadWithoutResult(ctx, t, resultChan)
 
-	responses := map[graphsync.RequestID]metadata.Metadata{
-		requestID: metadata.Metadata{
-			metadata.Item{
-				Link:         link,
-				BlockPresent: true,
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
 			},
-		},
-	}
-	asyncLoader.ProcessResponse(responses, blocks)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.NotNil(t, result.Data, "should send response")
-	require.Nil(t, result.Err, "should not send error")
-
-	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
-
-	require.Equal(t, block.RawData(), blockStore[link], "should store block")
+		}
+		asyncLoader.ProcessResponse(responses, blocks)
+		assertSuccessResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+		st.AssertBlockStored(t, block)
+	})
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
+	st := newStore()
 
-	link := testutil.NewTestLink()
-	called := make(chan struct{}, 2)
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		called <- struct{}{}
-		callCount++
-		return loader(link, linkContext)
-	}
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		link := testutil.NewTestLink()
+		requestID := graphsync.RequestID(rand.Int31())
+		err := asyncLoader.StartRequest(requestID, "")
+		require.NoError(t, err)
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
 
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
+		st.AssertAttemptLoadWithoutResult(ctx, t, resultChan)
 
-	requestID := graphsync.RequestID(rand.Int31())
-	asyncLoader.StartRequest(requestID)
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
-
-	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
-	responses := map[graphsync.RequestID]metadata.Metadata{
-		requestID: metadata.Metadata{
-			metadata.Item{
-				Link:         link,
-				BlockPresent: false,
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: false,
+				},
 			},
-		},
-	}
-	asyncLoader.ProcessResponse(responses, nil)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.Nil(t, result.Data, "should not send responses")
-	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
+		}
+		asyncLoader.ProcessResponse(responses, nil)
+		assertFailResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+	})
 }
 
 func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
+	st := newStore()
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		link := testutil.NewTestLink()
+		requestID := graphsync.RequestID(rand.Int31())
+		err := asyncLoader.StartRequest(requestID, "")
+		require.NoError(t, err)
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
+		st.AssertAttemptLoadWithoutResult(ctx, t, resultChan)
+		asyncLoader.CompleteResponsesFor(requestID)
+		assertFailResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+	})
+}
+
+func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
+	blocks := testutil.GenerateBlocksOfSize(1, 100)
+	block := blocks[0]
+	link := cidlink.Link{Cid: block.Cid()}
+	st := newStore()
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		requestID := graphsync.RequestID(rand.Int31())
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
+			},
+		}
+		asyncLoader.ProcessResponse(responses, blocks)
+		resultChan := asyncLoader.AsyncLoad(requestID, link)
+
+		assertSuccessResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 0)
+
+		resultChan = asyncLoader.AsyncLoad(requestID, link)
+		assertSuccessResponse(ctx, t, resultChan)
+		st.AssertLocalLoads(t, 1)
+
+		st.AssertBlockStored(t, block)
+	})
+}
+
+func TestRequestSplittingLoadLocallyFromBlockstore(t *testing.T) {
+	st := newStore()
+	otherSt := newStore()
+	block := testutil.GenerateBlocksOfSize(1, 100)[0]
+	link := otherSt.Store(t, block)
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		err := asyncLoader.RegisterPersistenceOption("other", otherSt.loader, otherSt.storer)
+		require.NoError(t, err)
+		requestID1 := graphsync.RequestID(rand.Int31())
+		resultChan1 := asyncLoader.AsyncLoad(requestID1, link)
+		requestID2 := graphsync.RequestID(rand.Int31())
+		err = asyncLoader.StartRequest(requestID2, "other")
+		require.NoError(t, err)
+		resultChan2 := asyncLoader.AsyncLoad(requestID2, link)
+
+		assertFailResponse(ctx, t, resultChan1)
+		assertSuccessResponse(ctx, t, resultChan2)
+		st.AssertLocalLoads(t, 1)
+	})
+}
+
+func TestRequestSplittingSameBlockTwoStores(t *testing.T) {
+	st := newStore()
+	otherSt := newStore()
+	blocks := testutil.GenerateBlocksOfSize(1, 100)
+	block := blocks[0]
+	link := cidlink.Link{Cid: block.Cid()}
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		err := asyncLoader.RegisterPersistenceOption("other", otherSt.loader, otherSt.storer)
+		require.NoError(t, err)
+		requestID1 := graphsync.RequestID(rand.Int31())
+		requestID2 := graphsync.RequestID(rand.Int31())
+		err = asyncLoader.StartRequest(requestID1, "")
+		require.NoError(t, err)
+		err = asyncLoader.StartRequest(requestID2, "other")
+		require.NoError(t, err)
+		resultChan1 := asyncLoader.AsyncLoad(requestID1, link)
+		resultChan2 := asyncLoader.AsyncLoad(requestID2, link)
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID1: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
+			},
+			requestID2: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
+			},
+		}
+		asyncLoader.ProcessResponse(responses, blocks)
+
+		assertSuccessResponse(ctx, t, resultChan1)
+		assertSuccessResponse(ctx, t, resultChan2)
+		st.AssertBlockStored(t, block)
+		otherSt.AssertBlockStored(t, block)
+	})
+}
+
+func TestRequestSplittingSameBlockOnlyOneResponse(t *testing.T) {
+	st := newStore()
+	otherSt := newStore()
+	blocks := testutil.GenerateBlocksOfSize(1, 100)
+	block := blocks[0]
+	link := cidlink.Link{Cid: block.Cid()}
+	withLoader(st, func(ctx context.Context, asyncLoader *AsyncLoader) {
+		err := asyncLoader.RegisterPersistenceOption("other", otherSt.loader, otherSt.storer)
+		require.NoError(t, err)
+		requestID1 := graphsync.RequestID(rand.Int31())
+		requestID2 := graphsync.RequestID(rand.Int31())
+		err = asyncLoader.StartRequest(requestID1, "")
+		require.NoError(t, err)
+		err = asyncLoader.StartRequest(requestID2, "other")
+		require.NoError(t, err)
+		resultChan1 := asyncLoader.AsyncLoad(requestID1, link)
+		resultChan2 := asyncLoader.AsyncLoad(requestID2, link)
+		responses := map[graphsync.RequestID]metadata.Metadata{
+			requestID2: metadata.Metadata{
+				metadata.Item{
+					Link:         link,
+					BlockPresent: true,
+				},
+			},
+		}
+		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.CompleteResponsesFor(requestID1)
+
+		assertFailResponse(ctx, t, resultChan1)
+		assertSuccessResponse(ctx, t, resultChan2)
+		otherSt.AssertBlockStored(t, block)
+	})
+}
+
+type store struct {
+	internalLoader ipld.Loader
+	storer         ipld.Storer
+	blockstore     map[ipld.Link][]byte
+	localLoads     int
+	called         chan struct{}
+}
+
+func newStore() *store {
+	blockstore := make(map[ipld.Link][]byte)
+	loader, storer := testutil.NewTestStore(blockstore)
+	return &store{
+		internalLoader: loader,
+		storer:         storer,
+		blockstore:     blockstore,
+		localLoads:     0,
+		called:         make(chan struct{}),
+	}
+}
+
+func (st *store) loader(lnk ipld.Link, lnkCtx ipld.LinkContext) (io.Reader, error) {
+	select {
+	case <-st.called:
+	default:
+		close(st.called)
+	}
+	st.localLoads++
+	return st.internalLoader(lnk, lnkCtx)
+}
+
+func (st *store) AssertLocalLoads(t *testing.T, localLoads int) {
+	require.Equalf(t, localLoads, st.localLoads, "should have loaded locally %d times", localLoads)
+}
+
+func (st *store) AssertBlockStored(t *testing.T, blk blocks.Block) {
+	require.Equal(t, blk.RawData(), st.blockstore[cidlink.Link{Cid: blk.Cid()}], "should store block")
+}
+
+func (st *store) AssertAttemptLoadWithoutResult(ctx context.Context, t *testing.T, resultChan <-chan types.AsyncLoadResult) {
+	testutil.AssertDoesReceiveFirst(t, st.called, "should attempt load with no result", resultChan, ctx.Done())
+}
+
+func (st *store) Store(t *testing.T, blk blocks.Block) ipld.Link {
+	writer, commit, err := st.storer(ipld.LinkContext{})
+	require.NoError(t, err)
+	_, err = writer.Write(blk.RawData())
+	require.NoError(t, err, "seeds block store")
+	link := cidlink.Link{Cid: blk.Cid()}
+	err = commit(link)
+	require.NoError(t, err, "seeds block store")
+	return link
+}
+
+func withLoader(st *store, exec func(ctx context.Context, asyncLoader *AsyncLoader)) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
-
-	link := testutil.NewTestLink()
-	called := make(chan struct{}, 2)
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		called <- struct{}{}
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
+	asyncLoader := New(ctx, st.loader, st.storer)
 	asyncLoader.Startup()
+	exec(ctx, asyncLoader)
+}
 
-	requestID := graphsync.RequestID(rand.Int31())
-	asyncLoader.StartRequest(requestID)
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
+func assertSuccessResponse(ctx context.Context, t *testing.T, resultChan <-chan types.AsyncLoadResult) {
+	var result types.AsyncLoadResult
+	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
+	require.NotNil(t, result.Data, "should send response")
+	require.Nil(t, result.Err, "should not send error")
+}
 
-	testutil.AssertDoesReceiveFirst(t, called, "should attempt load with no result", resultChan, ctx.Done())
-	asyncLoader.CompleteResponsesFor(requestID)
-
+func assertFailResponse(ctx context.Context, t *testing.T, resultChan <-chan types.AsyncLoadResult) {
 	var result types.AsyncLoadResult
 	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
 	require.Nil(t, result.Data, "should not send responses")
 	require.NotNil(t, result.Err, "should send an error")
-	require.Equal(t, 1, callCount, "should attempt to load from local store exactly once")
-}
-
-func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	callCount := 0
-	blockStore := make(map[ipld.Link][]byte)
-	loader, storer := testutil.NewTestStore(blockStore)
-	blocks := testutil.GenerateBlocksOfSize(1, 100)
-	block := blocks[0]
-
-	link := cidlink.Link{Cid: block.Cid()}
-
-	wrappedLoader := func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
-		callCount++
-		return loader(link, linkContext)
-	}
-
-	asyncLoader := New(ctx, wrappedLoader, storer)
-	asyncLoader.Startup()
-
-	requestID := graphsync.RequestID(rand.Int31())
-	responses := map[graphsync.RequestID]metadata.Metadata{
-		requestID: metadata.Metadata{
-			metadata.Item{
-				Link:         link,
-				BlockPresent: true,
-			},
-		},
-	}
-	asyncLoader.ProcessResponse(responses, blocks)
-	resultChan := asyncLoader.AsyncLoad(requestID, link)
-
-	var result types.AsyncLoadResult
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.NotNil(t, result.Data, "should send response")
-	require.Nil(t, result.Err, "should not send error")
-
-	require.Zero(t, callCount, "should not attempt to load link from local store")
-	require.Equal(t, block.RawData(), blockStore[link], "should store block")
-
-	resultChan = asyncLoader.AsyncLoad(requestID, link)
-
-	testutil.AssertReceive(ctx, t, resultChan, &result, "should close response channel with response")
-	require.NotNil(t, result.Data, "should send response")
-	require.Nil(t, result.Err, "should not send error")
-	require.NotZero(t, callCount, "should attempt to load link from local store")
-	require.Equal(t, block.RawData(), blockStore[link], "should store block")
 }

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -35,7 +35,7 @@ type inProgressRequestStatus struct {
 
 type responseHook struct {
 	key  uint64
-	hook graphsync.OnResponseReceivedHook
+	hook graphsync.OnIncomingResponseHook
 }
 
 // PeerHandler is an interface that can send requests to peers
@@ -204,13 +204,13 @@ func (rm *RequestManager) ProcessResponses(p peer.ID, responses []gsmsg.GraphSyn
 }
 
 type registerHookMessage struct {
-	hook               graphsync.OnResponseReceivedHook
+	hook               graphsync.OnIncomingResponseHook
 	unregisterHookChan chan graphsync.UnregisterHookFunc
 }
 
 // RegisterHook registers an extension to processincoming responses
 func (rm *RequestManager) RegisterHook(
-	hook graphsync.OnResponseReceivedHook) graphsync.UnregisterHookFunc {
+	hook graphsync.OnIncomingResponseHook) graphsync.UnregisterHookFunc {
 	response := make(chan graphsync.UnregisterHookFunc)
 	select {
 	case rm.messages <- &registerHookMessage{hook, response}:

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -60,8 +60,11 @@ func newFakeAsyncLoader() *fakeAsyncLoader {
 		blks:             make(chan []blocks.Block, 1),
 	}
 }
-func (fal *fakeAsyncLoader) StartRequest(requestID graphsync.RequestID) {
+
+func (fal *fakeAsyncLoader) StartRequest(graphsync.RequestID, string) error {
+	return nil
 }
+
 func (fal *fakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
 	fal.responses <- responses
@@ -593,3 +596,26 @@ func TestEncodingExtensions(t *testing.T) {
 		testutil.VerifyEmptyResponse(requestCtx, t, returnedResponseChan)
 	})
 }
+
+/*
+func TestOutgoingRequestHooks(t *testing.T) {
+	requestRecordChan := make(chan requestRecord, 2)
+	fph := &fakePeerHandler{requestRecordChan}
+	ctx := context.Background()
+	fal := newFakeAsyncLoader()
+	requestManager := New(ctx, fal)
+	requestManager.SetDelegate(fph)
+	requestManager.Startup()
+
+	requestCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	peers := testutil.GeneratePeers(1)
+
+	blockStore := make(map[ipld.Link][]byte)
+	loader, storer := testutil.NewTestStore(blockStore)
+	blockChain := testutil.SetupBlockChain(ctx, t, loader, storer, 100, 5)
+
+	returnedResponseChan, returnedErrorChan := requestManager.SendRequest(requestCtx, peers[0], blockChain.TipLink, blockChain.Selector())
+
+}
+*/

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -46,11 +46,18 @@ type requestKey struct {
 	link      ipld.Link
 }
 
+type storeKey struct {
+	requestID graphsync.RequestID
+	storeName string
+}
+
 type fakeAsyncLoader struct {
 	responseChannelsLk sync.RWMutex
 	responseChannels   map[requestKey]chan types.AsyncLoadResult
 	responses          chan map[graphsync.RequestID]metadata.Metadata
 	blks               chan []blocks.Block
+	storesRequestedLk  sync.RWMutex
+	storesRequested    map[storeKey]struct{}
 }
 
 func newFakeAsyncLoader() *fakeAsyncLoader {
@@ -58,10 +65,14 @@ func newFakeAsyncLoader() *fakeAsyncLoader {
 		responseChannels: make(map[requestKey]chan types.AsyncLoadResult),
 		responses:        make(chan map[graphsync.RequestID]metadata.Metadata, 1),
 		blks:             make(chan []blocks.Block, 1),
+		storesRequested:  make(map[storeKey]struct{}),
 	}
 }
 
-func (fal *fakeAsyncLoader) StartRequest(graphsync.RequestID, string) error {
+func (fal *fakeAsyncLoader) StartRequest(requestID graphsync.RequestID, name string) error {
+	fal.storesRequestedLk.Lock()
+	fal.storesRequested[storeKey{requestID, name}] = struct{}{}
+	fal.storesRequestedLk.Unlock()
 	return nil
 }
 
@@ -89,6 +100,13 @@ func (fal *fakeAsyncLoader) verifyNoRemainingData(t *testing.T, requestID graphs
 		require.NotEqual(t, key.requestID, requestID, "did not clean up request properly")
 	}
 	fal.responseChannelsLk.Unlock()
+}
+
+func (fal *fakeAsyncLoader) verifyStoreUsed(t *testing.T, requestID graphsync.RequestID, storeName string) {
+	fal.storesRequestedLk.RLock()
+	_, ok := fal.storesRequested[storeKey{requestID, storeName}]
+	require.True(t, ok, "request should load from correct store")
+	fal.storesRequestedLk.RUnlock()
 }
 
 func (fal *fakeAsyncLoader) asyncLoad(requestID graphsync.RequestID, link ipld.Link) chan types.AsyncLoadResult {
@@ -541,7 +559,7 @@ func TestEncodingExtensions(t *testing.T) {
 		receivedExtensionData <- data
 		return <-expectedError
 	}
-	requestManager.RegisterHook(hook)
+	requestManager.RegisterResponseHook(hook)
 	returnedResponseChan, returnedErrorChan := requestManager.SendRequest(requestCtx, peers[0], blockChain.TipLink, blockChain.Selector(), extension1, extension2)
 
 	rr := readNNetworkRequests(requestCtx, t, requestRecordChan, 1)[0]
@@ -597,7 +615,6 @@ func TestEncodingExtensions(t *testing.T) {
 	})
 }
 
-/*
 func TestOutgoingRequestHooks(t *testing.T) {
 	requestRecordChan := make(chan requestRecord, 2)
 	fph := &fakePeerHandler{requestRecordChan}
@@ -615,7 +632,50 @@ func TestOutgoingRequestHooks(t *testing.T) {
 	loader, storer := testutil.NewTestStore(blockStore)
 	blockChain := testutil.SetupBlockChain(ctx, t, loader, storer, 100, 5)
 
-	returnedResponseChan, returnedErrorChan := requestManager.SendRequest(requestCtx, peers[0], blockChain.TipLink, blockChain.Selector())
+	extensionName1 := graphsync.ExtensionName("blockchain")
+	extension1 := graphsync.ExtensionData{
+		Name: extensionName1,
+		Data: nil,
+	}
 
+	hook := func(p peer.ID, r graphsync.RequestData, ha graphsync.OutgoingRequestHookActions) {
+		_, has := r.Extension(extensionName1)
+		if has {
+			ha.UseNodeBuilderChooser(blockChain.Chooser)
+			ha.UsePersistenceOption("chainstore")
+		}
+	}
+	requestManager.RegisterRequestHook(hook)
+
+	returnedResponseChan1, returnedErrorChan1 := requestManager.SendRequest(requestCtx, peers[0], blockChain.TipLink, blockChain.Selector(), extension1)
+	returnedResponseChan2, returnedErrorChan2 := requestManager.SendRequest(requestCtx, peers[0], blockChain.TipLink, blockChain.Selector())
+
+	requestRecords := readNNetworkRequests(requestCtx, t, requestRecordChan, 2)
+
+	md := metadataForBlocks(blockChain.AllBlocks(), true)
+	mdEncoded, err := metadata.EncodeMetadata(md)
+	require.NoError(t, err)
+	mdExt := graphsync.ExtensionData{
+		Name: graphsync.ExtensionMetadata,
+		Data: mdEncoded,
+	}
+	responses := []gsmsg.GraphSyncResponse{
+		gsmsg.NewResponse(requestRecords[0].gsr.ID(), graphsync.RequestCompletedFull, mdExt),
+		gsmsg.NewResponse(requestRecords[1].gsr.ID(), graphsync.RequestCompletedFull, mdExt),
+	}
+	requestManager.ProcessResponses(peers[0], responses, blockChain.AllBlocks())
+	fal.verifyLastProcessedBlocks(ctx, t, blockChain.AllBlocks())
+	fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+		requestRecords[0].gsr.ID(): md,
+		requestRecords[1].gsr.ID(): md,
+	})
+	fal.successResponseOn(requestRecords[0].gsr.ID(), blockChain.AllBlocks())
+	fal.successResponseOn(requestRecords[1].gsr.ID(), blockChain.AllBlocks())
+
+	blockChain.VerifyWholeChainWithTypes(requestCtx, returnedResponseChan1)
+	blockChain.VerifyWholeChain(requestCtx, returnedResponseChan2)
+	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan1)
+	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan2)
+	fal.verifyStoreUsed(t, requestRecords[0].gsr.ID(), "chainstore")
+	fal.verifyStoreUsed(t, requestRecords[1].gsr.ID(), "")
 }
-*/

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -40,7 +40,7 @@ type responseTaskData struct {
 
 type requestHook struct {
 	key  uint64
-	hook graphsync.OnRequestReceivedHook
+	hook graphsync.OnIncomingRequestHook
 }
 
 // QueryQueue is an interface that can receive new selector query tasks
@@ -115,7 +115,7 @@ func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, reque
 }
 
 // RegisterHook registers an extension to process new incoming requests
-func (rm *ResponseManager) RegisterHook(hook graphsync.OnRequestReceivedHook) graphsync.UnregisterHookFunc {
+func (rm *ResponseManager) RegisterHook(hook graphsync.OnIncomingRequestHook) graphsync.UnregisterHookFunc {
 	rm.requestHooksLk.Lock()
 	rh := requestHook{rm.requestHookNextKey, hook}
 	rm.requestHookNextKey++

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -130,8 +130,8 @@ func (rm *ResponseManager) RegisterPersistenceOption(name string, loader ipld.Lo
 	return nil
 }
 
-// RegisterHook registers an extension to process new incoming requests
-func (rm *ResponseManager) RegisterHook(hook graphsync.OnIncomingRequestHook) graphsync.UnregisterHookFunc {
+// RegisterRequestHook registers an extension to process new incoming requests
+func (rm *ResponseManager) RegisterRequestHook(hook graphsync.OnIncomingRequestHook) graphsync.UnregisterHookFunc {
 	rm.requestHooksLk.Lock()
 	rh := requestHook{rm.requestHookNextKey, hook}
 	rm.requestHookNextKey++

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -2,6 +2,7 @@ package responsemanager
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -71,13 +72,15 @@ type ResponseManager struct {
 	peerManager PeerManager
 	queryQueue  QueryQueue
 
-	messages            chan responseManagerMessage
-	workSignal          chan struct{}
-	ticker              *time.Ticker
-	inProgressResponses map[responseKey]inProgressResponseStatus
-	requestHooksLk      sync.RWMutex
-	requestHookNextKey  uint64
-	requestHooks        []requestHook
+	messages             chan responseManagerMessage
+	workSignal           chan struct{}
+	ticker               *time.Ticker
+	inProgressResponses  map[responseKey]inProgressResponseStatus
+	requestHooksLk       sync.RWMutex
+	requestHookNextKey   uint64
+	requestHooks         []requestHook
+	persistenceOptionsLk sync.RWMutex
+	persistenceOptions   map[string]ipld.Loader
 }
 
 // New creates a new response manager from the given context, loader,
@@ -97,6 +100,7 @@ func New(ctx context.Context,
 		workSignal:          make(chan struct{}, 1),
 		ticker:              time.NewTicker(thawSpeed),
 		inProgressResponses: make(map[responseKey]inProgressResponseStatus),
+		persistenceOptions:  make(map[string]ipld.Loader),
 	}
 }
 
@@ -112,6 +116,18 @@ func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, reque
 	case <-rm.ctx.Done():
 	case <-ctx.Done():
 	}
+}
+
+// RegisterPersistenceOption registers a new loader for the response manager
+func (rm *ResponseManager) RegisterPersistenceOption(name string, loader ipld.Loader) error {
+	rm.persistenceOptionsLk.Lock()
+	defer rm.persistenceOptionsLk.Unlock()
+	_, ok := rm.persistenceOptions[name]
+	if ok {
+		return errors.New("persistence option alreayd registered")
+	}
+	rm.persistenceOptions[name] = loader
+	return nil
 }
 
 // RegisterHook registers an extension to process new incoming requests
@@ -205,6 +221,7 @@ func noopVisitor(tp traversal.Progress, n ipld.Node, tr traversal.VisitReason) e
 }
 
 type hookActions struct {
+	persistenceOptions map[string]ipld.Loader
 	isValidated        bool
 	requestID          graphsync.RequestID
 	peerResponseSender peerresponsemanager.PeerResponseSender
@@ -226,7 +243,12 @@ func (ha *hookActions) ValidateRequest() {
 	ha.isValidated = true
 }
 
-func (ha *hookActions) UseLoader(loader ipld.Loader) {
+func (ha *hookActions) UsePersistenceOption(name string) {
+	loader, ok := ha.persistenceOptions[name]
+	if !ok {
+		ha.TerminateWithError(errors.New("unknown loader option"))
+		return
+	}
 	ha.loader = loader
 }
 
@@ -239,15 +261,18 @@ func (rm *ResponseManager) executeQuery(ctx context.Context,
 	request gsmsg.GraphSyncRequest) {
 	peerResponseSender := rm.peerManager.SenderForPeer(p)
 	selectorSpec := request.Selector()
-	ha := &hookActions{false, request.ID(), peerResponseSender, nil, rm.loader, nil}
 	rm.requestHooksLk.RLock()
+	rm.persistenceOptionsLk.RLock()
+	ha := &hookActions{rm.persistenceOptions, false, request.ID(), peerResponseSender, nil, rm.loader, nil}
 	for _, requestHook := range rm.requestHooks {
 		requestHook.hook(p, request, ha)
 		if ha.err != nil {
 			rm.requestHooksLk.RUnlock()
+			rm.persistenceOptionsLk.RUnlock()
 			return
 		}
 	}
+	rm.persistenceOptionsLk.RUnlock()
 	rm.requestHooksLk.RUnlock()
 	if !ha.isValidated {
 		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -309,7 +309,7 @@ func TestValidationAndExtensions(t *testing.T) {
 	t.Run("if non validating hook succeeds, does not pass validation", func(t *testing.T) {
 		responseManager := New(ctx, loader, peerManager, queryQueue)
 		responseManager.Startup()
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.SendExtensionData(extensionResponse)
 		})
 		responseManager.ProcessRequests(ctx, p, requests)
@@ -324,7 +324,7 @@ func TestValidationAndExtensions(t *testing.T) {
 	t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
 		responseManager := New(ctx, loader, peerManager, queryQueue)
 		responseManager.Startup()
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.ValidateRequest()
 			hookActions.SendExtensionData(extensionResponse)
 		})
@@ -340,10 +340,10 @@ func TestValidationAndExtensions(t *testing.T) {
 	t.Run("if any hook fails, should fail", func(t *testing.T) {
 		responseManager := New(ctx, loader, peerManager, queryQueue)
 		responseManager.Startup()
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.ValidateRequest()
 		})
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.SendExtensionData(extensionResponse)
 			hookActions.TerminateWithError(errors.New("everything went to crap"))
 		})
@@ -359,7 +359,7 @@ func TestValidationAndExtensions(t *testing.T) {
 	t.Run("hooks can be unregistered", func(t *testing.T) {
 		responseManager := New(ctx, loader, peerManager, queryQueue)
 		responseManager.Startup()
-		unregister := responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		unregister := responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.ValidateRequest()
 			hookActions.SendExtensionData(extensionResponse)
 		})
@@ -388,7 +388,7 @@ func TestValidationAndExtensions(t *testing.T) {
 		responseManager := New(ctx, oloader, peerManager, queryQueue)
 		responseManager.Startup()
 		// add validating hook -- so the request SHOULD succeed
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.ValidateRequest()
 		})
 
@@ -399,7 +399,7 @@ func TestValidationAndExtensions(t *testing.T) {
 		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 
 		// register hook to use different loader
-		_ = responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		_ = responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			if _, found := requestData.Extension(extensionName); found {
 				hookActions.UseLoader(loader)
 				hookActions.SendExtensionData(extensionResponse)
@@ -426,7 +426,7 @@ func TestValidationAndExtensions(t *testing.T) {
 		}
 
 		// add validating hook -- so the request SHOULD succeed
-		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			hookActions.ValidateRequest()
 		})
 
@@ -438,7 +438,7 @@ func TestValidationAndExtensions(t *testing.T) {
 		require.Equal(t, 0, customChooserCallCount)
 
 		// register hook to use custom chooser
-		_ = responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+		_ = responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			if _, found := requestData.Extension(extensionName); found {
 				hookActions.UseNodeBuilderChooser(customChooser)
 				hookActions.SendExtensionData(extensionResponse)

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -398,10 +398,12 @@ func TestValidationAndExtensions(t *testing.T) {
 		testutil.AssertReceive(ctx, t, completedRequestChan, &lastRequest, "should complete request")
 		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
 
+		err := responseManager.RegisterPersistenceOption("chainstore", loader)
+		require.NoError(t, err)
 		// register hook to use different loader
 		_ = responseManager.RegisterHook(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 			if _, found := requestData.Extension(extensionName); found {
-				hookActions.UseLoader(loader)
+				hookActions.UsePersistenceOption("chainstore")
 				hookActions.SendExtensionData(extensionResponse)
 			}
 		})

--- a/selectorvalidator/selectorvalidator.go
+++ b/selectorvalidator/selectorvalidator.go
@@ -21,8 +21,8 @@ var (
 // SelectorValidator returns an OnRequestReceivedHook that only validates
 // requests if their selector only has no recursions that are greater than
 // maxAcceptedDepth
-func SelectorValidator(maxAcceptedDepth int) graphsync.OnRequestReceivedHook {
-	return func(p peer.ID, request graphsync.RequestData, hookActions graphsync.RequestReceivedHookActions) {
+func SelectorValidator(maxAcceptedDepth int) graphsync.OnIncomingRequestHook {
+	return func(p peer.ID, request graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 		err := ValidateMaxRecursionDepth(request.Selector(), maxAcceptedDepth)
 		if err == nil {
 			hookActions.ValidateRequest()

--- a/testutil/chaintypes/gen/main.go
+++ b/testutil/chaintypes/gen/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+
+	"github.com/ipld/go-ipld-prime/schema"
+	gengo "github.com/ipld/go-ipld-prime/schema/gen/go"
+)
+
+func main() {
+	openOrPanic := func(filename string) *os.File {
+		y, err := os.OpenFile(filename, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0644)
+		if err != nil {
+			panic(err)
+		}
+		return y
+	}
+
+	tLink := schema.SpawnLink("Link")
+	tBytes := schema.SpawnBytes("Bytes")
+	tString := schema.SpawnString("String")
+	tParents := schema.SpawnList("Parents", tLink, false)
+	tMessages := schema.SpawnList("Messages", tBytes, false)
+	tBlock := schema.SpawnStruct("Block",
+		[]schema.StructField{
+			schema.SpawnStructField("Parents", tParents, false, false),
+			schema.SpawnStructField("Messages", tMessages, false, false),
+		},
+		schema.StructRepresentation_Map{},
+	)
+
+	f := openOrPanic("testchain_minima.go")
+	gengo.EmitMinima("chaintypes", f)
+
+	f = openOrPanic("testchain_gen.go")
+	gengo.EmitFileHeader("chaintypes", f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindBytes(tBytes), f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindLink(tLink), f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindString(tString), f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindList(tParents), f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindList(tMessages), f)
+	gengo.EmitEntireType(gengo.NewGeneratorForKindStruct(tBlock), f)
+
+}

--- a/testutil/chaintypes/testchain_gen.go
+++ b/testutil/chaintypes/testchain_gen.go
@@ -1,0 +1,1366 @@
+package chaintypes
+
+import (
+	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/impl/typed"
+	"github.com/ipld/go-ipld-prime/schema"
+)
+
+// Code generated go-ipld-prime DO NOT EDIT.
+
+type Bytes struct{ x []byte }
+
+// TODO generateKindBytes.EmitNativeAccessors
+// TODO generateKindBytes.EmitNativeBuilder
+type MaybeBytes struct {
+	Maybe typed.Maybe
+	Value Bytes
+}
+
+func (m MaybeBytes) Must() Bytes {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = Bytes{}
+var _ typed.Node = Bytes{}
+
+func (Bytes) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Bytes) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_Bytes
+}
+func (Bytes) LookupString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) Lookup(ipld.Node) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) LookupIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) MapIterator() ipld.MapIterator {
+	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}}
+}
+func (Bytes) ListIterator() ipld.ListIterator {
+	return listIteratorReject{ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}}
+}
+func (Bytes) Length() int {
+	return -1
+}
+func (Bytes) IsUndefined() bool {
+	return false
+}
+func (Bytes) IsNull() bool {
+	return false
+}
+func (Bytes) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Bytes}
+}
+func (x Bytes) AsBytes() ([]byte, error) {
+	return x.x, nil
+}
+func (Bytes) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) NodeBuilder() ipld.NodeBuilder {
+	return _Bytes__NodeBuilder{}
+}
+
+type _Bytes__NodeBuilder struct{}
+
+func Bytes__NodeBuilder() ipld.NodeBuilder {
+	return _Bytes__NodeBuilder{}
+}
+func (_Bytes__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Bytes}
+}
+func (_Bytes__NodeBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Bytes}
+}
+func (nb _Bytes__NodeBuilder) CreateBytes(v []byte) (ipld.Node, error) {
+	return Bytes{v}, nil
+}
+func (_Bytes__NodeBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Bytes.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Bytes}
+}
+func (Bytes) Representation() ipld.Node {
+	panic("TODO representation")
+}
+
+type Link struct{ x ipld.Link }
+
+// TODO generateKindLink.EmitNativeAccessors
+// TODO generateKindLink.EmitNativeBuilder
+type MaybeLink struct {
+	Maybe typed.Maybe
+	Value Link
+}
+
+func (m MaybeLink) Must() Link {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = Link{}
+var _ typed.Node = Link{}
+
+func (Link) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Link) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_Link
+}
+func (Link) LookupString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) Lookup(ipld.Node) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) LookupIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) MapIterator() ipld.MapIterator {
+	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Link", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}}
+}
+func (Link) ListIterator() ipld.ListIterator {
+	return listIteratorReject{ipld.ErrWrongKind{TypeName: "Link", MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}}
+}
+func (Link) Length() int {
+	return -1
+}
+func (Link) IsUndefined() bool {
+	return false
+}
+func (Link) IsNull() bool {
+	return false
+}
+func (Link) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Link", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Link", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Link", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Link", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Link}
+}
+func (Link) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Link}
+}
+func (x Link) AsLink() (ipld.Link, error) {
+	return x.x, nil
+}
+func (Link) NodeBuilder() ipld.NodeBuilder {
+	return _Link__NodeBuilder{}
+}
+
+type _Link__NodeBuilder struct{}
+
+func Link__NodeBuilder() ipld.NodeBuilder {
+	return _Link__NodeBuilder{}
+}
+func (_Link__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Link}
+}
+func (_Link__NodeBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Link.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Link}
+}
+func (nb _Link__NodeBuilder) CreateLink(v ipld.Link) (ipld.Node, error) {
+	return Link{v}, nil
+}
+func (Link) Representation() ipld.Node {
+	panic("TODO representation")
+}
+
+type String struct{ x string }
+
+func (x String) String() string {
+	return x.x
+}
+
+type String__Content struct {
+	Value string
+}
+
+func (b String__Content) Build() (String, error) {
+	x := String{
+		b.Value,
+	}
+	// FUTURE : want to support customizable validation.
+	//   but 'if v, ok := x.(schema.Validatable); ok {' doesn't fly: need a way to work on concrete types.
+	return x, nil
+}
+func (b String__Content) MustBuild() String {
+	if x, err := b.Build(); err != nil {
+		panic(err)
+	} else {
+		return x
+	}
+}
+
+type MaybeString struct {
+	Maybe typed.Maybe
+	Value String
+}
+
+func (m MaybeString) Must() String {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = String{}
+var _ typed.Node = String{}
+
+func (String) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (String) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_String
+}
+func (String) LookupString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+}
+func (String) Lookup(ipld.Node) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "Lookup", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+}
+func (String) LookupIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+}
+func (String) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "LookupSegment", AppropriateKind: ipld.ReprKindSet_Recursive, ActualKind: ipld.ReprKind_String}
+}
+func (String) MapIterator() ipld.MapIterator {
+	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "String", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}}
+}
+func (String) ListIterator() ipld.ListIterator {
+	return listIteratorReject{ipld.ErrWrongKind{TypeName: "String", MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}}
+}
+func (String) Length() int {
+	return -1
+}
+func (String) IsUndefined() bool {
+	return false
+}
+func (String) IsNull() bool {
+	return false
+}
+func (String) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "String", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_String}
+}
+func (String) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "String", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_String}
+}
+func (String) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "String", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_String}
+}
+func (x String) AsString() (string, error) {
+	return x.x, nil
+}
+func (String) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_String}
+}
+func (String) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_String}
+}
+func (String) NodeBuilder() ipld.NodeBuilder {
+	return _String__NodeBuilder{}
+}
+
+type _String__NodeBuilder struct{}
+
+func String__NodeBuilder() ipld.NodeBuilder {
+	return _String__NodeBuilder{}
+}
+func (_String__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_String}
+}
+func (nb _String__NodeBuilder) CreateString(v string) (ipld.Node, error) {
+	return String{v}, nil
+}
+func (_String__NodeBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_String}
+}
+func (_String__NodeBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "String.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_String}
+}
+func (String) Representation() ipld.Node {
+	panic("TODO representation")
+}
+
+type Parents struct {
+	x []Link
+}
+
+// TODO generateKindList.EmitNativeAccessors
+// TODO generateKindList.EmitNativeBuilder
+type MaybeParents struct {
+	Maybe typed.Maybe
+	Value Parents
+}
+
+func (m MaybeParents) Must() Parents {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = Parents{}
+var _ typed.Node = Parents{}
+
+func (Parents) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Parents) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_List
+}
+func (Parents) LookupString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (x Parents) Lookup(key ipld.Node) (ipld.Node, error) {
+	ki, err := key.AsInt()
+	if err != nil {
+		return nil, ipld.ErrInvalidKey{"got " + key.ReprKind().String() + ", need Int"}
+	}
+	return x.LookupIndex(ki)
+}
+func (x Parents) LookupIndex(index int) (ipld.Node, error) {
+	if index >= len(x.x) {
+		return nil, ipld.ErrNotExists{ipld.PathSegmentOfInt(index)}
+	}
+	return x.x[index], nil
+}
+func (n Parents) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	idx, err := seg.Index()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupIndex(idx)
+}
+func (Parents) MapIterator() ipld.MapIterator {
+	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Parents", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}}
+}
+func (x Parents) ListIterator() ipld.ListIterator {
+	return &_Parents__Itr{&x, 0}
+}
+
+type _Parents__Itr struct {
+	node *Parents
+	idx  int
+}
+
+func (itr *_Parents__Itr) Next() (idx int, value ipld.Node, _ error) {
+	if itr.idx >= len(itr.node.x) {
+		return 0, nil, ipld.ErrIteratorOverread{}
+	}
+	idx = itr.idx
+	value = itr.node.x[idx]
+	itr.idx++
+	return
+}
+
+func (itr *_Parents__Itr) Done() bool {
+	return itr.idx >= len(itr.node.x)
+}
+
+func (x Parents) Length() int {
+	return len(x.x)
+}
+func (Parents) IsUndefined() bool {
+	return false
+}
+func (Parents) IsNull() bool {
+	return false
+}
+func (Parents) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_List}
+}
+func (Parents) NodeBuilder() ipld.NodeBuilder {
+	return _Parents__NodeBuilder{}
+}
+
+type _Parents__NodeBuilder struct{}
+
+func Parents__NodeBuilder() ipld.NodeBuilder {
+	return _Parents__NodeBuilder{}
+}
+func (_Parents__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (nb _Parents__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return &_Parents__ListBuilder{v: &Parents{}}, nil
+}
+
+type _Parents__ListBuilder struct {
+	v *Parents
+}
+
+func (lb *_Parents__ListBuilder) growList(k int) {
+	oldLen := len(lb.v.x)
+	minLen := k + 1
+	if minLen > oldLen {
+		// Grow.
+		oldCap := cap(lb.v.x)
+		if minLen > oldCap {
+			// Out of cap; do whole new backing array allocation.
+			//  Growth maths are per stdlib's reflect.grow.
+			// First figure out how much growth to do.
+			newCap := oldCap
+			if newCap == 0 {
+				newCap = minLen
+			} else {
+				for minLen > newCap {
+					if minLen < 1024 {
+						newCap += newCap
+					} else {
+						newCap += newCap / 4
+					}
+				}
+			}
+			// Now alloc and copy over old.
+			newArr := make([]Link, minLen, newCap)
+			copy(newArr, lb.v.x)
+			lb.v.x = newArr
+		} else {
+			// Still have cap, just extend the slice.
+			lb.v.x = lb.v.x[0:minLen]
+		}
+	}
+}
+
+func (lb *_Parents__ListBuilder) validate(v ipld.Node) error {
+	if v.IsNull() {
+		panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+	}
+	tv, ok := v.(typed.Node)
+	if !ok {
+		panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+	}
+	_, ok = v.(Link)
+	if !ok {
+		panic("value for type Parents is type Link; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+	}
+	return nil
+}
+
+func (lb *_Parents__ListBuilder) unsafeSet(idx int, v ipld.Node) {
+	x := v.(Link)
+	lb.v.x[idx] = x
+}
+
+func (lb *_Parents__ListBuilder) AppendAll(vs []ipld.Node) error {
+	for _, v := range vs {
+		err := lb.validate(v)
+		if err != nil {
+			return err
+		}
+	}
+	off := len(lb.v.x)
+	new := off + len(vs)
+	lb.growList(new - 1)
+	for _, v := range vs {
+		lb.unsafeSet(off, v)
+		off++
+	}
+	return nil
+}
+
+func (lb *_Parents__ListBuilder) Append(v ipld.Node) error {
+	err := lb.validate(v)
+	if err != nil {
+		return err
+	}
+	off := len(lb.v.x)
+	lb.growList(off)
+	lb.unsafeSet(off, v)
+	return nil
+}
+func (lb *_Parents__ListBuilder) Set(idx int, v ipld.Node) error {
+	err := lb.validate(v)
+	if err != nil {
+		return err
+	}
+	lb.growList(idx)
+	lb.unsafeSet(idx, v)
+	return nil
+}
+
+func (lb *_Parents__ListBuilder) Build() (ipld.Node, error) {
+	v := *lb.v
+	lb = nil
+	return v, nil
+}
+
+func (lb *_Parents__ListBuilder) BuilderForValue(_ int) ipld.NodeBuilder {
+	return Link__NodeBuilder()
+}
+
+func (nb _Parents__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	panic("TODO later")
+}
+func (_Parents__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_List}
+}
+func (_Parents__NodeBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Parents.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_List}
+}
+func (n Parents) Representation() ipld.Node {
+	panic("TODO representation")
+}
+
+type Messages struct {
+	x []Bytes
+}
+
+// TODO generateKindList.EmitNativeAccessors
+// TODO generateKindList.EmitNativeBuilder
+type MaybeMessages struct {
+	Maybe typed.Maybe
+	Value Messages
+}
+
+func (m MaybeMessages) Must() Messages {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = Messages{}
+var _ typed.Node = Messages{}
+
+func (Messages) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Messages) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_List
+}
+func (Messages) LookupString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "LookupString", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (x Messages) Lookup(key ipld.Node) (ipld.Node, error) {
+	ki, err := key.AsInt()
+	if err != nil {
+		return nil, ipld.ErrInvalidKey{"got " + key.ReprKind().String() + ", need Int"}
+	}
+	return x.LookupIndex(ki)
+}
+func (x Messages) LookupIndex(index int) (ipld.Node, error) {
+	if index >= len(x.x) {
+		return nil, ipld.ErrNotExists{ipld.PathSegmentOfInt(index)}
+	}
+	return x.x[index], nil
+}
+func (n Messages) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	idx, err := seg.Index()
+	if err != nil {
+		return nil, err
+	}
+	return n.LookupIndex(idx)
+}
+func (Messages) MapIterator() ipld.MapIterator {
+	return mapIteratorReject{ipld.ErrWrongKind{TypeName: "Messages", MethodName: "MapIterator", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}}
+}
+func (x Messages) ListIterator() ipld.ListIterator {
+	return &_Messages__Itr{&x, 0}
+}
+
+type _Messages__Itr struct {
+	node *Messages
+	idx  int
+}
+
+func (itr *_Messages__Itr) Next() (idx int, value ipld.Node, _ error) {
+	if itr.idx >= len(itr.node.x) {
+		return 0, nil, ipld.ErrIteratorOverread{}
+	}
+	idx = itr.idx
+	value = itr.node.x[idx]
+	itr.idx++
+	return
+}
+
+func (itr *_Messages__Itr) Done() bool {
+	return itr.idx >= len(itr.node.x)
+}
+
+func (x Messages) Length() int {
+	return len(x.x)
+}
+func (Messages) IsUndefined() bool {
+	return false
+}
+func (Messages) IsNull() bool {
+	return false
+}
+func (Messages) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_List}
+}
+func (Messages) NodeBuilder() ipld.NodeBuilder {
+	return _Messages__NodeBuilder{}
+}
+
+type _Messages__NodeBuilder struct{}
+
+func Messages__NodeBuilder() ipld.NodeBuilder {
+	return _Messages__NodeBuilder{}
+}
+func (_Messages__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "AmendMap", AppropriateKind: ipld.ReprKindSet_JustMap, ActualKind: ipld.ReprKind_List}
+}
+func (nb _Messages__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return &_Messages__ListBuilder{v: &Messages{}}, nil
+}
+
+type _Messages__ListBuilder struct {
+	v *Messages
+}
+
+func (lb *_Messages__ListBuilder) growList(k int) {
+	oldLen := len(lb.v.x)
+	minLen := k + 1
+	if minLen > oldLen {
+		// Grow.
+		oldCap := cap(lb.v.x)
+		if minLen > oldCap {
+			// Out of cap; do whole new backing array allocation.
+			//  Growth maths are per stdlib's reflect.grow.
+			// First figure out how much growth to do.
+			newCap := oldCap
+			if newCap == 0 {
+				newCap = minLen
+			} else {
+				for minLen > newCap {
+					if minLen < 1024 {
+						newCap += newCap
+					} else {
+						newCap += newCap / 4
+					}
+				}
+			}
+			// Now alloc and copy over old.
+			newArr := make([]Bytes, minLen, newCap)
+			copy(newArr, lb.v.x)
+			lb.v.x = newArr
+		} else {
+			// Still have cap, just extend the slice.
+			lb.v.x = lb.v.x[0:minLen]
+		}
+	}
+}
+
+func (lb *_Messages__ListBuilder) validate(v ipld.Node) error {
+	if v.IsNull() {
+		panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+	}
+	tv, ok := v.(typed.Node)
+	if !ok {
+		panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+	}
+	_, ok = v.(Bytes)
+	if !ok {
+		panic("value for type Messages is type Bytes; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+	}
+	return nil
+}
+
+func (lb *_Messages__ListBuilder) unsafeSet(idx int, v ipld.Node) {
+	x := v.(Bytes)
+	lb.v.x[idx] = x
+}
+
+func (lb *_Messages__ListBuilder) AppendAll(vs []ipld.Node) error {
+	for _, v := range vs {
+		err := lb.validate(v)
+		if err != nil {
+			return err
+		}
+	}
+	off := len(lb.v.x)
+	new := off + len(vs)
+	lb.growList(new - 1)
+	for _, v := range vs {
+		lb.unsafeSet(off, v)
+		off++
+	}
+	return nil
+}
+
+func (lb *_Messages__ListBuilder) Append(v ipld.Node) error {
+	err := lb.validate(v)
+	if err != nil {
+		return err
+	}
+	off := len(lb.v.x)
+	lb.growList(off)
+	lb.unsafeSet(off, v)
+	return nil
+}
+func (lb *_Messages__ListBuilder) Set(idx int, v ipld.Node) error {
+	err := lb.validate(v)
+	if err != nil {
+		return err
+	}
+	lb.growList(idx)
+	lb.unsafeSet(idx, v)
+	return nil
+}
+
+func (lb *_Messages__ListBuilder) Build() (ipld.Node, error) {
+	v := *lb.v
+	lb = nil
+	return v, nil
+}
+
+func (lb *_Messages__ListBuilder) BuilderForValue(_ int) ipld.NodeBuilder {
+	return Bytes__NodeBuilder()
+}
+
+func (nb _Messages__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	panic("TODO later")
+}
+func (_Messages__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_List}
+}
+func (_Messages__NodeBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Messages.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_List}
+}
+func (n Messages) Representation() ipld.Node {
+	panic("TODO representation")
+}
+
+type Block struct {
+	Parents  Parents
+	Messages Messages
+}
+
+func (x Parents) FieldParents() Parents {
+	// TODO going to tear through here with changes to Maybe system in a moment anyway
+	return Parents{}
+}
+func (x Messages) FieldMessages() Messages {
+	// TODO going to tear through here with changes to Maybe system in a moment anyway
+	return Messages{}
+}
+
+type Block__Content struct {
+	// TODO
+	// TODO
+}
+
+func (b Block__Content) Build() (Block, error) {
+	x := Block{
+		// TODO
+	}
+	// FUTURE : want to support customizable validation.
+	//   but 'if v, ok := x.(schema.Validatable); ok {' doesn't fly: need a way to work on concrete types.
+	return x, nil
+}
+func (b Block__Content) MustBuild() Block {
+	if x, err := b.Build(); err != nil {
+		panic(err)
+	} else {
+		return x
+	}
+}
+
+type MaybeBlock struct {
+	Maybe typed.Maybe
+	Value Block
+}
+
+func (m MaybeBlock) Must() Block {
+	if m.Maybe != typed.Maybe_Value {
+		panic("unbox of a maybe rejected")
+	}
+	return m.Value
+}
+
+var _ ipld.Node = Block{}
+var _ typed.Node = Block{}
+
+func (Block) Type() schema.Type {
+	return nil /*TODO:typelit*/
+}
+func (Block) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_Map
+}
+func (x Block) LookupString(key string) (ipld.Node, error) {
+	switch key {
+	case "Parents":
+		return x.Parents, nil
+	case "Messages":
+		return x.Messages, nil
+	default:
+		return nil, typed.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
+	}
+}
+func (x Block) Lookup(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, ipld.ErrInvalidKey{"got " + key.ReprKind().String() + ", need string"}
+	}
+	return x.LookupString(ks)
+}
+func (Block) LookupIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (n Block) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupString(seg.String())
+}
+func (x Block) MapIterator() ipld.MapIterator {
+	return &_Block__Itr{&x, 0}
+}
+
+type _Block__Itr struct {
+	node *Block
+	idx  int
+}
+
+func (itr *_Block__Itr) Next() (k ipld.Node, v ipld.Node, _ error) {
+	if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	switch itr.idx {
+	case 0:
+		k = String{"Parents"}
+		v = itr.node.Parents
+	case 1:
+		k = String{"Messages"}
+		v = itr.node.Messages
+	default:
+		panic("unreachable")
+	}
+	itr.idx++
+	return
+}
+func (itr *_Block__Itr) Done() bool {
+	return itr.idx >= 2
+}
+
+func (Block) ListIterator() ipld.ListIterator {
+	return listIteratorReject{ipld.ErrWrongKind{TypeName: "Block", MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}}
+}
+func (Block) Length() int {
+	return 2
+}
+func (Block) IsUndefined() bool {
+	return false
+}
+func (Block) IsNull() bool {
+	return false
+}
+func (Block) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Map}
+}
+func (Block) NodeBuilder() ipld.NodeBuilder {
+	return _Block__NodeBuilder{}
+}
+
+type _Block__NodeBuilder struct{}
+
+func Block__NodeBuilder() ipld.NodeBuilder {
+	return _Block__NodeBuilder{}
+}
+func (nb _Block__NodeBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return &_Block__MapBuilder{v: &Block{}}, nil
+}
+
+type _Block__MapBuilder struct {
+	v               *Block
+	Parents__isset  bool
+	Messages__isset bool
+}
+
+func (mb *_Block__MapBuilder) Insert(k, v ipld.Node) error {
+	ks, err := k.AsString()
+	if err != nil {
+		return ipld.ErrInvalidKey{"not a string: " + err.Error()}
+	}
+	switch ks {
+	case "Parents":
+		if v.IsNull() {
+			panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+		}
+		tv, ok := v.(typed.Node)
+		if !ok {
+			panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+		}
+		x, ok := v.(Parents)
+		if !ok {
+			panic("field 'Parents' in type Block is type Parents; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+		}
+		mb.v.Parents = x
+		mb.Parents__isset = true
+	case "Messages":
+		if v.IsNull() {
+			panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+		}
+		tv, ok := v.(typed.Node)
+		if !ok {
+			panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+		}
+		x, ok := v.(Messages)
+		if !ok {
+			panic("field 'Messages' in type Block is type Messages; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+		}
+		mb.v.Messages = x
+		mb.Messages__isset = true
+	default:
+		return typed.ErrNoSuchField{Type: nil /*TODO:typelit*/, FieldName: ks}
+	}
+	return nil
+}
+func (mb *_Block__MapBuilder) Delete(k ipld.Node) error {
+	panic("TODO later")
+}
+func (mb *_Block__MapBuilder) Build() (ipld.Node, error) {
+	if !mb.Parents__isset {
+		panic("missing required field 'Parents' in building struct Block") // FIXME need an error type for this
+	}
+	if !mb.Messages__isset {
+		panic("missing required field 'Messages' in building struct Block") // FIXME need an error type for this
+	}
+	v := *mb.v
+	mb = nil
+	return v, nil
+}
+func (mb *_Block__MapBuilder) BuilderForKeys() ipld.NodeBuilder {
+	return _String__NodeBuilder{}
+}
+func (mb *_Block__MapBuilder) BuilderForValue(ks string) ipld.NodeBuilder {
+	switch ks {
+	case "Parents":
+		return Parents__NodeBuilder()
+	case "Messages":
+		return Messages__NodeBuilder()
+	default:
+		panic(typed.ErrNoSuchField{Type: nil /*TODO:typelit*/, FieldName: ks})
+	}
+	return nil
+}
+
+func (nb _Block__NodeBuilder) AmendMap() (ipld.MapBuilder, error) {
+	panic("TODO later")
+}
+func (_Block__NodeBuilder) CreateList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) AmendList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__NodeBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Map}
+}
+func (n Block) Representation() ipld.Node {
+	return _Block__Repr{&n}
+}
+
+var _ ipld.Node = _Block__Repr{}
+
+type _Block__Repr struct {
+	n *Block
+}
+
+func (_Block__Repr) ReprKind() ipld.ReprKind {
+	return ipld.ReprKind_Map
+}
+func (rn _Block__Repr) LookupString(key string) (ipld.Node, error) {
+	switch key {
+	case "Parents":
+		return rn.n.Parents, nil
+	case "Messages":
+		return rn.n.Messages, nil
+	default:
+		return nil, typed.ErrNoSuchField{Type: nil /*TODO*/, FieldName: key}
+	}
+}
+func (rn _Block__Repr) Lookup(key ipld.Node) (ipld.Node, error) {
+	ks, err := key.AsString()
+	if err != nil {
+		return nil, ipld.ErrInvalidKey{"got " + key.ReprKind().String() + ", need string"}
+	}
+	return rn.LookupString(ks)
+}
+func (_Block__Repr) LookupIndex(idx int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "LookupIndex", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (n _Block__Repr) LookupSegment(seg ipld.PathSegment) (ipld.Node, error) {
+	return n.LookupString(seg.String())
+}
+func (rn _Block__Repr) MapIterator() ipld.MapIterator {
+	return &_Block__ReprItr{rn.n, 0}
+}
+
+type _Block__ReprItr struct {
+	node *Block
+	idx  int
+}
+
+func (itr *_Block__ReprItr) Next() (k ipld.Node, v ipld.Node, _ error) {
+	if itr.idx >= 2 {
+		return nil, nil, ipld.ErrIteratorOverread{}
+	}
+	for {
+		switch itr.idx {
+		case 0:
+			k = String{"Parents"}
+			v = itr.node.Parents
+		case 1:
+			k = String{"Messages"}
+			v = itr.node.Messages
+		default:
+			panic("unreachable")
+		}
+	}
+	itr.idx++
+	return
+}
+func (itr *_Block__ReprItr) Done() bool {
+	return itr.idx >= 2
+}
+
+func (_Block__Repr) ListIterator() ipld.ListIterator {
+	return listIteratorReject{ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "ListIterator", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}}
+}
+func (rn _Block__Repr) Length() int {
+	l := 2
+	return l
+}
+func (_Block__Repr) IsUndefined() bool {
+	return false
+}
+func (_Block__Repr) IsNull() bool {
+	return false
+}
+func (_Block__Repr) AsBool() (bool, error) {
+	return false, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) AsInt() (int, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) AsFloat() (float64, error) {
+	return 0, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) AsString() (string, error) {
+	return "", ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) AsBytes() ([]byte, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) AsLink() (ipld.Link, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation", MethodName: "AsLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__Repr) NodeBuilder() ipld.NodeBuilder {
+	return _Block__ReprBuilder{}
+}
+
+type _Block__ReprBuilder struct{}
+
+func Block__ReprBuilder() ipld.NodeBuilder {
+	return _Block__ReprBuilder{}
+}
+func (nb _Block__ReprBuilder) CreateMap() (ipld.MapBuilder, error) {
+	return &_Block__ReprMapBuilder{v: &Block{}}, nil
+}
+
+type _Block__ReprMapBuilder struct {
+	v               *Block
+	Parents__isset  bool
+	Messages__isset bool
+}
+
+func (mb *_Block__ReprMapBuilder) Insert(k, v ipld.Node) error {
+	ks, err := k.AsString()
+	if err != nil {
+		return ipld.ErrInvalidKey{"not a string: " + err.Error()}
+	}
+	switch ks {
+	case "Parents":
+		if mb.Parents__isset {
+			panic("repeated assignment to field") // FIXME need an error type for this
+		}
+		if v.IsNull() {
+			panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+		}
+		tv, ok := v.(typed.Node)
+		if !ok {
+			panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+		}
+		x, ok := v.(Parents)
+		if !ok {
+			panic("field 'Parents' (key: 'Parents') in type Block is type Parents; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+		}
+		mb.v.Parents = x
+		mb.Parents__isset = true
+	case "Messages":
+		if mb.Messages__isset {
+			panic("repeated assignment to field") // FIXME need an error type for this
+		}
+		if v.IsNull() {
+			panic("type mismatch on struct field assignment: cannot assign null to non-nullable field") // FIXME need an error type for this
+		}
+		tv, ok := v.(typed.Node)
+		if !ok {
+			panic("need typed.Node for insertion into struct") // FIXME need an error type for this
+		}
+		x, ok := v.(Messages)
+		if !ok {
+			panic("field 'Messages' (key: 'Messages') in type Block is type Messages; cannot assign " + tv.Type().Name()) // FIXME need an error type for this
+		}
+		mb.v.Messages = x
+		mb.Messages__isset = true
+	default:
+		return typed.ErrNoSuchField{Type: nil /*TODO:typelit*/, FieldName: ks}
+	}
+	return nil
+}
+func (mb *_Block__ReprMapBuilder) Delete(k ipld.Node) error {
+	panic("TODO later")
+}
+func (mb *_Block__ReprMapBuilder) Build() (ipld.Node, error) {
+	if !mb.Parents__isset {
+		panic("missing required field 'Parents' (key: 'Parents') in building struct Block") // FIXME need an error type for this
+	}
+	if !mb.Messages__isset {
+		panic("missing required field 'Messages' (key: 'Messages') in building struct Block") // FIXME need an error type for this
+	}
+	v := mb.v
+	mb = nil
+	return v, nil
+}
+func (mb *_Block__ReprMapBuilder) BuilderForKeys() ipld.NodeBuilder {
+	return _String__NodeBuilder{}
+}
+func (mb *_Block__ReprMapBuilder) BuilderForValue(ks string) ipld.NodeBuilder {
+	switch ks {
+	case "Parents":
+		return Parents__NodeBuilder()
+	case "Messages":
+		return Messages__NodeBuilder()
+	default:
+		panic(typed.ErrNoSuchField{Type: nil /*TODO:typelit*/, FieldName: ks})
+	}
+	return nil
+}
+
+func (nb _Block__ReprBuilder) AmendMap() (ipld.MapBuilder, error) {
+	panic("TODO later")
+}
+func (_Block__ReprBuilder) CreateList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) AmendList() (ipld.ListBuilder, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "AmendList", AppropriateKind: ipld.ReprKindSet_JustList, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateNull() (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateNull", AppropriateKind: ipld.ReprKindSet_JustNull, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateBool(bool) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateBool", AppropriateKind: ipld.ReprKindSet_JustBool, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateInt(int) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateInt", AppropriateKind: ipld.ReprKindSet_JustInt, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateFloat(float64) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateFloat", AppropriateKind: ipld.ReprKindSet_JustFloat, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateString(string) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateString", AppropriateKind: ipld.ReprKindSet_JustString, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateBytes([]byte) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateBytes", AppropriateKind: ipld.ReprKindSet_JustBytes, ActualKind: ipld.ReprKind_Map}
+}
+func (_Block__ReprBuilder) CreateLink(ipld.Link) (ipld.Node, error) {
+	return nil, ipld.ErrWrongKind{TypeName: "Block.Representation.Builder", MethodName: "CreateLink", AppropriateKind: ipld.ReprKindSet_JustLink, ActualKind: ipld.ReprKind_Map}
+}

--- a/testutil/chaintypes/testchain_minima.go
+++ b/testutil/chaintypes/testchain_minima.go
@@ -1,0 +1,14 @@
+package chaintypes
+
+import (
+	ipld "github.com/ipld/go-ipld-prime"
+)
+
+type mapIteratorReject struct{ err error }
+type listIteratorReject struct{ err error }
+
+func (itr mapIteratorReject) Next() (ipld.Node, ipld.Node, error) { return nil, nil, itr.err }
+func (itr mapIteratorReject) Done() bool                          { return false }
+
+func (itr listIteratorReject) Next() (int, ipld.Node, error) { return -1, nil, itr.err }
+func (itr listIteratorReject) Done() bool                    { return false }

--- a/testutil/testchain.go
+++ b/testutil/testchain.go
@@ -245,7 +245,7 @@ func (tbc *TestBlockChain) RemainderBlocks(from int) []blocks.Block {
 	return tbc.Blocks(from, tbc.blockChainLength)
 }
 
-// BlockChooser is a NodeBuilderChooser function that always returns the block chain
-func BlockChooser(ipld.Link, ipld.LinkContext) ipld.NodeBuilder {
+// Chooser is a NodeBuilderChooser function that always returns the block chain
+func (tbc *TestBlockChain) Chooser(ipld.Link, ipld.LinkContext) ipld.NodeBuilder {
 	return chaintypes.Block__NodeBuilder()
 }


### PR DESCRIPTION
# Goals

Background on the needs here:
- There's a strong need in the filecoin ecosystem to be able to swap out blockstores for certain types of requests
- One of the key paths to optimizing graphsync performance is to be able to use special ipld node types (code-gen'd) for specific use cases

# Implementation

This builds on the previous addition of swapping the loader and node-builder-chooser on the response side with similar hooks on the request side. Because the request side has to deal with storing as well as  loading, and in order to not end up with duplicate store operations, I've decided to uniquely identify loader/storer combos as alternate persistence options, distinguished by a unique string name. (toyed with trying to not require the string name, but as you know, go is not good with comparability in function types)

Implementation:
- Test Infra: Add a codegen'd node type for the existing test blockchain
- Add function to registering persistence options by name + loader/storer combo
- Add concept of outgoing request hook -- unlike the incoming hook (on the response manager), this hook modifies how outgoing requests from the request manager get processed
- Rename hooks to achieve name symmetry (only production use right now is FC, so we can handle updates)
- Add alternate queues to the async loading system -- split processing of responses by the persistence option they use
- Add request hooks to the request manager for outgoing request hooks
- Refactor the async loader tests significantly for conciseness and clarify, more DRY
- Refactor response manager hooks to use named persistence options rather than loader directly
- Build test chain using custom node types and add the ability to check that correct node types were used in traverse
- Add integration test to demonstrate round trip functionality -- loader and storing from an alternate store and using a custom node type.