### PR TITLE
Refactor request execution and use IPLD SkipMe functionality for proper partial results on a request

### DIFF
--- a/ipldutil/ipldutil.go
+++ b/ipldutil/ipldutil.go
@@ -3,7 +3,6 @@ package ipldutil
 import (
 	"bytes"
 	"context"
-	"errors"
 
 	ipld "github.com/ipld/go-ipld-prime"
 	dagpb "github.com/ipld/go-ipld-prime-proto"
@@ -14,13 +13,6 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 	ipldselector "github.com/ipld/go-ipld-prime/traversal/selector"
 )
-
-var errDoNotFollow = errors.New("Dont Follow Me")
-
-// ErrDoNotFollow is just a wrapper for whatever IPLD's ErrDoNotFollow ends up looking like
-func ErrDoNotFollow() error {
-	return errDoNotFollow
-}
 
 var (
 	defaultChooser traversal.LinkTargetNodeStyleChooser = dagpb.AddDagPBSupportToChooser(func(ipld.Link, ipld.LinkContext) (ipld.NodeStyle, error) {

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"context"
+
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/ipldutil"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/requestmanager/loader"
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal"
+)
+
+// RequestExecution runs a single graphsync request with data loaded from the
+// asynchronous loader
+type RequestExecution struct {
+	Request          gsmsg.GraphSyncRequest
+	SendRequest      func(gsmsg.GraphSyncRequest)
+	Loader           loader.AsyncLoadFn
+	RunBlockHooks    func(blk graphsync.BlockData) error
+	TerminateRequest func()
+	NodeStyleChooser traversal.LinkTargetNodeStyleChooser
+}
+
+// Start begins execution of a request in a go routine
+func (re RequestExecution) Start(ctx context.Context) (chan graphsync.ResponseProgress, chan error) {
+	executor := &requestExecutor{
+		inProgressChan:   make(chan graphsync.ResponseProgress),
+		inProgressErr:    make(chan error),
+		ctx:              ctx,
+		request:          re.Request,
+		sendRequest:      re.SendRequest,
+		loader:           re.Loader,
+		runBlockHooks:    re.RunBlockHooks,
+		terminateRequest: re.TerminateRequest,
+		nodeStyleChooser: re.NodeStyleChooser,
+	}
+	executor.sendRequest(executor.request)
+	go executor.run()
+	return executor.inProgressChan, executor.inProgressErr
+}
+
+type requestExecutor struct {
+	inProgressChan   chan graphsync.ResponseProgress
+	inProgressErr    chan error
+	ctx              context.Context
+	request          gsmsg.GraphSyncRequest
+	sendRequest      func(gsmsg.GraphSyncRequest)
+	loader           loader.AsyncLoadFn
+	runBlockHooks    func(blk graphsync.BlockData) error
+	terminateRequest func()
+	nodeStyleChooser traversal.LinkTargetNodeStyleChooser
+}
+
+func (re *requestExecutor) visitor(tp traversal.Progress, node ipld.Node, tr traversal.VisitReason) error {
+	select {
+	case <-re.ctx.Done():
+	case re.inProgressChan <- graphsync.ResponseProgress{
+		Node:      node,
+		Path:      tp.Path,
+		LastBlock: tp.LastBlock,
+	}:
+	}
+	return nil
+}
+
+func (re *requestExecutor) run() {
+	selector, _ := ipldutil.ParseSelector(re.request.Selector())
+	loaderFn := loader.WrapAsyncLoader(re.ctx, re.loader, re.request.ID(), re.inProgressErr, re.runBlockHooks)
+	_ = ipldutil.Traverse(re.ctx, loaderFn, re.nodeStyleChooser, cidlink.Link{Cid: re.request.Root()}, selector, re.visitor)
+	re.terminateRequest()
+	close(re.inProgressChan)
+	close(re.inProgressErr)
+}

--- a/requestmanager/utils.go
+++ b/requestmanager/utils.go
@@ -1,28 +1,10 @@
 package requestmanager
 
 import (
-	"context"
-
 	"github.com/ipfs/go-graphsync"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
-	ipld "github.com/ipld/go-ipld-prime"
-	"github.com/ipld/go-ipld-prime/traversal"
 )
-
-func visitToChannel(ctx context.Context, inProgressChan chan graphsync.ResponseProgress) traversal.AdvVisitFn {
-	return func(tp traversal.Progress, node ipld.Node, tr traversal.VisitReason) error {
-		select {
-		case <-ctx.Done():
-		case inProgressChan <- graphsync.ResponseProgress{
-			Node:      node,
-			Path:      tp.Path,
-			LastBlock: tp.LastBlock,
-		}:
-		}
-		return nil
-	}
-}
 
 func metadataForResponses(responses []gsmsg.GraphSyncResponse) map[graphsync.RequestID]metadata.Metadata {
 	responseMetadata := make(map[graphsync.RequestID]metadata.Metadata, len(responses))

--- a/responsemanager/runtraversal/runtraversal.go
+++ b/responsemanager/runtraversal/runtraversal.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ipfs/go-graphsync/ipldutil"
 	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/traversal"
 )
 
 // ResponseSender sends responses over the network
@@ -29,7 +30,7 @@ func RunTraversal(
 		result, err := loader(lnk, lnkCtx)
 		var data []byte
 		if err != nil {
-			traverser.Error(err)
+			traverser.Error(traversal.SkipMe{})
 		} else {
 			var blockBuffer bytes.Buffer
 			_, err = io.Copy(&blockBuffer, result)

--- a/responsemanager/runtraversal/runtraversal_test.go
+++ b/responsemanager/runtraversal/runtraversal_test.go
@@ -11,6 +11,7 @@ import (
 
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal"
 )
 
 type fakeResponseKey struct {
@@ -171,7 +172,7 @@ func TestRunTraversal(t *testing.T) {
 			loadOutcomes: []traverseOutcome{
 				{false, nil, blks[0].RawData()},
 				{false, nil, blks[1].RawData()},
-				{true, errors.New("block not found"), nil},
+				{true, traversal.SkipMe{}, nil},
 			},
 			errorsOnSend: []error{
 				nil, nil, nil,


### PR DESCRIPTION
# Goals

In preparation for adding pause/resume to the request side of graphsync, refactor some code into a request "executor module". Also properly implement skipping parts of the tree that are missing -- at the time we originally wrote graphsync, IPLD selectors had not abilty to "skip" on block load errors but now they have this ability.

# Implementation

- extract code that runs in a go routine for request execution to its own module
   - also removes need for a seperate networkErrorChannel
- remove visitToChannel function
- Properly use IPLD SkipMe's so we can complete graphsync requests where provider is missing some branches