### PR TITLE
fix(responsemanager): add nil check

### DIFF
--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -240,6 +240,10 @@ func (rm *ResponseManager) processQueriesWorker() {
 			case <-rm.ctx.Done():
 				return
 			}
+			if taskData == nil {
+				log.Info("Empty task on peer request stack")
+				continue
+			}
 			status, err := rm.executeTask(key, taskData)
 			select {
 			case rm.messages <- &finishTaskRequest{key, status, err}:


### PR DESCRIPTION
MInor: add nil check for an empty task (task deleted but not finished removing from peer task queue)