### PR TITLE
Incoming Block Hooks

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -214,7 +214,7 @@ type OnIncomingResponseHook func(p peer.ID, responseData ResponseData, hookActio
 // The difference between BlockSize & BlockSizeOnWire can be used to determine
 // where the block came from (Local vs remote)
 // It receives an interface for customizing how we handle the ongoing execution of the request
-type OnIncomingBlockHook func(p peer.ID, responseData ResponseData, blockData BlockData, hookActions IncomingResponseHookActions)
+type OnIncomingBlockHook func(p peer.ID, responseData ResponseData, blockData BlockData, hookActions IncomingBlockHookActions)
 
 // OnOutgoingRequestHook is a hook that runs immediately prior to sending a request
 // It receives the peer we're sending a request to and all the data aobut the request

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -169,6 +169,11 @@ func (gs *GraphSync) RegisterCompletedResponseListener(listener graphsync.OnResp
 	return gs.completedResponseListeners.Register(listener)
 }
 
+// RegisterIncomingBlockHook adds a hook that runs when a block is received and validated (put in block store)
+func (gs *GraphSync) RegisterIncomingBlockHook(_ graphsync.OnIncomingBlockHook) graphsync.UnregisterHookFunc {
+	return nil
+}
+
 // UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 func (gs *GraphSync) UnpauseResponse(p peer.ID, requestID graphsync.RequestID) error {
 	return gs.responseManager.UnpauseResponse(p, requestID)

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -342,6 +342,67 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 	require.Equal(t, td.extensionUpdateData, receivedUpdateData, "did not receive correct extension update data")
 }
 
+func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+
+	var receivedReponseData []byte
+	var receivedUpdateData []byte
+	// initialize graphsync on first node to make requests
+	requestor := td.GraphSyncHost1()
+
+	// setup receiving peer to just record message coming in
+	blockChainLength := 100
+	blockChain := testutil.SetupBlockChain(ctx, t, td.loader2, td.storer2, 100, blockChainLength)
+
+	stopPoint := 50
+	blocksReceived := 0
+	requestor.RegisterIncomingBlockHook(func(p peer.ID, response graphsync.ResponseData, block graphsync.BlockData, hookActions graphsync.IncomingBlockHookActions) {
+		blocksReceived++
+		if response.Status() == graphsync.RequestPaused && blocksReceived == stopPoint {
+			var has bool
+			receivedReponseData, has = response.Extension(td.extensionName)
+			if has {
+				hookActions.UpdateRequestWithExtensions(td.extensionUpdate)
+			}
+		}
+	})
+
+	// initialize graphsync on second node to response to requests
+	responder := td.GraphSyncHost2()
+	blocksSent := 0
+	responder.RegisterOutgoingBlockHook(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+		_, has := requestData.Extension(td.extensionName)
+		if has {
+			blocksSent++
+			if blocksSent == stopPoint {
+				hookActions.SendExtensionData(td.extensionResponse)
+				hookActions.PauseResponse()
+			}
+		} else {
+			hookActions.TerminateWithError(errors.New("should have sent extension"))
+		}
+	})
+	responder.RegisterRequestUpdatedHook(func(p peer.ID, request graphsync.RequestData, update graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+		var has bool
+		receivedUpdateData, has = update.Extension(td.extensionName)
+		if has {
+			hookActions.UnpauseResponse()
+		}
+	})
+	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
+
+	blockChain.VerifyWholeChain(ctx, progressChan)
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
+	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
+
+	require.Equal(t, td.extensionResponseData, receivedReponseData, "did not receive correct extension response data")
+	require.Equal(t, td.extensionUpdateData, receivedUpdateData, "did not receive correct extension update data")
+}
+
 func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
 	// create network
 	ctx := context.Background()

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
@@ -25,11 +25,8 @@ func NewLoadRequest(requestID graphsync.RequestID,
 }
 
 // LoadAttempter attempts to load a link to an array of bytes
-// it has three results:
-// bytes present, error nil = success
-// bytes nil, error present = error
-// bytes nil, error nil = did not load, but try again later
-type LoadAttempter func(graphsync.RequestID, ipld.Link) ([]byte, error)
+// and returns an async load result
+type LoadAttempter func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult
 
 // LoadAttemptQueue attempts to load using the load attempter, and then can
 // place requests on a retry queue
@@ -48,14 +45,9 @@ func New(loadAttempter LoadAttempter) *LoadAttemptQueue {
 // AttemptLoad attempts to loads the given load request, and if retry is true
 // it saves the loadrequest for retrying later
 func (laq *LoadAttemptQueue) AttemptLoad(lr LoadRequest, retry bool) {
-	response, err := laq.loadAttempter(lr.requestID, lr.link)
-	if err != nil {
-		lr.resultChan <- types.AsyncLoadResult{Data: nil, Err: err}
-		close(lr.resultChan)
-		return
-	}
-	if response != nil {
-		lr.resultChan <- types.AsyncLoadResult{Data: response, Err: nil}
+	response := laq.loadAttempter(lr.requestID, lr.link)
+	if response.Err != nil || response.Data != nil {
+		lr.resultChan <- response
 		close(lr.resultChan)
 		return
 	}

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue_test.go
@@ -19,9 +19,11 @@ func TestAsyncLoadInitialLoadSucceeds(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult {
 		callCount++
-		return testutil.RandomBytes(100), nil
+		return types.AsyncLoadResult{
+			Data: testutil.RandomBytes(100),
+		}
 	}
 	loadAttemptQueue := New(loadAttempter)
 
@@ -45,9 +47,11 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult {
 		callCount++
-		return nil, fmt.Errorf("something went wrong")
+		return types.AsyncLoadResult{
+			Err: fmt.Errorf("something went wrong"),
+		}
 	}
 	loadAttemptQueue := New(loadAttempter)
 
@@ -69,13 +73,15 @@ func TestAsyncLoadInitialLoadIndeterminateRetryFalse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	callCount := 0
-	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult {
 		var result []byte
 		if callCount > 0 {
 			result = testutil.RandomBytes(100)
 		}
 		callCount++
-		return result, nil
+		return types.AsyncLoadResult{
+			Data: result,
+		}
 	}
 
 	loadAttemptQueue := New(loadAttempter)
@@ -99,14 +105,16 @@ func TestAsyncLoadInitialLoadIndeterminateRetryTrueThenRetriedSuccess(t *testing
 	defer cancel()
 	callCount := 0
 	called := make(chan struct{}, 2)
-	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult {
 		var result []byte
 		called <- struct{}{}
 		if callCount > 0 {
 			result = testutil.RandomBytes(100)
 		}
 		callCount++
-		return result, nil
+		return types.AsyncLoadResult{
+			Data: result,
+		}
 	}
 	loadAttemptQueue := New(loadAttempter)
 
@@ -132,14 +140,16 @@ func TestAsyncLoadInitialLoadIndeterminateThenRequestFinishes(t *testing.T) {
 	defer cancel()
 	callCount := 0
 	called := make(chan struct{}, 2)
-	loadAttempter := func(graphsync.RequestID, ipld.Link) ([]byte, error) {
+	loadAttempter := func(graphsync.RequestID, ipld.Link) types.AsyncLoadResult {
 		var result []byte
 		called <- struct{}{}
 		if callCount > 0 {
 			result = testutil.RandomBytes(100)
 		}
 		callCount++
-		return result, nil
+		return types.AsyncLoadResult{
+			Data: result,
+		}
 	}
 	loadAttemptQueue := New(loadAttempter)
 

--- a/requestmanager/hooks/blockhooks.go
+++ b/requestmanager/hooks/blockhooks.go
@@ -1,0 +1,44 @@
+package hooks
+
+import (
+	"github.com/hannahhoward/go-pubsub"
+	"github.com/libp2p/go-libp2p-core/peer"
+
+	"github.com/ipfs/go-graphsync"
+)
+
+// IncomingBlockHooks is a set of incoming block hooks that can be processed
+type IncomingBlockHooks struct {
+	pubSub *pubsub.PubSub
+}
+
+type internalBlockHookEvent struct {
+	p        peer.ID
+	response graphsync.ResponseData
+	block    graphsync.BlockData
+	rha      *updateHookActions
+}
+
+func blockHookDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
+	ie := event.(internalBlockHookEvent)
+	hook := subscriberFn.(graphsync.OnIncomingBlockHook)
+	hook(ie.p, ie.response, ie.block, ie.rha)
+	return ie.rha.err
+}
+
+// NewBlockHooks returns a new list of incoming request hooks
+func NewBlockHooks() *IncomingBlockHooks {
+	return &IncomingBlockHooks{pubSub: pubsub.New(blockHookDispatcher)}
+}
+
+// Register registers an extension to process incoming responses
+func (ibh *IncomingBlockHooks) Register(hook graphsync.OnIncomingBlockHook) graphsync.UnregisterHookFunc {
+	return graphsync.UnregisterHookFunc(ibh.pubSub.Subscribe(hook))
+}
+
+// ProcessBlockHooks runs response hooks against an incoming response
+func (ibh *IncomingBlockHooks) ProcessBlockHooks(p peer.ID, response graphsync.ResponseData, block graphsync.BlockData) UpdateResult {
+	rha := &updateHookActions{}
+	_ = ibh.pubSub.Publish(internalBlockHookEvent{p, response, block, rha})
+	return rha.result()
+}

--- a/requestmanager/hooks/responsehooks.go
+++ b/requestmanager/hooks/responsehooks.go
@@ -15,7 +15,7 @@ type IncomingResponseHooks struct {
 type internalResponseHookEvent struct {
 	p        peer.ID
 	response graphsync.ResponseData
-	rha      *responseHookActions
+	rha      *updateHookActions
 }
 
 func responseHookDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
@@ -35,35 +35,35 @@ func (irh *IncomingResponseHooks) Register(hook graphsync.OnIncomingResponseHook
 	return graphsync.UnregisterHookFunc(irh.pubSub.Subscribe(hook))
 }
 
-// ResponseResult is the outcome of running response hooks
-type ResponseResult struct {
+// UpdateResult is the outcome of running response hooks
+type UpdateResult struct {
 	Err        error
 	Extensions []graphsync.ExtensionData
 }
 
 // ProcessResponseHooks runs response hooks against an incoming response
-func (irh *IncomingResponseHooks) ProcessResponseHooks(p peer.ID, response graphsync.ResponseData) ResponseResult {
-	rha := &responseHookActions{}
+func (irh *IncomingResponseHooks) ProcessResponseHooks(p peer.ID, response graphsync.ResponseData) UpdateResult {
+	rha := &updateHookActions{}
 	_ = irh.pubSub.Publish(internalResponseHookEvent{p, response, rha})
 	return rha.result()
 }
 
-type responseHookActions struct {
+type updateHookActions struct {
 	err        error
 	extensions []graphsync.ExtensionData
 }
 
-func (rha *responseHookActions) result() ResponseResult {
-	return ResponseResult{
+func (rha *updateHookActions) result() UpdateResult {
+	return UpdateResult{
 		Err:        rha.err,
 		Extensions: rha.extensions,
 	}
 }
 
-func (rha *responseHookActions) TerminateWithError(err error) {
+func (rha *updateHookActions) TerminateWithError(err error) {
 	rha.err = err
 }
 
-func (rha *responseHookActions) UpdateRequestWithExtensions(extensions ...graphsync.ExtensionData) {
+func (rha *updateHookActions) UpdateRequestWithExtensions(extensions ...graphsync.ExtensionData) {
 	rha.extensions = append(rha.extensions, extensions...)
 }

--- a/requestmanager/loader/loader.go
+++ b/requestmanager/loader/loader.go
@@ -16,6 +16,10 @@ import (
 // a channel which will eventually return data for the link or an err
 type AsyncLoadFn func(graphsync.RequestID, ipld.Link) <-chan types.AsyncLoadResult
 
+// OnNewBlockFn is a function that is called whenever a new block is successfully loaded
+// before the loader completes
+type OnNewBlockFn func(graphsync.BlockData) error
+
 // WrapAsyncLoader creates a regular ipld link laoder from an asynchronous load
 // function, with the given cancellation context, for the given requests, and will
 // transmit load errors on the given channel
@@ -23,7 +27,8 @@ func WrapAsyncLoader(
 	ctx context.Context,
 	asyncLoadFn AsyncLoadFn,
 	requestID graphsync.RequestID,
-	errorChan chan error) ipld.Loader {
+	errorChan chan error,
+	onNewBlockFn OnNewBlockFn) ipld.Loader {
 	return func(link ipld.Link, linkContext ipld.LinkContext) (io.Reader, error) {
 		resultChan := asyncLoadFn(requestID, link)
 		select {
@@ -38,7 +43,39 @@ func WrapAsyncLoader(
 					return nil, ipldutil.ErrDoNotFollow()
 				}
 			}
+			err := onNewBlockFn(&blockData{link, result.Local, uint64(len(result.Data))})
+			if err != nil {
+				select {
+				case <-ctx.Done():
+				case errorChan <- err:
+				}
+				return nil, err
+			}
 			return bytes.NewReader(result.Data), nil
 		}
 	}
+}
+
+type blockData struct {
+	link  ipld.Link
+	local bool
+	size  uint64
+}
+
+// Link is the link/cid for the block
+func (bd *blockData) Link() ipld.Link {
+	return bd.link
+}
+
+// BlockSize specifies the size of the block
+func (bd *blockData) BlockSize() uint64 {
+	return bd.size
+}
+
+// BlockSize specifies the amount of data actually transmitted over the network
+func (bd *blockData) BlockSizeOnWire() uint64 {
+	if bd.local {
+		return 0
+	}
+	return bd.size
 }

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -672,7 +672,7 @@ func TestBlockHooks(t *testing.T) {
 			metadata, has := receivedResponse.Extension(graphsync.ExtensionMetadata)
 			require.True(t, has)
 			require.Equal(t, firstMetadataEncoded, metadata, "should receive correct metadata")
-			receivedExtensionData, has := receivedResponse.Extension(extensionName1)
+			receivedExtensionData, _ := receivedResponse.Extension(extensionName1)
 			require.Equal(t, expectedData, receivedExtensionData, "should receive correct response extension data")
 			var receivedBlock graphsync.BlockData
 			testutil.AssertReceive(ctx, t, receivedBlocks, &receivedBlock, "did not receive block data")
@@ -686,6 +686,7 @@ func TestBlockHooks(t *testing.T) {
 		nextBlocks := td.blockChain.RemainderBlocks(3)
 		nextMetadata := metadataForBlocks(nextBlocks, true)
 		nextMetadataEncoded, err := metadata.EncodeMetadata(nextMetadata)
+		require.NoError(t, err)
 		secondResponses := []gsmsg.GraphSyncResponse{
 			gsmsg.NewResponse(gsr.ID(),
 				graphsync.RequestCompletedFull, graphsync.ExtensionData{
@@ -738,7 +739,7 @@ func TestBlockHooks(t *testing.T) {
 			metadata, has := receivedResponse.Extension(graphsync.ExtensionMetadata)
 			require.True(t, has)
 			require.Equal(t, nextMetadataEncoded, metadata, "should receive correct metadata")
-			receivedExtensionData, has := receivedResponse.Extension(extensionName1)
+			receivedExtensionData, _ := receivedResponse.Extension(extensionName1)
 			require.Equal(t, nextExpectedData, receivedExtensionData, "should receive correct response extension data")
 			var receivedBlock graphsync.BlockData
 			testutil.AssertReceive(ctx, t, receivedBlocks, &receivedBlock, "did not receive block data")

--- a/requestmanager/types/data.go
+++ b/requestmanager/types/data.go
@@ -2,6 +2,7 @@ package types
 
 // AsyncLoadResult is sent once over the channel returned by an async load.
 type AsyncLoadResult struct {
-	Data []byte
-	Err  error
+	Data  []byte
+	Local bool
+	Err   error
 }

--- a/responsemanager/hooks/hooks_test.go
+++ b/responsemanager/hooks/hooks_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"github.com/ipfs/go-graphsync/testutil"
 	"github.com/ipld/go-ipld-prime"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal/selector/builder"
 	peer "github.com/libp2p/go-libp2p-core/peer"
@@ -203,23 +202,6 @@ func TestRequestHookProcessing(t *testing.T) {
 	}
 }
 
-type fakeBlkData struct {
-	link ipld.Link
-	size uint64
-}
-
-func (fbd fakeBlkData) Link() ipld.Link {
-	return fbd.link
-}
-
-func (fbd fakeBlkData) BlockSize() uint64 {
-	return fbd.size
-}
-
-func (fbd fakeBlkData) BlockSizeOnWire() uint64 {
-	return fbd.size
-}
-
 func TestBlockHookProcessing(t *testing.T) {
 	extensionData := testutil.RandomBytes(100)
 	extensionName := graphsync.ExtensionName("AppleSauce/McGee")
@@ -238,10 +220,7 @@ func TestBlockHookProcessing(t *testing.T) {
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 	request := gsmsg.NewRequest(requestID, root, ssb.Matcher().Node(), graphsync.Priority(0), extension)
 	p := testutil.GeneratePeers(1)[0]
-	blockData := &fakeBlkData{
-		link: cidlink.Link{Cid: testutil.GenerateCids(1)[0]},
-		size: rand.Uint64(),
-	}
+	blockData := testutil.NewFakeBlockData()
 	testCases := map[string]struct {
 		configure func(t *testing.T, blockHooks *hooks.OutgoingBlockHooks)
 		assert    func(t *testing.T, result hooks.BlockResult)

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -42,12 +42,10 @@ type peerResponseSender struct {
 	peerHandler  PeerMessageHandler
 	outgoingWork chan struct{}
 
-	linkTrackerLk        sync.RWMutex
-	linkTracker          *linktracker.LinkTracker
-	responseBuildersLk   sync.RWMutex
-	responseBuilders     []*responsebuilder.ResponseBuilder
-	transactionLk        sync.RWMutex
-	transactionRequestID *graphsync.RequestID
+	linkTrackerLk      sync.RWMutex
+	linkTracker        *linktracker.LinkTracker
+	responseBuildersLk sync.RWMutex
+	responseBuilders   []*responsebuilder.ResponseBuilder
 }
 
 // PeerResponseSender handles batching, deduping, and sending responses for

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"bytes"
 	"context"
+	"math/rand"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -224,4 +225,29 @@ func VerifyEmptyResponse(ctx context.Context, t *testing.T, responseChan <-chan 
 // NewTestLink returns a randomly generated IPLD Link
 func NewTestLink() ipld.Link {
 	return cidlink.Link{Cid: GenerateCids(1)[0]}
+}
+
+type fakeBlkData struct {
+	link ipld.Link
+	size uint64
+}
+
+func (fbd fakeBlkData) Link() ipld.Link {
+	return fbd.link
+}
+
+func (fbd fakeBlkData) BlockSize() uint64 {
+	return fbd.size
+}
+
+func (fbd fakeBlkData) BlockSizeOnWire() uint64 {
+	return fbd.size
+}
+
+// NewFakeBlockData returns a fake block that matches the block data interface
+func NewFakeBlockData() graphsync.BlockData {
+	return &fakeBlkData{
+		link: cidlink.Link{Cid: GenerateCids(1)[0]},
+		size: rand.Uint64(),
+	}
 }


### PR DESCRIPTION
# Goals

Provide a mechanism to execute hooks on the client side as each block is successfully verified and loaded

# Implementation

- Define block hook interfaces
- Modify AsyncLoadResult to identify if request was loaded from local blockstore or from response from network
- Add block hooks infrastructure to requestmanager side -- using same pubsub interface
- Add block hook processing to the request manager & its loader. What this looks like is:
   - Add an extra parameter to the wrapped async loader to run a block hook on each successfully loaded block
   - Refactor setup request to seperate request validation and request processing
   - add an atomic.Value to each inProgressRequestStatus to track the last response received
   - add code to update last response received
   - when each block is loaded, the block hook function in the loader reads the last response for this request, then passes it to the block hooks to process, then takes action based on result
- Add transactions to the response sender -- this allows us to insure groups of response operations are sent in a single response -- fixes an existing bug with block hooks