### PR TITLE
Transmit extensions when request is paused in IncomingBlockHook

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -120,8 +120,8 @@ func CancelRequest(id graphsync.RequestID) GraphSyncRequest {
 }
 
 // UpdateRequest generates a new request to update an in progress request with the given extensions
-func UpdateRequest(id graphsync.RequestID, extensions ...graphsync.ExtensionData) GraphSyncRequest {
-	return newRequest(id, cid.Cid{}, nil, 0, false, true, toExtensionsMap(extensions))
+func UpdateRequest(id graphsync.RequestID, isCancel bool, extensions ...graphsync.ExtensionData) GraphSyncRequest {
+	return newRequest(id, cid.Cid{}, nil, 0, isCancel, true, toExtensionsMap(extensions))
 }
 
 func toExtensionsMap(extensions []graphsync.ExtensionData) (extensionsMap map[string][]byte) {

--- a/message/message_test.go
+++ b/message/message_test.go
@@ -184,7 +184,7 @@ func TestRequestUpdate(t *testing.T) {
 	}
 
 	gsm := New()
-	gsm.AddRequest(UpdateRequest(id, extension))
+	gsm.AddRequest(UpdateRequest(id, false, extension))
 
 	requests := gsm.Requests()
 	require.Len(t, requests, 1, "did not add cancel request")

--- a/responsemanager/hooks/hooks_test.go
+++ b/responsemanager/hooks/hooks_test.go
@@ -315,7 +315,7 @@ func TestUpdateHookProcessing(t *testing.T) {
 	requestID := graphsync.RequestID(rand.Int31())
 	ssb := builder.NewSelectorSpecBuilder(basicnode.Style.Any)
 	request := gsmsg.NewRequest(requestID, root, ssb.Matcher().Node(), graphsync.Priority(0), extension)
-	update := gsmsg.UpdateRequest(requestID, extensionUpdate)
+	update := gsmsg.UpdateRequest(requestID, false, extensionUpdate)
 	p := testutil.GeneratePeers(1)[0]
 	testCases := map[string]struct {
 		configure func(t *testing.T, updateHooks *hooks.RequestUpdatedHooks)

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -362,7 +362,10 @@ func (prm *processRequestMessage) handle(rm *ResponseManager) {
 				response.cancelFn()
 				if request.IsUpdate() {
 					result := rm.updateHooks.ProcessUpdateHooks(key.p, response.request, request)
-					rm.sendUpdateData(key, result)
+					err := rm.sendUpdateData(key, result)
+					if err != nil {
+						log.Warn("Error transmitting response for extension processing during cancel: %s", err.Error())
+					}
 				}
 				delete(rm.inProgressResponses, key)
 			}

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -988,7 +988,7 @@ func newTestData(t *testing.T) testData {
 		gsmsg.NewRequest(td.requestID, td.blockChain.TipLink.(cidlink.Link).Cid, td.blockChain.Selector(), graphsync.Priority(0), td.extension),
 	}
 	td.updateRequests = []gsmsg.GraphSyncRequest{
-		gsmsg.UpdateRequest(td.requestID, td.extensionUpdate),
+		gsmsg.UpdateRequest(td.requestID, false, td.extensionUpdate),
 	}
 	td.p = testutil.GeneratePeers(1)[0]
 	td.peristenceOptions = persistenceoptions.New()


### PR DESCRIPTION
# Goals

While not supporting transmitting extensions with PauseRequest or PauseResponse or CancelResponse imperative call yet, this fixes a bug where extensions transmitting with a pause called from an hook were not getting processed