### PR TITLE
Implement do-no-send-cids extension

### DIFF
--- a/cidset/cidset.go
+++ b/cidset/cidset.go
@@ -1,0 +1,48 @@
+package cidset
+
+import (
+	"errors"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync/ipldutil"
+	"github.com/ipld/go-ipld-prime/fluent"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+// EncodeCidSet encodes a cid set into bytes for the do-no-send-cids extension
+func EncodeCidSet(cids *cid.Set) ([]byte, error) {
+	list := fluent.MustBuildList(basicnode.Style.List, cids.Len(), func(la fluent.ListAssembler) {
+		_ = cids.ForEach(func(c cid.Cid) error {
+			la.AssembleValue().AssignLink(cidlink.Link{Cid: c})
+			return nil
+		})
+	})
+	return ipldutil.EncodeNode(list)
+}
+
+// DecodeCidSet decode a cid set from data for the do-no-send-cids extension
+func DecodeCidSet(data []byte) (*cid.Set, error) {
+	list, err := ipldutil.DecodeNode(data)
+	if err != nil {
+		return nil, err
+	}
+	set := cid.NewSet()
+	iter := list.ListIterator()
+	for !iter.Done() {
+		_, next, err := iter.Next()
+		if err != nil {
+			return nil, err
+		}
+		link, err := next.AsLink()
+		if err != nil {
+			return nil, err
+		}
+		asCidLink, ok := link.(cidlink.Link)
+		if !ok {
+			return nil, errors.New("contained non CID link")
+		}
+		set.Add(asCidLink.Cid)
+	}
+	return set, nil
+}

--- a/cidset/cidset_test.go
+++ b/cidset/cidset_test.go
@@ -1,0 +1,27 @@
+package cidset
+
+import (
+	"testing"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecodeEncodeCidSet(t *testing.T) {
+	cids := testutil.GenerateCids(10)
+	set := cid.NewSet()
+	for _, c := range cids {
+		set.Add(c)
+	}
+	encoded, err := EncodeCidSet(set)
+	require.NoError(t, err, "encode errored")
+	decodedCidSet, err := DecodeCidSet(encoded)
+	require.NoError(t, err, "decode errored")
+	require.Equal(t, decodedCidSet.Len(), set.Len())
+	err = decodedCidSet.ForEach(func(c cid.Cid) error {
+		require.True(t, set.Has(c))
+		return nil
+	})
+	require.NoError(t, err)
+}

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -52,6 +52,7 @@ type peerResponseSender struct {
 // a given peer across multiple requests.
 type PeerResponseSender interface {
 	peermanager.PeerProcess
+	IgnoreBlocks(requestID graphsync.RequestID, links []ipld.Link)
 	SendResponse(
 		requestID graphsync.RequestID,
 		link ipld.Link,
@@ -95,6 +96,14 @@ func NewResponseSender(ctx context.Context, p peer.ID, peerHandler PeerMessageHa
 // Startup initiates message sending for a peer
 func (prs *peerResponseSender) Startup() {
 	go prs.run()
+}
+
+func (prs *peerResponseSender) IgnoreBlocks(requestID graphsync.RequestID, links []ipld.Link) {
+	prs.linkTrackerLk.Lock()
+	for _, link := range links {
+		prs.linkTracker.RecordLinkTraversal(requestID, link, true)
+	}
+	prs.linkTrackerLk.Unlock()
 }
 
 type responseOperation interface {

--- a/responsemanager/peerresponsemanager/peerresponsesender_test.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender_test.go
@@ -32,7 +32,7 @@ func (fph *fakePeerHandler) SendResponse(p peer.ID, responses []gsmsg.GraphSyncR
 	return fph.done
 }
 
-func TestPeerResponseManagerSendsResponses(t *testing.T) {
+func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -134,7 +134,7 @@ func TestPeerResponseManagerSendsResponses(t *testing.T) {
 	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
 }
 
-func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
+func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
 
 	p := testutil.GeneratePeers(1)[0]
 	requestID1 := graphsync.RequestID(rand.Int31())
@@ -222,7 +222,7 @@ func TestPeerResponseManagerSendsVeryLargeBlocksResponses(t *testing.T) {
 
 }
 
-func TestPeerResponseManagerSendsExtensionData(t *testing.T) {
+func TestPeerResponseSenderSendsExtensionData(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -285,7 +285,7 @@ func TestPeerResponseManagerSendsExtensionData(t *testing.T) {
 	require.Equal(t, extensionData2, returnedData2, "did not encode first extension")
 }
 
-func TestPeerResponseManagerSendsResponsesInTransaction(t *testing.T) {
+func TestPeerResponseSenderSendsResponsesInTransaction(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -332,7 +332,87 @@ func TestPeerResponseManagerSendsResponsesInTransaction(t *testing.T) {
 	})
 	require.NoError(t, err)
 	testutil.AssertDoesReceive(ctx, t, sent, "should sent first message")
+}
 
+func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	p := testutil.GeneratePeers(1)[0]
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+	links := make([]ipld.Link, 0, len(blks))
+	for _, block := range blks {
+		links = append(links, cidlink.Link{Cid: block.Cid()})
+	}
+	done := make(chan struct{}, 1)
+	sent := make(chan struct{}, 1)
+	fph := &fakePeerHandler{
+		done: done,
+		sent: sent,
+	}
+	peerResponseSender := NewResponseSender(ctx, p, fph)
+	peerResponseSender.Startup()
+
+	peerResponseSender.IgnoreBlocks(requestID1, links)
+
+	bd := peerResponseSender.SendResponse(requestID1, links[0], blks[0].RawData())
+	require.Equal(t, links[0], bd.Link())
+	require.Equal(t, uint64(len(blks[0].RawData())), bd.BlockSize())
+	require.Equal(t, uint64(0), bd.BlockSizeOnWire())
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send first message")
+
+	require.Len(t, fph.lastBlocks, 0)
+
+	require.Len(t, fph.lastResponses, 1)
+	require.Equal(t, requestID1, fph.lastResponses[0].RequestID())
+	require.Equal(t, graphsync.PartialResponse, fph.lastResponses[0].Status())
+
+	bd = peerResponseSender.SendResponse(requestID2, links[0], blks[0].RawData())
+	require.Equal(t, links[0], bd.Link())
+	require.Equal(t, uint64(len(blks[0].RawData())), bd.BlockSize())
+	require.Equal(t, uint64(0), bd.BlockSizeOnWire())
+	bd = peerResponseSender.SendResponse(requestID1, links[1], blks[1].RawData())
+	require.Equal(t, links[1], bd.Link())
+	require.Equal(t, uint64(len(blks[1].RawData())), bd.BlockSize())
+	require.Equal(t, uint64(0), bd.BlockSizeOnWire())
+	bd = peerResponseSender.SendResponse(requestID1, links[2], blks[2].RawData())
+	require.Equal(t, links[2], bd.Link())
+	require.Equal(t, uint64(len(blks[2].RawData())), bd.BlockSize())
+	require.Equal(t, uint64(0), bd.BlockSizeOnWire())
+	peerResponseSender.FinishRequest(requestID1)
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send second message")
+
+	require.Len(t, fph.lastBlocks, 0)
+
+	require.Len(t, fph.lastResponses, 2, "did not send correct number of responses")
+	response1, err := findResponseForRequestID(fph.lastResponses, requestID1)
+	require.NoError(t, err)
+	require.Equal(t, graphsync.RequestCompletedFull, response1.Status(), "did not send correct response code in second message")
+	response2, err := findResponseForRequestID(fph.lastResponses, requestID2)
+	require.NoError(t, err)
+	require.Equal(t, graphsync.PartialResponse, response2.Status(), "did not send corrent response code in second message")
+
+	peerResponseSender.SendResponse(requestID2, links[3], blks[3].RawData())
+	peerResponseSender.FinishRequest(requestID2)
+
+	// let peer reponse manager know last message was sent so message sending can continue
+	done <- struct{}{}
+
+	testutil.AssertDoesReceive(ctx, t, sent, "did not send third message")
+
+	require.Equal(t, 1, len(fph.lastBlocks))
+	testutil.AssertContainsBlock(t, fph.lastBlocks, blks[3])
+
+	require.Len(t, fph.lastResponses, 1, "did not send correct number of responses")
+	response2, err = findResponseForRequestID(fph.lastResponses, requestID2)
+	require.NoError(t, err)
+	require.Equal(t, graphsync.RequestCompletedFull, response2.Status(), "did not send correct response code in third message")
 }
 
 func findResponseForRequestID(responses []gsmsg.GraphSyncResponse, requestID graphsync.RequestID) (gsmsg.GraphSyncResponse, error) {


### PR DESCRIPTION
# Goals

Provide responder side implementation of https://github.com/ipld/specs/blob/master/block-layer/graphsync/known_extensions.md#do-not-send-cids

# Implementation

- add functionality to peerResponseSender to preload links into the link tracker so blocks aren't sent
- add decode/encode functionality to/from specified cbor-encoded IPLD structure for cid.Set
- add code to process extension and pass links on to peerResponseSender in ResponseManager