### PR TITLE
Start Response Paused

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -158,6 +158,7 @@ type IncomingRequestHookActions interface {
 	UseLinkTargetNodeStyleChooser(traversal.LinkTargetNodeStyleChooser)
 	TerminateWithError(error)
 	ValidateRequest()
+	PauseResponse()
 }
 
 // OutgoingBlockHookActions are actions that an outgoing block hook can take to

--- a/requestmanager/hooks/hooks_test.go
+++ b/requestmanager/hooks/hooks_test.go
@@ -140,6 +140,17 @@ func TestBlockHookProcessing(t *testing.T) {
 				require.EqualError(t, result.Err, "something went wrong")
 			},
 		},
+		"pause request": {
+			configure: func(t *testing.T, hooks *hooks.IncomingBlockHooks) {
+				hooks.Register(func(p peer.ID, responseData graphsync.ResponseData, blockData graphsync.BlockData, hookActions graphsync.IncomingBlockHookActions) {
+					hookActions.PauseRequest()
+				})
+			},
+			assert: func(t *testing.T, result hooks.UpdateResult) {
+				require.Empty(t, result.Extensions)
+				require.EqualError(t, result.Err, hooks.ErrPaused{}.Error())
+			},
+		},
 		"hooks update with extensions": {
 			configure: func(t *testing.T, hooks *hooks.IncomingBlockHooks) {
 				hooks.Register(func(p peer.ID, responseData graphsync.ResponseData, blockData graphsync.BlockData, hookActions graphsync.IncomingBlockHookActions) {

--- a/responsemanager/hooks/hooks_test.go
+++ b/responsemanager/hooks/hooks_test.go
@@ -172,6 +172,19 @@ func TestRequestHookProcessing(t *testing.T) {
 		"hooks alter the node builder chooser": {
 			configure: func(t *testing.T, requestHooks *hooks.IncomingRequestHooks) {
 				requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+					hookActions.PauseResponse()
+					hookActions.ValidateRequest()
+				})
+			},
+			assert: func(t *testing.T, result hooks.RequestResult) {
+				require.True(t, result.IsValidated)
+				require.True(t, result.IsPaused)
+				require.NoError(t, result.Err)
+			},
+		},
+		"hooks start request paused": {
+			configure: func(t *testing.T, requestHooks *hooks.IncomingRequestHooks) {
+				requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
 					if _, found := requestData.Extension(extensionName); found {
 						hookActions.UseLinkTargetNodeStyleChooser(fakeChooser)
 						hookActions.SendExtensionData(extensionResponse)

--- a/responsemanager/hooks/requesthook.go
+++ b/responsemanager/hooks/requesthook.go
@@ -50,6 +50,7 @@ func (irh *IncomingRequestHooks) Register(hook graphsync.OnIncomingRequestHook) 
 // RequestResult is the outcome of running requesthooks
 type RequestResult struct {
 	IsValidated   bool
+	IsPaused      bool
 	CustomLoader  ipld.Loader
 	CustomChooser traversal.LinkTargetNodeStyleChooser
 	Err           error
@@ -68,6 +69,7 @@ func (irh *IncomingRequestHooks) ProcessRequestHooks(p peer.ID, request graphsyn
 type requestHookActions struct {
 	persistenceOptions PersistenceOptions
 	isValidated        bool
+	isPaused           bool
 	err                error
 	loader             ipld.Loader
 	chooser            traversal.LinkTargetNodeStyleChooser
@@ -77,6 +79,7 @@ type requestHookActions struct {
 func (ha *requestHookActions) result() RequestResult {
 	return RequestResult{
 		IsValidated:   ha.isValidated,
+		IsPaused:      ha.isPaused,
 		CustomLoader:  ha.loader,
 		CustomChooser: ha.chooser,
 		Err:           ha.err,
@@ -107,4 +110,8 @@ func (ha *requestHookActions) UsePersistenceOption(name string) {
 
 func (ha *requestHookActions) UseLinkTargetNodeStyleChooser(chooser traversal.LinkTargetNodeStyleChooser) {
 	ha.chooser = chooser
+}
+
+func (ha *requestHookActions) PauseResponse() {
+	ha.isPaused = true
 }


### PR DESCRIPTION
# Goals

add the ability for a hook to pause a response right when it's first received

# Implementation

- add PauseResponse to IncomingRequestHookActions
- Update hooks to record call to pause response
- Update response manager to ignore executing query right away if request is paused