### PR TITLE
Pause/Resume of requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,4 +39,5 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/tools v0.0.0-20191216173652-a0e659d51361 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-libp2p v0.6.0
 	github.com/libp2p/go-libp2p-core v0.5.0
+	github.com/libp2p/go-libp2p-peer v0.2.0
 	github.com/libp2p/go-libp2p-record v0.1.1 // indirect
 	github.com/multiformats/go-multiaddr v0.2.1
 	github.com/multiformats/go-multihash v0.0.13
@@ -39,5 +40,4 @@ require (
 	go.uber.org/multierr v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20190724013045-ca1201d0de80 // indirect
 	golang.org/x/tools v0.0.0-20191216173652-a0e659d51361 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543
 )

--- a/graphsync.go
+++ b/graphsync.go
@@ -273,6 +273,9 @@ type GraphExchange interface {
 	// Can also send extensions with unpause
 	UnpauseRequest(RequestID, ...ExtensionData) error
 
+	// PauseRequest pauses an in progress request (may take 1 or more blocks to process)
+	PauseRequest(RequestID) error
+
 	// UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 	// Can also send extensions with unpause
 	UnpauseResponse(peer.ID, RequestID, ...ExtensionData) error

--- a/graphsync.go
+++ b/graphsync.go
@@ -187,6 +187,7 @@ type IncomingResponseHookActions interface {
 type IncomingBlockHookActions interface {
 	TerminateWithError(error)
 	UpdateRequestWithExtensions(...ExtensionData)
+	PauseRequest()
 }
 
 // RequestUpdatedHookActions are actions that can be taken in a request updated hook to

--- a/graphsync.go
+++ b/graphsync.go
@@ -269,6 +269,10 @@ type GraphExchange interface {
 	// RegisterCompletedResponseListener adds a listener on the responder for completed responses
 	RegisterCompletedResponseListener(listener OnResponseCompletedListener) UnregisterHookFunc
 
+	// UnpauseRequest unpauses a request that was paused in a block hook based request ID
+	// Can also send extensions with unpause
+	UnpauseRequest(RequestID, ...ExtensionData) error
+
 	// UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 	// Can also send extensions with unpause
 	UnpauseResponse(peer.ID, RequestID, ...ExtensionData) error

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -183,6 +183,11 @@ func (gs *GraphSync) UnpauseRequest(requestID graphsync.RequestID, extensions ..
 	return gs.requestManager.UnpauseRequest(requestID, extensions...)
 }
 
+// PauseRequest pauses an in progress request (may take 1 or more blocks to process)
+func (gs *GraphSync) PauseRequest(requestID graphsync.RequestID) error {
+	return gs.requestManager.PauseRequest(requestID)
+}
+
 // UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 func (gs *GraphSync) UnpauseResponse(p peer.ID, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
 	return gs.responseManager.UnpauseResponse(p, requestID, extensions...)

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -177,6 +177,12 @@ func (gs *GraphSync) RegisterIncomingBlockHook(hook graphsync.OnIncomingBlockHoo
 	return gs.incomingBlockHooks.Register(hook)
 }
 
+// UnpauseRequest unpauses a request that was paused in a block hook based request ID
+// Can also send extensions with unpause
+func (gs *GraphSync) UnpauseRequest(requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
+	return gs.requestManager.UnpauseRequest(requestID, extensions...)
+}
+
 // UnpauseResponse unpauses a response that was paused in a block hook based on peer ID and request ID
 func (gs *GraphSync) UnpauseResponse(p peer.ID, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
 	return gs.responseManager.UnpauseResponse(p, requestID, extensions...)

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -443,6 +443,7 @@ func TestPauseResumeRequest(t *testing.T) {
 
 	require.Equal(t, (100 - stopPoint), totalSentAfterPause)
 }
+
 func TestPauseResumeViaUpdate(t *testing.T) {
 	// create network
 	ctx := context.Background()

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -16,7 +16,7 @@ import (
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/ipld/go-ipld-prime/traversal/selector"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 // ExecutionEnv are request parameters that last between requests

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
-	peer "github.com/libp2p/go-libp2p-peer"
+	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 )
 

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -1,0 +1,164 @@
+package executor_test
+
+import (
+	"context"
+	"errors"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/requestmanager/executor"
+	"github.com/ipfs/go-graphsync/requestmanager/loader"
+	"github.com/ipfs/go-graphsync/requestmanager/testloader"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRequestExecutionBlockChain(t *testing.T) {
+	testCases := map[string]struct {
+		configureLoader           func(requestID graphsync.RequestID, tbc *testutil.TestBlockChain, fal *testloader.FakeAsyncLoader)
+		configureRequestExecution func(requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv)
+		verifyResults             func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error)
+	}{
+		"simple success case": {
+			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
+				tbc.VerifyWholeChainSync(responses)
+				require.Empty(t, receivedErrors)
+				require.Equal(t, 0, ree.currentWaitForResumeResult)
+				require.Equal(t, []gsmsg.GraphSyncRequest{ree.request}, ree.requestsSent)
+				require.Len(t, ree.blookHooksCalled, 10)
+				require.True(t, ree.terminateRequested)
+				require.True(t, ree.nodeStyleChooserCalled)
+			},
+		},
+		"error at block hook": {
+			configureRequestExecution: func(requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
+				ree.blockHookResults[tbc.LinkTipIndex(5)] = errors.New("something went wrong")
+			},
+			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
+				tbc.VerifyResponseRangeSync(responses, 0, 5)
+				require.Len(t, receivedErrors, 1)
+				require.True(t, errors.Is(receivedErrors[0], errors.New("something went wrong")))
+				require.Equal(t, 0, ree.currentWaitForResumeResult)
+				require.Equal(t, []gsmsg.GraphSyncRequest{ree.request}, ree.requestsSent)
+				require.Len(t, ree.blookHooksCalled, 5)
+				require.True(t, ree.terminateRequested)
+				require.True(t, ree.nodeStyleChooserCalled)
+			},
+		},
+	}
+	for testCase, data := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			loader, storer := testutil.NewTestStore(make(map[ipld.Link][]byte))
+			tbc := testutil.SetupBlockChain(ctx, t, loader, storer, 100, 10)
+			fal := testloader.NewFakeAsyncLoader()
+			requestID := graphsync.RequestID(rand.Int31())
+			if data.configureLoader == nil {
+				fal.SuccessResponseOn(requestID, tbc.AllBlocks())
+			} else {
+				data.configureLoader(requestID, tbc, fal)
+			}
+			ree := &requestExecutionEnv{
+				blockHookResults: make(map[ipld.Link]error),
+				doNotSendCids:    cid.NewSet(),
+				request:          gsmsg.NewRequest(requestID, tbc.TipLink.(cidlink.Link).Cid, tbc.Selector(), graphsync.Priority(rand.Int31())),
+				loader:           fal.AsyncLoad,
+			}
+			if data.configureRequestExecution != nil {
+				data.configureRequestExecution(requestID, tbc, ree)
+			}
+			inProgress, inProgressErr := ree.requestExecution().Start(ctx)
+			var responsesReceived []graphsync.ResponseProgress
+			var errorsReceived []error
+			var inProgressDone, inProgressErrDone bool
+			for !inProgressDone || !inProgressErrDone {
+				select {
+				case response, ok := <-inProgress:
+					if !ok {
+						inProgress = nil
+						inProgressDone = true
+					} else {
+						responsesReceived = append(responsesReceived, response)
+					}
+				case err, ok := <-inProgressErr:
+					if !ok {
+						inProgressErr = nil
+						inProgressErrDone = true
+					} else {
+						errorsReceived = append(errorsReceived, err)
+					}
+				case <-ctx.Done():
+					t.Fatal("did not complete request")
+				}
+			}
+			data.verifyResults(t, tbc, ree, responsesReceived, errorsReceived)
+		})
+	}
+}
+
+type requestExecutionEnv struct {
+	// params
+	request              gsmsg.GraphSyncRequest
+	blockHookResults     map[ipld.Link]error
+	doNotSendCids        *cid.Set
+	waitForResumeResults [][]graphsync.ExtensionData
+
+	// results
+	currentWaitForResumeResult int
+	requestsSent               []gsmsg.GraphSyncRequest
+	blookHooksCalled           []ipld.Link
+	terminateRequested         bool
+	nodeStyleChooserCalled     bool
+
+	// loader tracks seperately
+	loader loader.AsyncLoadFn
+}
+
+func (ree *requestExecutionEnv) terminateRequest() {
+	ree.terminateRequested = true
+}
+
+func (ree *requestExecutionEnv) waitForResume() ([]graphsync.ExtensionData, error) {
+	if len(ree.waitForResumeResults) <= ree.currentWaitForResumeResult {
+		return nil, loader.ContextCancelError{}
+	}
+	extensions := ree.waitForResumeResults[ree.currentWaitForResumeResult]
+	ree.currentWaitForResumeResult++
+	return extensions, nil
+}
+
+func (ree *requestExecutionEnv) sendRequest(request gsmsg.GraphSyncRequest) {
+	ree.requestsSent = append(ree.requestsSent, request)
+}
+
+func (ree *requestExecutionEnv) nodeStyleChooser(ipld.Link, ipld.LinkContext) (ipld.NodeStyle, error) {
+	ree.nodeStyleChooserCalled = true
+	return basicnode.Style.Any, nil
+}
+
+func (ree *requestExecutionEnv) runBlockHooks(blk graphsync.BlockData) error {
+	ree.blookHooksCalled = append(ree.blookHooksCalled, blk.Link())
+	return ree.blockHookResults[blk.Link()]
+}
+
+func (ree *requestExecutionEnv) requestExecution() executor.RequestExecution {
+	return executor.RequestExecution{
+		Request:          ree.request,
+		SendRequest:      ree.sendRequest,
+		Loader:           ree.loader,
+		RunBlockHooks:    ree.runBlockHooks,
+		DoNotSendCids:    ree.doNotSendCids,
+		TerminateRequest: ree.terminateRequest,
+		WaitForResume:    ree.waitForResume,
+		NodeStyleChooser: ree.nodeStyleChooser,
+	}
+}

--- a/requestmanager/hooks/responsehooks.go
+++ b/requestmanager/hooks/responsehooks.go
@@ -7,6 +7,11 @@ import (
 	"github.com/ipfs/go-graphsync"
 )
 
+// ErrPaused indicates a request should stop processing, but only cause it's paused
+type ErrPaused struct{}
+
+func (e ErrPaused) Error() string { return "request has been paused" }
+
 // IncomingResponseHooks is a set of incoming response hooks that can be processed
 type IncomingResponseHooks struct {
 	pubSub *pubsub.PubSub
@@ -66,4 +71,8 @@ func (rha *updateHookActions) TerminateWithError(err error) {
 
 func (rha *updateHookActions) UpdateRequestWithExtensions(extensions ...graphsync.ExtensionData) {
 	rha.extensions = append(rha.extensions, extensions...)
+}
+
+func (rha *updateHookActions) PauseRequest() {
+	rha.err = ErrPaused{}
 }

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -72,7 +72,6 @@ type RequestManager struct {
 	requestHooks              RequestHooks
 	responseHooks             ResponseHooks
 	blockHooks                BlockHooks
-	executionEnv              executor.ExecutionEnv
 }
 
 type requestManagerMessage interface {

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -778,7 +778,8 @@ func TestPauseResumeExternal(t *testing.T) {
 	hook := func(p peer.ID, responseData graphsync.ResponseData, blockData graphsync.BlockData, hookActions graphsync.IncomingBlockHookActions) {
 		blocksReceived++
 		if blocksReceived == pauseAt {
-			td.requestManager.PauseRequest(responseData.RequestID())
+			err := td.requestManager.PauseRequest(responseData.RequestID())
+			require.NoError(t, err)
 			close(holdForPause)
 		}
 	}

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-graphsync/requestmanager/testloader"
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
@@ -39,111 +40,6 @@ func (fph *fakePeerHandler) SendRequest(p peer.ID,
 	fph.requestRecordChan <- requestRecord{
 		gsr: graphSyncRequest,
 		p:   p,
-	}
-}
-
-type requestKey struct {
-	requestID graphsync.RequestID
-	link      ipld.Link
-}
-
-type storeKey struct {
-	requestID graphsync.RequestID
-	storeName string
-}
-
-type fakeAsyncLoader struct {
-	responseChannelsLk sync.RWMutex
-	responseChannels   map[requestKey]chan types.AsyncLoadResult
-	responses          chan map[graphsync.RequestID]metadata.Metadata
-	blks               chan []blocks.Block
-	storesRequestedLk  sync.RWMutex
-	storesRequested    map[storeKey]struct{}
-}
-
-func newFakeAsyncLoader() *fakeAsyncLoader {
-	return &fakeAsyncLoader{
-		responseChannels: make(map[requestKey]chan types.AsyncLoadResult),
-		responses:        make(chan map[graphsync.RequestID]metadata.Metadata, 1),
-		blks:             make(chan []blocks.Block, 1),
-		storesRequested:  make(map[storeKey]struct{}),
-	}
-}
-
-func (fal *fakeAsyncLoader) StartRequest(requestID graphsync.RequestID, name string) error {
-	fal.storesRequestedLk.Lock()
-	fal.storesRequested[storeKey{requestID, name}] = struct{}{}
-	fal.storesRequestedLk.Unlock()
-	return nil
-}
-
-func (fal *fakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
-	blks []blocks.Block) {
-	fal.responses <- responses
-	fal.blks <- blks
-}
-func (fal *fakeAsyncLoader) verifyLastProcessedBlocks(ctx context.Context, t *testing.T, expectedBlocks []blocks.Block) {
-	var processedBlocks []blocks.Block
-	testutil.AssertReceive(ctx, t, fal.blks, &processedBlocks, "did not process blocks")
-	require.Equal(t, expectedBlocks, processedBlocks, "did not process correct blocks")
-}
-
-func (fal *fakeAsyncLoader) verifyLastProcessedResponses(ctx context.Context, t *testing.T,
-	expectedResponses map[graphsync.RequestID]metadata.Metadata) {
-	var responses map[graphsync.RequestID]metadata.Metadata
-	testutil.AssertReceive(ctx, t, fal.responses, &responses, "did not process responses")
-	require.Equal(t, expectedResponses, responses, "did not process correct responses")
-}
-
-func (fal *fakeAsyncLoader) verifyNoRemainingData(t *testing.T, requestID graphsync.RequestID) {
-	fal.responseChannelsLk.Lock()
-	for key := range fal.responseChannels {
-		require.NotEqual(t, key.requestID, requestID, "did not clean up request properly")
-	}
-	fal.responseChannelsLk.Unlock()
-}
-
-func (fal *fakeAsyncLoader) verifyStoreUsed(t *testing.T, requestID graphsync.RequestID, storeName string) {
-	fal.storesRequestedLk.RLock()
-	_, ok := fal.storesRequested[storeKey{requestID, storeName}]
-	require.True(t, ok, "request should load from correct store")
-	fal.storesRequestedLk.RUnlock()
-}
-
-func (fal *fakeAsyncLoader) asyncLoad(requestID graphsync.RequestID, link ipld.Link) chan types.AsyncLoadResult {
-	fal.responseChannelsLk.Lock()
-	responseChannel, ok := fal.responseChannels[requestKey{requestID, link}]
-	if !ok {
-		responseChannel = make(chan types.AsyncLoadResult, 1)
-		fal.responseChannels[requestKey{requestID, link}] = responseChannel
-	}
-	fal.responseChannelsLk.Unlock()
-	return responseChannel
-}
-
-func (fal *fakeAsyncLoader) AsyncLoad(requestID graphsync.RequestID, link ipld.Link) <-chan types.AsyncLoadResult {
-	return fal.asyncLoad(requestID, link)
-}
-func (fal *fakeAsyncLoader) CompleteResponsesFor(requestID graphsync.RequestID) {}
-func (fal *fakeAsyncLoader) CleanupRequest(requestID graphsync.RequestID) {
-	fal.responseChannelsLk.Lock()
-	for key := range fal.responseChannels {
-		if key.requestID == requestID {
-			delete(fal.responseChannels, key)
-		}
-	}
-	fal.responseChannelsLk.Unlock()
-}
-
-func (fal *fakeAsyncLoader) responseOn(requestID graphsync.RequestID, link ipld.Link, result types.AsyncLoadResult) {
-	responseChannel := fal.asyncLoad(requestID, link)
-	responseChannel <- result
-	close(responseChannel)
-}
-
-func (fal *fakeAsyncLoader) successResponseOn(requestID graphsync.RequestID, blks []blocks.Block) {
-	for _, block := range blks {
-		fal.responseOn(requestID, cidlink.Link{Cid: block.Cid()}, types.AsyncLoadResult{Data: block.RawData(), Local: false, Err: nil})
 	}
 }
 
@@ -225,13 +121,13 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 	}
 
 	td.requestManager.ProcessResponses(peers[0], firstResponses, firstBlocks)
-	td.fal.verifyLastProcessedBlocks(ctx, t, firstBlocks)
-	td.fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+	td.fal.VerifyLastProcessedBlocks(ctx, t, firstBlocks)
+	td.fal.VerifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
 		requestRecords[0].gsr.ID(): firstMetadata1,
 		requestRecords[1].gsr.ID(): firstMetadata2,
 	})
-	td.fal.successResponseOn(requestRecords[0].gsr.ID(), td.blockChain.AllBlocks())
-	td.fal.successResponseOn(requestRecords[1].gsr.ID(), blockChain2.Blocks(0, 3))
+	td.fal.SuccessResponseOn(requestRecords[0].gsr.ID(), td.blockChain.AllBlocks())
+	td.fal.SuccessResponseOn(requestRecords[1].gsr.ID(), blockChain2.Blocks(0, 3))
 
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan1)
 	blockChain2.VerifyResponseRange(requestCtx, returnedResponseChan2, 0, 3)
@@ -248,12 +144,12 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 	}
 
 	td.requestManager.ProcessResponses(peers[0], moreResponses, moreBlocks)
-	td.fal.verifyLastProcessedBlocks(ctx, t, moreBlocks)
-	td.fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+	td.fal.VerifyLastProcessedBlocks(ctx, t, moreBlocks)
+	td.fal.VerifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
 		requestRecords[1].gsr.ID(): moreMetadata,
 	})
 
-	td.fal.successResponseOn(requestRecords[1].gsr.ID(), moreBlocks)
+	td.fal.SuccessResponseOn(requestRecords[1].gsr.ID(), moreBlocks)
 
 	blockChain2.VerifyRemainder(requestCtx, returnedResponseChan2, 3)
 	testutil.VerifyEmptyErrors(requestCtx, t, returnedErrorChan1)
@@ -284,8 +180,8 @@ func TestCancelRequestInProgress(t *testing.T) {
 
 	td.requestManager.ProcessResponses(peers[0], firstResponses, firstBlocks)
 
-	td.fal.successResponseOn(requestRecords[0].gsr.ID(), firstBlocks)
-	td.fal.successResponseOn(requestRecords[1].gsr.ID(), firstBlocks)
+	td.fal.SuccessResponseOn(requestRecords[0].gsr.ID(), firstBlocks)
+	td.fal.SuccessResponseOn(requestRecords[1].gsr.ID(), firstBlocks)
 	td.blockChain.VerifyResponseRange(requestCtx1, returnedResponseChan1, 0, 3)
 	cancel1()
 	rr := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
@@ -300,8 +196,8 @@ func TestCancelRequestInProgress(t *testing.T) {
 		gsmsg.NewResponse(requestRecords[1].gsr.ID(), graphsync.RequestCompletedFull, moreMetadata),
 	}
 	td.requestManager.ProcessResponses(peers[0], moreResponses, moreBlocks)
-	td.fal.successResponseOn(requestRecords[0].gsr.ID(), moreBlocks)
-	td.fal.successResponseOn(requestRecords[1].gsr.ID(), moreBlocks)
+	td.fal.SuccessResponseOn(requestRecords[0].gsr.ID(), moreBlocks)
+	td.fal.SuccessResponseOn(requestRecords[1].gsr.ID(), moreBlocks)
 
 	testutil.VerifyEmptyResponse(requestCtx, t, returnedResponseChan1)
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan2)
@@ -327,7 +223,7 @@ func TestCancelManagerExitsGracefully(t *testing.T) {
 		gsmsg.NewResponse(rr.gsr.ID(), graphsync.PartialResponse, firstMetadata),
 	}
 	td.requestManager.ProcessResponses(peers[0], firstResponses, firstBlocks)
-	td.fal.successResponseOn(rr.gsr.ID(), firstBlocks)
+	td.fal.SuccessResponseOn(rr.gsr.ID(), firstBlocks)
 	td.blockChain.VerifyResponseRange(ctx, returnedResponseChan, 0, 3)
 	managerCancel()
 
@@ -337,7 +233,7 @@ func TestCancelManagerExitsGracefully(t *testing.T) {
 		gsmsg.NewResponse(rr.gsr.ID(), graphsync.RequestCompletedFull, moreMetadata),
 	}
 	td.requestManager.ProcessResponses(peers[0], moreResponses, moreBlocks)
-	td.fal.successResponseOn(rr.gsr.ID(), moreBlocks)
+	td.fal.SuccessResponseOn(rr.gsr.ID(), moreBlocks)
 	testutil.VerifyEmptyResponse(requestCtx, t, returnedResponseChan)
 	testutil.VerifyEmptyErrors(requestCtx, t, returnedErrorChan)
 }
@@ -374,7 +270,7 @@ func TestLocallyFulfilledFirstRequestFailsLater(t *testing.T) {
 	rr := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
 
 	// async loaded response responds immediately
-	td.fal.successResponseOn(rr.gsr.ID(), td.blockChain.AllBlocks())
+	td.fal.SuccessResponseOn(rr.gsr.ID(), td.blockChain.AllBlocks())
 
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan)
 
@@ -401,7 +297,7 @@ func TestLocallyFulfilledFirstRequestSucceedsLater(t *testing.T) {
 	rr := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
 
 	// async loaded response responds immediately
-	td.fal.successResponseOn(rr.gsr.ID(), td.blockChain.AllBlocks())
+	td.fal.SuccessResponseOn(rr.gsr.ID(), td.blockChain.AllBlocks())
 
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan)
 
@@ -411,7 +307,7 @@ func TestLocallyFulfilledFirstRequestSucceedsLater(t *testing.T) {
 	}
 	td.requestManager.ProcessResponses(peers[0], firstResponses, td.blockChain.AllBlocks())
 
-	td.fal.verifyNoRemainingData(t, rr.gsr.ID())
+	td.fal.VerifyNoRemainingData(t, rr.gsr.ID())
 	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan)
 }
 
@@ -433,7 +329,7 @@ func TestRequestReturnsMissingBlocks(t *testing.T) {
 	}
 	td.requestManager.ProcessResponses(peers[0], firstResponses, nil)
 	for _, block := range td.blockChain.AllBlocks() {
-		td.fal.responseOn(rr.gsr.ID(), cidlink.Link{Cid: block.Cid()}, types.AsyncLoadResult{Data: nil, Err: fmt.Errorf("Terrible Thing")})
+		td.fal.ResponseOn(rr.gsr.ID(), cidlink.Link{Cid: block.Cid()}, types.AsyncLoadResult{Data: nil, Err: fmt.Errorf("Terrible Thing")})
 	}
 	testutil.VerifyEmptyResponse(ctx, t, returnedResponseChan)
 	errs := testutil.CollectErrors(ctx, t, returnedErrorChan)
@@ -653,11 +549,11 @@ func TestBlockHooks(t *testing.T) {
 		}
 
 		td.requestManager.ProcessResponses(peers[0], firstResponses, firstBlocks)
-		td.fal.verifyLastProcessedBlocks(ctx, t, firstBlocks)
-		td.fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+		td.fal.VerifyLastProcessedBlocks(ctx, t, firstBlocks)
+		td.fal.VerifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
 			rr.gsr.ID(): firstMetadata,
 		})
-		td.fal.successResponseOn(rr.gsr.ID(), firstBlocks)
+		td.fal.SuccessResponseOn(rr.gsr.ID(), firstBlocks)
 
 		ur := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
 		receivedUpdateData, has := ur.gsr.Extension(extensionName1)
@@ -717,11 +613,11 @@ func TestBlockHooks(t *testing.T) {
 			expectedUpdateChan <- update
 		}
 		td.requestManager.ProcessResponses(peers[0], secondResponses, nextBlocks)
-		td.fal.verifyLastProcessedBlocks(ctx, t, nextBlocks)
-		td.fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+		td.fal.VerifyLastProcessedBlocks(ctx, t, nextBlocks)
+		td.fal.VerifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
 			rr.gsr.ID(): nextMetadata,
 		})
-		td.fal.successResponseOn(rr.gsr.ID(), nextBlocks)
+		td.fal.SuccessResponseOn(rr.gsr.ID(), nextBlocks)
 
 		ur = readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
 		receivedUpdateData, has = ur.gsr.Extension(extensionName1)
@@ -792,26 +688,26 @@ func TestOutgoingRequestHooks(t *testing.T) {
 		gsmsg.NewResponse(requestRecords[1].gsr.ID(), graphsync.RequestCompletedFull, mdExt),
 	}
 	td.requestManager.ProcessResponses(peers[0], responses, td.blockChain.AllBlocks())
-	td.fal.verifyLastProcessedBlocks(ctx, t, td.blockChain.AllBlocks())
-	td.fal.verifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
+	td.fal.VerifyLastProcessedBlocks(ctx, t, td.blockChain.AllBlocks())
+	td.fal.VerifyLastProcessedResponses(ctx, t, map[graphsync.RequestID]metadata.Metadata{
 		requestRecords[0].gsr.ID(): md,
 		requestRecords[1].gsr.ID(): md,
 	})
-	td.fal.successResponseOn(requestRecords[0].gsr.ID(), td.blockChain.AllBlocks())
-	td.fal.successResponseOn(requestRecords[1].gsr.ID(), td.blockChain.AllBlocks())
+	td.fal.SuccessResponseOn(requestRecords[0].gsr.ID(), td.blockChain.AllBlocks())
+	td.fal.SuccessResponseOn(requestRecords[1].gsr.ID(), td.blockChain.AllBlocks())
 
 	td.blockChain.VerifyWholeChainWithTypes(requestCtx, returnedResponseChan1)
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan2)
 	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan1)
 	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan2)
-	td.fal.verifyStoreUsed(t, requestRecords[0].gsr.ID(), "chainstore")
-	td.fal.verifyStoreUsed(t, requestRecords[1].gsr.ID(), "")
+	td.fal.VerifyStoreUsed(t, requestRecords[0].gsr.ID(), "chainstore")
+	td.fal.VerifyStoreUsed(t, requestRecords[1].gsr.ID(), "")
 }
 
 type testData struct {
 	requestRecordChan chan requestRecord
 	fph               *fakePeerHandler
-	fal               *fakeAsyncLoader
+	fal               *testloader.FakeAsyncLoader
 	requestHooks      *hooks.OutgoingRequestHooks
 	responseHooks     *hooks.IncomingResponseHooks
 	blockHooks        *hooks.IncomingBlockHooks
@@ -826,7 +722,7 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td := &testData{}
 	td.requestRecordChan = make(chan requestRecord, 3)
 	td.fph = &fakePeerHandler{td.requestRecordChan}
-	td.fal = newFakeAsyncLoader()
+	td.fal = testloader.NewFakeAsyncLoader()
 	td.requestHooks = hooks.NewRequestHooks()
 	td.responseHooks = hooks.NewResponseHooks()
 	td.blockHooks = hooks.NewBlockHooks()

--- a/requestmanager/testloader/asyncloader.go
+++ b/requestmanager/testloader/asyncloader.go
@@ -83,11 +83,11 @@ func (fal *FakeAsyncLoader) VerifyLastProcessedResponses(ctx context.Context, t 
 // VerifyNoRemainingData verifies no outstanding response channels are open for the given
 // RequestID (CleanupRequest was called last)
 func (fal *FakeAsyncLoader) VerifyNoRemainingData(t *testing.T, requestID graphsync.RequestID) {
-	fal.responseChannelsLk.Lock()
+	fal.responseChannelsLk.RLock()
 	for key := range fal.responseChannels {
 		require.NotEqual(t, key.requestID, requestID, "did not clean up request properly")
 	}
-	fal.responseChannelsLk.Unlock()
+	fal.responseChannelsLk.RUnlock()
 }
 
 // VerifyStoreUsed verifies the given store was used for the given request

--- a/requestmanager/testloader/asyncloader.go
+++ b/requestmanager/testloader/asyncloader.go
@@ -1,0 +1,147 @@
+package testloader
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	blocks "github.com/ipfs/go-block-format"
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/metadata"
+	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/ipfs/go-graphsync/testutil"
+	"github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/stretchr/testify/require"
+)
+
+type requestKey struct {
+	requestID graphsync.RequestID
+	link      ipld.Link
+}
+
+type storeKey struct {
+	requestID graphsync.RequestID
+	storeName string
+}
+
+// FakeAsyncLoader simultates the requestmanager.AsyncLoader interface
+// with mocked responses and can also be used to simulate a
+// loader.AsycLoadFn -- all responses are stubbed and no actual processing is
+// done
+type FakeAsyncLoader struct {
+	responseChannelsLk sync.RWMutex
+	responseChannels   map[requestKey]chan types.AsyncLoadResult
+	responses          chan map[graphsync.RequestID]metadata.Metadata
+	blks               chan []blocks.Block
+	storesRequestedLk  sync.RWMutex
+	storesRequested    map[storeKey]struct{}
+}
+
+// NewFakeAsyncLoader returns a new FakeAsyncLoader instance
+func NewFakeAsyncLoader() *FakeAsyncLoader {
+	return &FakeAsyncLoader{
+		responseChannels: make(map[requestKey]chan types.AsyncLoadResult),
+		responses:        make(chan map[graphsync.RequestID]metadata.Metadata, 1),
+		blks:             make(chan []blocks.Block, 1),
+		storesRequested:  make(map[storeKey]struct{}),
+	}
+}
+
+// StartRequest just requests what store was requested for a given requestID
+func (fal *FakeAsyncLoader) StartRequest(requestID graphsync.RequestID, name string) error {
+	fal.storesRequestedLk.Lock()
+	fal.storesRequested[storeKey{requestID, name}] = struct{}{}
+	fal.storesRequestedLk.Unlock()
+	return nil
+}
+
+// ProcessResponse just records values passed to verify expectations later
+func (fal *FakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
+	blks []blocks.Block) {
+	fal.responses <- responses
+	fal.blks <- blks
+}
+
+// VerifyLastProcessedBlocks verifies the blocks passed to the last call to ProcessResponse
+// match the expected ones
+func (fal *FakeAsyncLoader) VerifyLastProcessedBlocks(ctx context.Context, t *testing.T, expectedBlocks []blocks.Block) {
+	var processedBlocks []blocks.Block
+	testutil.AssertReceive(ctx, t, fal.blks, &processedBlocks, "did not process blocks")
+	require.Equal(t, expectedBlocks, processedBlocks, "did not process correct blocks")
+}
+
+// VerifyLastProcessedResponses verifies the responses passed to the last call to ProcessResponse
+// match the expected ones
+func (fal *FakeAsyncLoader) VerifyLastProcessedResponses(ctx context.Context, t *testing.T,
+	expectedResponses map[graphsync.RequestID]metadata.Metadata) {
+	var responses map[graphsync.RequestID]metadata.Metadata
+	testutil.AssertReceive(ctx, t, fal.responses, &responses, "did not process responses")
+	require.Equal(t, expectedResponses, responses, "did not process correct responses")
+}
+
+// VerifyNoRemainingData verifies no outstanding response channels are open for the given
+// RequestID (CleanupRequest was called last)
+func (fal *FakeAsyncLoader) VerifyNoRemainingData(t *testing.T, requestID graphsync.RequestID) {
+	fal.responseChannelsLk.Lock()
+	for key := range fal.responseChannels {
+		require.NotEqual(t, key.requestID, requestID, "did not clean up request properly")
+	}
+	fal.responseChannelsLk.Unlock()
+}
+
+// VerifyStoreUsed verifies the given store was used for the given request
+func (fal *FakeAsyncLoader) VerifyStoreUsed(t *testing.T, requestID graphsync.RequestID, storeName string) {
+	fal.storesRequestedLk.RLock()
+	_, ok := fal.storesRequested[storeKey{requestID, storeName}]
+	require.True(t, ok, "request should load from correct store")
+	fal.storesRequestedLk.RUnlock()
+}
+
+func (fal *FakeAsyncLoader) asyncLoad(requestID graphsync.RequestID, link ipld.Link) chan types.AsyncLoadResult {
+	fal.responseChannelsLk.Lock()
+	responseChannel, ok := fal.responseChannels[requestKey{requestID, link}]
+	if !ok {
+		responseChannel = make(chan types.AsyncLoadResult, 1)
+		fal.responseChannels[requestKey{requestID, link}] = responseChannel
+	}
+	fal.responseChannelsLk.Unlock()
+	return responseChannel
+}
+
+// AsyncLoad simulates an asynchronous load with responses stubbed by ResponseOn & SuccessResponseOn
+func (fal *FakeAsyncLoader) AsyncLoad(requestID graphsync.RequestID, link ipld.Link) <-chan types.AsyncLoadResult {
+	return fal.asyncLoad(requestID, link)
+}
+
+// CompleteResponsesFor in the case of the test loader does nothing
+func (fal *FakeAsyncLoader) CompleteResponsesFor(requestID graphsync.RequestID) {}
+
+// CleanupRequest simulates the effect of cleaning up the request by removing any response channels
+// for the request
+func (fal *FakeAsyncLoader) CleanupRequest(requestID graphsync.RequestID) {
+	fal.responseChannelsLk.Lock()
+	for key := range fal.responseChannels {
+		if key.requestID == requestID {
+			delete(fal.responseChannels, key)
+		}
+	}
+	fal.responseChannelsLk.Unlock()
+}
+
+// ResponseOn sets the value returned when the given link is loaded for the given request. Because it's an
+// "asynchronous" load, this can be called AFTER the attempt to load this link -- and the client will only get
+// the response at that point
+func (fal *FakeAsyncLoader) ResponseOn(requestID graphsync.RequestID, link ipld.Link, result types.AsyncLoadResult) {
+	responseChannel := fal.asyncLoad(requestID, link)
+	responseChannel <- result
+	close(responseChannel)
+}
+
+// SuccessResponseOn is convenience function for setting several asynchronous responses at once as all successes
+// and returning the given blocks
+func (fal *FakeAsyncLoader) SuccessResponseOn(requestID graphsync.RequestID, blks []blocks.Block) {
+	for _, block := range blks {
+		fal.ResponseOn(requestID, cidlink.Link{Cid: block.Cid()}, types.AsyncLoadResult{Data: block.RawData(), Local: false, Err: nil})
+	}
+}

--- a/responsemanager/hooks/blockhooks.go
+++ b/responsemanager/hooks/blockhooks.go
@@ -1,15 +1,15 @@
 package hooks
 
 import (
-	"errors"
-
 	"github.com/hannahhoward/go-pubsub"
 	"github.com/ipfs/go-graphsync"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 )
 
 // ErrPaused indicates a request should stop processing, but only cause it's paused
-var ErrPaused = errors.New("request has been paused")
+type ErrPaused struct{}
+
+func (e ErrPaused) Error() string { return "request has been paused" }
 
 // OutgoingBlockHooks is a set of outgoing block hooks that can be processed
 type OutgoingBlockHooks struct {
@@ -71,5 +71,5 @@ func (bha *blockHookActions) TerminateWithError(err error) {
 }
 
 func (bha *blockHookActions) PauseResponse() {
-	bha.err = ErrPaused
+	bha.err = ErrPaused{}
 }

--- a/responsemanager/hooks/hooks_test.go
+++ b/responsemanager/hooks/hooks_test.go
@@ -262,7 +262,7 @@ func TestBlockHookProcessing(t *testing.T) {
 			},
 			assert: func(t *testing.T, result hooks.BlockResult) {
 				require.Empty(t, result.Extensions)
-				require.EqualError(t, result.Err, hooks.ErrPaused.Error())
+				require.EqualError(t, result.Err, hooks.ErrPaused{}.Error())
 			},
 		},
 	}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -396,7 +396,7 @@ func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 	if !ok {
 		return
 	}
-	if ftr.err == hooks.ErrPaused {
+	if _, ok := ftr.err.(hooks.ErrPaused); ok {
 		response.isPaused = true
 		return
 	}

--- a/testutil/testchain.go
+++ b/testutil/testchain.go
@@ -206,6 +206,22 @@ func (tbc *TestBlockChain) VerifyResponseRange(ctx context.Context, responseChan
 	tbc.checkResponses(responses, from, to, false)
 }
 
+// VerifyWholeChainSync verifies the given set of read responses are the expected responses for the whole chain
+func (tbc *TestBlockChain) VerifyWholeChainSync(responses []graphsync.ResponseProgress) {
+	tbc.VerifyRemainderSync(responses, 0)
+}
+
+// VerifyRemainderSync verifies the given set of read responses are the remainder of the chain starting at the nth block from the tip
+func (tbc *TestBlockChain) VerifyRemainderSync(responses []graphsync.ResponseProgress, from int) {
+	tbc.checkResponses(responses, from, tbc.blockChainLength, false)
+}
+
+// VerifyResponseRangeSync verifies given set of read responses match responses for the given range of the blockchain, indexed from the tip
+// (with possibly more data left in the channel)
+func (tbc *TestBlockChain) VerifyResponseRangeSync(responses []graphsync.ResponseProgress, from int, to int) {
+	tbc.checkResponses(responses, from, to, false)
+}
+
 // VerifyWholeChainWithTypes verifies the given response channel returns the expected responses for the whole chain
 // and that the types in the response are the expected types for a block chain
 func (tbc *TestBlockChain) VerifyWholeChainWithTypes(ctx context.Context, responseChan <-chan graphsync.ResponseProgress) {


### PR DESCRIPTION
# Goals

This PR uses the DoNotSendCids extension to implement pause resume of graphsync requests.

# Implementation

From the responder side, it appears as if requests have been cancelled.
On the requestor side however, when a pause is triggered, the request is cancelled and the put in a pause state. When restarted, it recreates the request but sends a list of CIDs to skip send so the request can execute as if it were restarted