### PR TITLE
feat(responsemanager): add listener for completed responses

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -217,6 +217,9 @@ type OnOutgoingBlockHook func(p peer.ID, request RequestData, block BlockData, h
 // It receives an interface to taking further action on the response
 type OnRequestUpdatedHook func(p peer.ID, request RequestData, updateRequest RequestData, hookActions RequestUpdatedHookActions)
 
+// OnResponseCompletedListener provides a way to listen for when responder has finished serving a response
+type OnResponseCompletedListener func(p peer.ID, request RequestData, status ResponseStatusCode)
+
 // UnregisterHookFunc is a function call to unregister a hook that was previously registered
 type UnregisterHookFunc func()
 
@@ -242,6 +245,9 @@ type GraphExchange interface {
 
 	// RegisterRequestUpdatedHook adds a hook that runs every time an update to a request is received
 	RegisterRequestUpdatedHook(hook OnRequestUpdatedHook) UnregisterHookFunc
+
+	// RegisterCompletedResponseListener adds a listener on the responder for completed responses
+	RegisterCompletedResponseListener(listener OnResponseCompletedListener) UnregisterHookFunc
 
 	// UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 	UnpauseResponse(peer.ID, RequestID) error

--- a/responsemanager/hooks/completedlisteners.go
+++ b/responsemanager/hooks/completedlisteners.go
@@ -1,0 +1,53 @@
+package hooks
+
+import (
+	"sync"
+
+	"github.com/ipfs/go-graphsync"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+type completedListener struct {
+	key      uint64
+	listener graphsync.OnResponseCompletedListener
+}
+
+// CompletedResponseListeners is a set of listeners for completed responses
+type CompletedResponseListeners struct {
+	listenersLk sync.RWMutex
+	nextKey     uint64
+	listeners   []completedListener
+}
+
+// NewCompletedResponseListeners returns a new list of completed response listeners
+func NewCompletedResponseListeners() *CompletedResponseListeners {
+	return &CompletedResponseListeners{}
+}
+
+// Register registers an listener for completed responses
+func (crl *CompletedResponseListeners) Register(listener graphsync.OnResponseCompletedListener) graphsync.UnregisterHookFunc {
+	crl.listenersLk.Lock()
+	cl := completedListener{crl.nextKey, listener}
+	crl.nextKey++
+	crl.listeners = append(crl.listeners, cl)
+	crl.listenersLk.Unlock()
+	return func() {
+		crl.listenersLk.Lock()
+		defer crl.listenersLk.Unlock()
+		for i, matchListener := range crl.listeners {
+			if cl.key == matchListener.key {
+				crl.listeners = append(crl.listeners[:i], crl.listeners[i+1:]...)
+				return
+			}
+		}
+	}
+}
+
+// NotifyCompletedListeners runs notifies all completed listeners that a response has completed
+func (crl *CompletedResponseListeners) NotifyCompletedListeners(p peer.ID, request graphsync.RequestData, status graphsync.ResponseStatusCode) {
+	crl.listenersLk.RLock()
+	defer crl.listenersLk.RUnlock()
+	for _, listener := range crl.listeners {
+		listener.listener(p, request, status)
+	}
+}

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -55,7 +55,7 @@ type PeerResponseSender interface {
 		data []byte,
 	) graphsync.BlockData
 	SendExtensionData(graphsync.RequestID, graphsync.ExtensionData)
-	FinishRequest(requestID graphsync.RequestID)
+	FinishRequest(requestID graphsync.RequestID) graphsync.ResponseStatusCode
 	FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode)
 	PauseRequest(requestID graphsync.RequestID)
 }
@@ -147,7 +147,7 @@ func (prm *peerResponseSender) SendResponse(
 }
 
 // FinishRequest marks the given requestID as having sent all responses
-func (prm *peerResponseSender) FinishRequest(requestID graphsync.RequestID) {
+func (prm *peerResponseSender) FinishRequest(requestID graphsync.RequestID) graphsync.ResponseStatusCode {
 	prm.linkTrackerLk.Lock()
 	isComplete := prm.linkTracker.FinishRequest(requestID)
 	prm.linkTrackerLk.Unlock()
@@ -158,6 +158,7 @@ func (prm *peerResponseSender) FinishRequest(requestID graphsync.RequestID) {
 		status = graphsync.RequestCompletedPartial
 	}
 	prm.finish(requestID, status)
+	return status
 }
 
 // FinishWithError marks the given requestID as having terminated with an error


### PR DESCRIPTION
# Goals

Provide a way for graphsync user to determine when it finishes responding to a received request

# Implementation

- Add one last hook -- this time just a listener -- that gets called on the responder side when we finish responding to requests
- modify PeerResponseSender to provide correct response status information for completed requests