### PR TITLE
fix(message): regen protobuf code

### DIFF
--- a/message/pb/message.pb.go
+++ b/message/pb/message.pb.go
@@ -3,12 +3,14 @@
 
 package graphsync_message_pb
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto"
-
-import io "io"
+import (
+	fmt "fmt"
+	_ "github.com/gogo/protobuf/gogoproto"
+	proto "github.com/gogo/protobuf/proto"
+	io "io"
+	math "math"
+	math_bits "math/bits"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -19,21 +21,21 @@ var _ = math.Inf
 // is compatible with the proto package it is being compiled against.
 // A compilation error at this line likely means your copy of the
 // proto package needs to be updated.
-const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
+const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
 type Message struct {
 	// the actual data included in this message
 	CompleteRequestList bool               `protobuf:"varint,1,opt,name=completeRequestList,proto3" json:"completeRequestList,omitempty"`
-	Requests            []Message_Request  `protobuf:"bytes,2,rep,name=requests" json:"requests"`
-	Responses           []Message_Response `protobuf:"bytes,3,rep,name=responses" json:"responses"`
-	Data                []Message_Block    `protobuf:"bytes,4,rep,name=data" json:"data"`
+	Requests            []Message_Request  `protobuf:"bytes,2,rep,name=requests,proto3" json:"requests"`
+	Responses           []Message_Response `protobuf:"bytes,3,rep,name=responses,proto3" json:"responses"`
+	Data                []Message_Block    `protobuf:"bytes,4,rep,name=data,proto3" json:"data"`
 }
 
 func (m *Message) Reset()         { *m = Message{} }
 func (m *Message) String() string { return proto.CompactTextString(m) }
 func (*Message) ProtoMessage()    {}
 func (*Message) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_5de5dd65106cd0db, []int{0}
+	return fileDescriptor_33c57e4bae7b9afd, []int{0}
 }
 func (m *Message) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -43,15 +45,15 @@ func (m *Message) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
 		return xxx_messageInfo_Message.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Message) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message.Merge(dst, src)
+func (m *Message) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message.Merge(m, src)
 }
 func (m *Message) XXX_Size() int {
 	return m.Size()
@@ -94,7 +96,7 @@ type Message_Request struct {
 	Id         int32             `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Root       []byte            `protobuf:"bytes,2,opt,name=root,proto3" json:"root,omitempty"`
 	Selector   []byte            `protobuf:"bytes,3,opt,name=selector,proto3" json:"selector,omitempty"`
-	Extensions map[string][]byte `protobuf:"bytes,4,rep,name=extensions" json:"extensions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Extensions map[string][]byte `protobuf:"bytes,4,rep,name=extensions,proto3" json:"extensions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	Priority   int32             `protobuf:"varint,5,opt,name=priority,proto3" json:"priority,omitempty"`
 	Cancel     bool              `protobuf:"varint,6,opt,name=cancel,proto3" json:"cancel,omitempty"`
 	Update     bool              `protobuf:"varint,7,opt,name=update,proto3" json:"update,omitempty"`
@@ -104,7 +106,7 @@ func (m *Message_Request) Reset()         { *m = Message_Request{} }
 func (m *Message_Request) String() string { return proto.CompactTextString(m) }
 func (*Message_Request) ProtoMessage()    {}
 func (*Message_Request) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_5de5dd65106cd0db, []int{0, 0}
+	return fileDescriptor_33c57e4bae7b9afd, []int{0, 0}
 }
 func (m *Message_Request) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -114,15 +116,15 @@ func (m *Message_Request) XXX_Marshal(b []byte, deterministic bool) ([]byte, err
 		return xxx_messageInfo_Message_Request.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Message_Request) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message_Request.Merge(dst, src)
+func (m *Message_Request) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message_Request.Merge(m, src)
 }
 func (m *Message_Request) XXX_Size() int {
 	return m.Size()
@@ -185,14 +187,14 @@ func (m *Message_Request) GetUpdate() bool {
 type Message_Response struct {
 	Id         int32             `protobuf:"varint,1,opt,name=id,proto3" json:"id,omitempty"`
 	Status     int32             `protobuf:"varint,2,opt,name=status,proto3" json:"status,omitempty"`
-	Extensions map[string][]byte `protobuf:"bytes,3,rep,name=extensions" json:"extensions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Extensions map[string][]byte `protobuf:"bytes,3,rep,name=extensions,proto3" json:"extensions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
 func (m *Message_Response) Reset()         { *m = Message_Response{} }
 func (m *Message_Response) String() string { return proto.CompactTextString(m) }
 func (*Message_Response) ProtoMessage()    {}
 func (*Message_Response) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_5de5dd65106cd0db, []int{0, 1}
+	return fileDescriptor_33c57e4bae7b9afd, []int{0, 1}
 }
 func (m *Message_Response) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -202,15 +204,15 @@ func (m *Message_Response) XXX_Marshal(b []byte, deterministic bool) ([]byte, er
 		return xxx_messageInfo_Message_Response.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Message_Response) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message_Response.Merge(dst, src)
+func (m *Message_Response) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message_Response.Merge(m, src)
 }
 func (m *Message_Response) XXX_Size() int {
 	return m.Size()
@@ -251,7 +253,7 @@ func (m *Message_Block) Reset()         { *m = Message_Block{} }
 func (m *Message_Block) String() string { return proto.CompactTextString(m) }
 func (*Message_Block) ProtoMessage()    {}
 func (*Message_Block) Descriptor() ([]byte, []int) {
-	return fileDescriptor_message_5de5dd65106cd0db, []int{0, 2}
+	return fileDescriptor_33c57e4bae7b9afd, []int{0, 2}
 }
 func (m *Message_Block) XXX_Unmarshal(b []byte) error {
 	return m.Unmarshal(b)
@@ -261,15 +263,15 @@ func (m *Message_Block) XXX_Marshal(b []byte, deterministic bool) ([]byte, error
 		return xxx_messageInfo_Message_Block.Marshal(b, m, deterministic)
 	} else {
 		b = b[:cap(b)]
-		n, err := m.MarshalTo(b)
+		n, err := m.MarshalToSizedBuffer(b)
 		if err != nil {
 			return nil, err
 		}
 		return b[:n], nil
 	}
 }
-func (dst *Message_Block) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Message_Block.Merge(dst, src)
+func (m *Message_Block) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Message_Block.Merge(m, src)
 }
 func (m *Message_Block) XXX_Size() int {
 	return m.Size()
@@ -302,10 +304,46 @@ func init() {
 	proto.RegisterMapType((map[string][]byte)(nil), "graphsync.message.pb.Message.Response.ExtensionsEntry")
 	proto.RegisterType((*Message_Block)(nil), "graphsync.message.pb.Message.Block")
 }
+
+func init() { proto.RegisterFile("message.proto", fileDescriptor_33c57e4bae7b9afd) }
+
+var fileDescriptor_33c57e4bae7b9afd = []byte{
+	// 458 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0xcb, 0x6e, 0xd3, 0x40,
+	0x14, 0x8d, 0x9d, 0xd8, 0x49, 0x2f, 0xe5, 0xa1, 0xa1, 0xaa, 0x46, 0x5e, 0x98, 0x08, 0x04, 0xca,
+	0x06, 0x17, 0x51, 0x81, 0x10, 0x52, 0x37, 0x91, 0x2a, 0x24, 0x04, 0x9b, 0x91, 0x60, 0xef, 0x38,
+	0xb7, 0xae, 0x55, 0xc7, 0x63, 0x66, 0xc6, 0xa8, 0xfe, 0x0b, 0xfe, 0x83, 0x7f, 0x60, 0x5d, 0x76,
+	0x5d, 0xb2, 0x42, 0x28, 0xf9, 0x11, 0xe4, 0x3b, 0x83, 0x79, 0x55, 0xa5, 0x12, 0xbb, 0x7b, 0xee,
+	0xcc, 0x39, 0xf7, 0x71, 0x66, 0xe0, 0xfa, 0x0a, 0xb5, 0x4e, 0x73, 0x4c, 0x6a, 0x25, 0x8d, 0x64,
+	0x3b, 0xb9, 0x4a, 0xeb, 0x63, 0xdd, 0x56, 0x59, 0xd2, 0x1f, 0x2c, 0xa2, 0x87, 0x79, 0x61, 0x8e,
+	0x9b, 0x45, 0x92, 0xc9, 0xd5, 0x5e, 0x2e, 0x73, 0xb9, 0x47, 0x97, 0x17, 0xcd, 0x11, 0x21, 0x02,
+	0x14, 0x59, 0x91, 0xbb, 0x9f, 0x42, 0x18, 0xbf, 0xb6, 0x6c, 0xf6, 0x08, 0x6e, 0x67, 0x72, 0x55,
+	0x97, 0x68, 0x50, 0xe0, 0xbb, 0x06, 0xb5, 0x79, 0x55, 0x68, 0xc3, 0xbd, 0xa9, 0x37, 0x9b, 0x88,
+	0x8b, 0x8e, 0xd8, 0x0b, 0x98, 0x28, 0x0b, 0x35, 0xf7, 0xa7, 0xc3, 0xd9, 0xb5, 0xc7, 0xf7, 0x93,
+	0x8b, 0xba, 0x4a, 0x5c, 0x89, 0xc4, 0x91, 0xe7, 0xa3, 0xb3, 0xaf, 0x77, 0x06, 0xa2, 0x27, 0xb3,
+	0x97, 0xb0, 0xa5, 0x50, 0xd7, 0xb2, 0xd2, 0xa8, 0xf9, 0x90, 0x94, 0x1e, 0xfc, 0x4b, 0xc9, 0x5e,
+	0x77, 0x52, 0x3f, 0xe9, 0xec, 0x00, 0x46, 0xcb, 0xd4, 0xa4, 0x7c, 0x44, 0x32, 0xf7, 0x2e, 0x97,
+	0x99, 0x97, 0x32, 0x3b, 0x71, 0x1a, 0x44, 0x8b, 0x3e, 0xfa, 0x30, 0x76, 0x6d, 0xb2, 0x1b, 0xe0,
+	0x17, 0x4b, 0x5a, 0x40, 0x20, 0xfc, 0x62, 0xc9, 0x18, 0x8c, 0x94, 0x94, 0x86, 0xfb, 0x53, 0x6f,
+	0xb6, 0x2d, 0x28, 0x66, 0x11, 0x4c, 0x34, 0x96, 0x98, 0x19, 0xa9, 0xf8, 0x90, 0xf2, 0x3d, 0x66,
+	0x6f, 0x00, 0xf0, 0xd4, 0x60, 0xa5, 0x0b, 0x59, 0x69, 0xd7, 0xd0, 0x93, 0x2b, 0x6d, 0x28, 0x39,
+	0xec, 0x79, 0x87, 0x95, 0x51, 0xad, 0xf8, 0x45, 0xa8, 0x2b, 0x59, 0xab, 0x42, 0xaa, 0xc2, 0xb4,
+	0x3c, 0xa0, 0xe6, 0x7a, 0xcc, 0x76, 0x21, 0xcc, 0xd2, 0x2a, 0xc3, 0x92, 0x87, 0xe4, 0x9b, 0x43,
+	0x5d, 0xbe, 0xa9, 0x97, 0xa9, 0x41, 0x3e, 0xb6, 0x79, 0x8b, 0xa2, 0x03, 0xb8, 0xf9, 0x47, 0x29,
+	0x76, 0x0b, 0x86, 0x27, 0xd8, 0xd2, 0xd8, 0x5b, 0xa2, 0x0b, 0xd9, 0x0e, 0x04, 0xef, 0xd3, 0xb2,
+	0x41, 0x37, 0xb8, 0x05, 0xcf, 0xfd, 0x67, 0x5e, 0xf4, 0xd9, 0x83, 0xc9, 0x0f, 0x2b, 0xfe, 0x5a,
+	0xd7, 0x2e, 0x84, 0xda, 0xa4, 0xa6, 0xd1, 0xc4, 0x0b, 0x84, 0x43, 0xec, 0xed, 0x6f, 0x6b, 0xb1,
+	0x76, 0x3f, 0xbd, 0x9a, 0xdd, 0x97, 0xed, 0xe5, 0x7f, 0x67, 0xd9, 0x87, 0x80, 0x9e, 0x43, 0xd7,
+	0x77, 0xad, 0xf0, 0xa8, 0x38, 0x25, 0xde, 0xb6, 0x70, 0xa8, 0xb3, 0x9f, 0x5e, 0x96, 0xb3, 0xbf,
+	0x8b, 0xe7, 0xfc, 0x6c, 0x1d, 0x7b, 0xe7, 0xeb, 0xd8, 0xfb, 0xb6, 0x8e, 0xbd, 0x0f, 0x9b, 0x78,
+	0x70, 0xbe, 0x89, 0x07, 0x5f, 0x36, 0xf1, 0x60, 0x11, 0xd2, 0x0f, 0xdb, 0xff, 0x1e, 0x00, 0x00,
+	0xff, 0xff, 0xaa, 0x5e, 0x01, 0x7e, 0xb7, 0x03, 0x00, 0x00,
+}
+
 func (m *Message) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -313,63 +351,74 @@ func (m *Message) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Message) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
+	if len(m.Data) > 0 {
+		for iNdEx := len(m.Data) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Data[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMessage(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.Responses) > 0 {
+		for iNdEx := len(m.Responses) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Responses[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMessage(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x1a
+		}
+	}
+	if len(m.Requests) > 0 {
+		for iNdEx := len(m.Requests) - 1; iNdEx >= 0; iNdEx-- {
+			{
+				size, err := m.Requests[iNdEx].MarshalToSizedBuffer(dAtA[:i])
+				if err != nil {
+					return 0, err
+				}
+				i -= size
+				i = encodeVarintMessage(dAtA, i, uint64(size))
+			}
+			i--
+			dAtA[i] = 0x12
+		}
+	}
 	if m.CompleteRequestList {
-		dAtA[i] = 0x8
-		i++
+		i--
 		if m.CompleteRequestList {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x8
 	}
-	if len(m.Requests) > 0 {
-		for _, msg := range m.Requests {
-			dAtA[i] = 0x12
-			i++
-			i = encodeVarintMessage(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.Responses) > 0 {
-		for _, msg := range m.Responses {
-			dAtA[i] = 0x1a
-			i++
-			i = encodeVarintMessage(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	if len(m.Data) > 0 {
-		for _, msg := range m.Data {
-			dAtA[i] = 0x22
-			i++
-			i = encodeVarintMessage(dAtA, i, uint64(msg.Size()))
-			n, err := msg.MarshalTo(dAtA[i:])
-			if err != nil {
-				return 0, err
-			}
-			i += n
-		}
-	}
-	return i, nil
+	return len(dAtA) - i, nil
 }
 
 func (m *Message_Request) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -377,82 +426,87 @@ func (m *Message_Request) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Message_Request) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_Request) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Id != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(m.Id))
-	}
-	if len(m.Root) > 0 {
-		dAtA[i] = 0x12
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(len(m.Root)))
-		i += copy(dAtA[i:], m.Root)
-	}
-	if len(m.Selector) > 0 {
-		dAtA[i] = 0x1a
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(len(m.Selector)))
-		i += copy(dAtA[i:], m.Selector)
-	}
-	if len(m.Extensions) > 0 {
-		for k, _ := range m.Extensions {
-			dAtA[i] = 0x22
-			i++
-			v := m.Extensions[k]
-			byteSize := 0
-			if len(v) > 0 {
-				byteSize = 1 + len(v) + sovMessage(uint64(len(v)))
-			}
-			mapSize := 1 + len(k) + sovMessage(uint64(len(k))) + byteSize
-			i = encodeVarintMessage(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintMessage(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			if len(v) > 0 {
-				dAtA[i] = 0x12
-				i++
-				i = encodeVarintMessage(dAtA, i, uint64(len(v)))
-				i += copy(dAtA[i:], v)
-			}
-		}
-	}
-	if m.Priority != 0 {
-		dAtA[i] = 0x28
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(m.Priority))
-	}
-	if m.Cancel {
-		dAtA[i] = 0x30
-		i++
-		if m.Cancel {
-			dAtA[i] = 1
-		} else {
-			dAtA[i] = 0
-		}
-		i++
-	}
 	if m.Update {
-		dAtA[i] = 0x38
-		i++
+		i--
 		if m.Update {
 			dAtA[i] = 1
 		} else {
 			dAtA[i] = 0
 		}
-		i++
+		i--
+		dAtA[i] = 0x38
 	}
-	return i, nil
+	if m.Cancel {
+		i--
+		if m.Cancel {
+			dAtA[i] = 1
+		} else {
+			dAtA[i] = 0
+		}
+		i--
+		dAtA[i] = 0x30
+	}
+	if m.Priority != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.Priority))
+		i--
+		dAtA[i] = 0x28
+	}
+	if len(m.Extensions) > 0 {
+		for k := range m.Extensions {
+			v := m.Extensions[k]
+			baseI := i
+			if len(v) > 0 {
+				i -= len(v)
+				copy(dAtA[i:], v)
+				i = encodeVarintMessage(dAtA, i, uint64(len(v)))
+				i--
+				dAtA[i] = 0x12
+			}
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintMessage(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintMessage(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x22
+		}
+	}
+	if len(m.Selector) > 0 {
+		i -= len(m.Selector)
+		copy(dAtA[i:], m.Selector)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.Selector)))
+		i--
+		dAtA[i] = 0x1a
+	}
+	if len(m.Root) > 0 {
+		i -= len(m.Root)
+		copy(dAtA[i:], m.Root)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.Root)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if m.Id != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.Id))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Message_Response) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -460,50 +514,53 @@ func (m *Message_Response) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Message_Response) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_Response) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if m.Id != 0 {
-		dAtA[i] = 0x8
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(m.Id))
-	}
-	if m.Status != 0 {
-		dAtA[i] = 0x10
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(m.Status))
-	}
 	if len(m.Extensions) > 0 {
-		for k, _ := range m.Extensions {
-			dAtA[i] = 0x1a
-			i++
+		for k := range m.Extensions {
 			v := m.Extensions[k]
-			byteSize := 0
+			baseI := i
 			if len(v) > 0 {
-				byteSize = 1 + len(v) + sovMessage(uint64(len(v)))
-			}
-			mapSize := 1 + len(k) + sovMessage(uint64(len(k))) + byteSize
-			i = encodeVarintMessage(dAtA, i, uint64(mapSize))
-			dAtA[i] = 0xa
-			i++
-			i = encodeVarintMessage(dAtA, i, uint64(len(k)))
-			i += copy(dAtA[i:], k)
-			if len(v) > 0 {
-				dAtA[i] = 0x12
-				i++
+				i -= len(v)
+				copy(dAtA[i:], v)
 				i = encodeVarintMessage(dAtA, i, uint64(len(v)))
-				i += copy(dAtA[i:], v)
+				i--
+				dAtA[i] = 0x12
 			}
+			i -= len(k)
+			copy(dAtA[i:], k)
+			i = encodeVarintMessage(dAtA, i, uint64(len(k)))
+			i--
+			dAtA[i] = 0xa
+			i = encodeVarintMessage(dAtA, i, uint64(baseI-i))
+			i--
+			dAtA[i] = 0x1a
 		}
 	}
-	return i, nil
+	if m.Status != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.Status))
+		i--
+		dAtA[i] = 0x10
+	}
+	if m.Id != 0 {
+		i = encodeVarintMessage(dAtA, i, uint64(m.Id))
+		i--
+		dAtA[i] = 0x8
+	}
+	return len(dAtA) - i, nil
 }
 
 func (m *Message_Block) Marshal() (dAtA []byte, err error) {
 	size := m.Size()
 	dAtA = make([]byte, size)
-	n, err := m.MarshalTo(dAtA)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
 	if err != nil {
 		return nil, err
 	}
@@ -511,33 +568,42 @@ func (m *Message_Block) Marshal() (dAtA []byte, err error) {
 }
 
 func (m *Message_Block) MarshalTo(dAtA []byte) (int, error) {
-	var i int
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *Message_Block) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
 	_ = i
 	var l int
 	_ = l
-	if len(m.Prefix) > 0 {
-		dAtA[i] = 0xa
-		i++
-		i = encodeVarintMessage(dAtA, i, uint64(len(m.Prefix)))
-		i += copy(dAtA[i:], m.Prefix)
-	}
 	if len(m.Data) > 0 {
-		dAtA[i] = 0x12
-		i++
+		i -= len(m.Data)
+		copy(dAtA[i:], m.Data)
 		i = encodeVarintMessage(dAtA, i, uint64(len(m.Data)))
-		i += copy(dAtA[i:], m.Data)
+		i--
+		dAtA[i] = 0x12
 	}
-	return i, nil
+	if len(m.Prefix) > 0 {
+		i -= len(m.Prefix)
+		copy(dAtA[i:], m.Prefix)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.Prefix)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
 }
 
 func encodeVarintMessage(dAtA []byte, offset int, v uint64) int {
+	offset -= sovMessage(v)
+	base := offset
 	for v >= 1<<7 {
 		dAtA[offset] = uint8(v&0x7f | 0x80)
 		v >>= 7
 		offset++
 	}
 	dAtA[offset] = uint8(v)
-	return offset + 1
+	return base
 }
 func (m *Message) Size() (n int) {
 	if m == nil {
@@ -655,14 +721,7 @@ func (m *Message_Block) Size() (n int) {
 }
 
 func sovMessage(x uint64) (n int) {
-	for {
-		n++
-		x >>= 7
-		if x == 0 {
-			break
-		}
-	}
-	return n
+	return (math_bits.Len64(x|1) + 6) / 7
 }
 func sozMessage(x uint64) (n int) {
 	return sovMessage(uint64((x << 1) ^ uint64((int64(x) >> 63))))
@@ -682,7 +741,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -710,7 +769,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -730,7 +789,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -739,6 +798,9 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -761,7 +823,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -770,6 +832,9 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -792,7 +857,7 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -801,6 +866,9 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -816,6 +884,9 @@ func (m *Message) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
 			if (iNdEx + skippy) > l {
@@ -845,7 +916,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -873,7 +944,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Id |= (int32(b) & 0x7F) << shift
+				m.Id |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -892,7 +963,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -901,6 +972,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -923,7 +997,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -932,6 +1006,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -954,7 +1031,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -963,6 +1040,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -983,7 +1063,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					wire |= (uint64(b) & 0x7F) << shift
+					wire |= uint64(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -1000,7 +1080,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						stringLenmapkey |= uint64(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -1010,6 +1090,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 						return ErrInvalidLengthMessage
 					}
 					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthMessage
+					}
 					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
@@ -1026,7 +1109,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						mapbyteLen |= (uint64(b) & 0x7F) << shift
+						mapbyteLen |= uint64(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -1036,6 +1119,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 						return ErrInvalidLengthMessage
 					}
 					postbytesIndex := iNdEx + intMapbyteLen
+					if postbytesIndex < 0 {
+						return ErrInvalidLengthMessage
+					}
 					if postbytesIndex > l {
 						return io.ErrUnexpectedEOF
 					}
@@ -1073,7 +1159,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Priority |= (int32(b) & 0x7F) << shift
+				m.Priority |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1092,7 +1178,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1112,7 +1198,7 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				v |= (int(b) & 0x7F) << shift
+				v |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1125,6 +1211,9 @@ func (m *Message_Request) Unmarshal(dAtA []byte) error {
 				return err
 			}
 			if skippy < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if (iNdEx + skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
 			if (iNdEx + skippy) > l {
@@ -1154,7 +1243,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1182,7 +1271,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Id |= (int32(b) & 0x7F) << shift
+				m.Id |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1201,7 +1290,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				m.Status |= (int32(b) & 0x7F) << shift
+				m.Status |= int32(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1220,7 +1309,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				msglen |= (int(b) & 0x7F) << shift
+				msglen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1229,6 +1318,9 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + msglen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1249,7 +1341,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 					}
 					b := dAtA[iNdEx]
 					iNdEx++
-					wire |= (uint64(b) & 0x7F) << shift
+					wire |= uint64(b&0x7F) << shift
 					if b < 0x80 {
 						break
 					}
@@ -1266,7 +1358,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						stringLenmapkey |= (uint64(b) & 0x7F) << shift
+						stringLenmapkey |= uint64(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -1276,6 +1368,9 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 						return ErrInvalidLengthMessage
 					}
 					postStringIndexmapkey := iNdEx + intStringLenmapkey
+					if postStringIndexmapkey < 0 {
+						return ErrInvalidLengthMessage
+					}
 					if postStringIndexmapkey > l {
 						return io.ErrUnexpectedEOF
 					}
@@ -1292,7 +1387,7 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 						}
 						b := dAtA[iNdEx]
 						iNdEx++
-						mapbyteLen |= (uint64(b) & 0x7F) << shift
+						mapbyteLen |= uint64(b&0x7F) << shift
 						if b < 0x80 {
 							break
 						}
@@ -1302,6 +1397,9 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 						return ErrInvalidLengthMessage
 					}
 					postbytesIndex := iNdEx + intMapbyteLen
+					if postbytesIndex < 0 {
+						return ErrInvalidLengthMessage
+					}
 					if postbytesIndex > l {
 						return io.ErrUnexpectedEOF
 					}
@@ -1334,6 +1432,9 @@ func (m *Message_Response) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthMessage
 			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1361,7 +1462,7 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 			}
 			b := dAtA[iNdEx]
 			iNdEx++
-			wire |= (uint64(b) & 0x7F) << shift
+			wire |= uint64(b&0x7F) << shift
 			if b < 0x80 {
 				break
 			}
@@ -1389,7 +1490,7 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1398,6 +1499,9 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1420,7 +1524,7 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 				}
 				b := dAtA[iNdEx]
 				iNdEx++
-				byteLen |= (int(b) & 0x7F) << shift
+				byteLen |= int(b&0x7F) << shift
 				if b < 0x80 {
 					break
 				}
@@ -1429,6 +1533,9 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 				return ErrInvalidLengthMessage
 			}
 			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if postIndex > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1446,6 +1553,9 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 			if skippy < 0 {
 				return ErrInvalidLengthMessage
 			}
+			if (iNdEx + skippy) < 0 {
+				return ErrInvalidLengthMessage
+			}
 			if (iNdEx + skippy) > l {
 				return io.ErrUnexpectedEOF
 			}
@@ -1461,6 +1571,7 @@ func (m *Message_Block) Unmarshal(dAtA []byte) error {
 func skipMessage(dAtA []byte) (n int, err error) {
 	l := len(dAtA)
 	iNdEx := 0
+	depth := 0
 	for iNdEx < l {
 		var wire uint64
 		for shift := uint(0); ; shift += 7 {
@@ -1492,10 +1603,8 @@ func skipMessage(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			return iNdEx, nil
 		case 1:
 			iNdEx += 8
-			return iNdEx, nil
 		case 2:
 			var length int
 			for shift := uint(0); ; shift += 7 {
@@ -1512,88 +1621,34 @@ func skipMessage(dAtA []byte) (n int, err error) {
 					break
 				}
 			}
-			iNdEx += length
 			if length < 0 {
 				return 0, ErrInvalidLengthMessage
 			}
-			return iNdEx, nil
+			iNdEx += length
 		case 3:
-			for {
-				var innerWire uint64
-				var start int = iNdEx
-				for shift := uint(0); ; shift += 7 {
-					if shift >= 64 {
-						return 0, ErrIntOverflowMessage
-					}
-					if iNdEx >= l {
-						return 0, io.ErrUnexpectedEOF
-					}
-					b := dAtA[iNdEx]
-					iNdEx++
-					innerWire |= (uint64(b) & 0x7F) << shift
-					if b < 0x80 {
-						break
-					}
-				}
-				innerWireType := int(innerWire & 0x7)
-				if innerWireType == 4 {
-					break
-				}
-				next, err := skipMessage(dAtA[start:])
-				if err != nil {
-					return 0, err
-				}
-				iNdEx = start + next
-			}
-			return iNdEx, nil
+			depth++
 		case 4:
-			return iNdEx, nil
+			if depth == 0 {
+				return 0, ErrUnexpectedEndOfGroupMessage
+			}
+			depth--
 		case 5:
 			iNdEx += 4
-			return iNdEx, nil
 		default:
 			return 0, fmt.Errorf("proto: illegal wireType %d", wireType)
 		}
+		if iNdEx < 0 {
+			return 0, ErrInvalidLengthMessage
+		}
+		if depth == 0 {
+			return iNdEx, nil
+		}
 	}
-	panic("unreachable")
+	return 0, io.ErrUnexpectedEOF
 }
 
 var (
-	ErrInvalidLengthMessage = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowMessage   = fmt.Errorf("proto: integer overflow")
+	ErrInvalidLengthMessage        = fmt.Errorf("proto: negative length found during unmarshaling")
+	ErrIntOverflowMessage          = fmt.Errorf("proto: integer overflow")
+	ErrUnexpectedEndOfGroupMessage = fmt.Errorf("proto: unexpected end of group")
 )
-
-func init() { proto.RegisterFile("message.proto", fileDescriptor_message_5de5dd65106cd0db) }
-
-var fileDescriptor_message_5de5dd65106cd0db = []byte{
-	// 458 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xa4, 0x53, 0xcb, 0x6e, 0xd3, 0x40,
-	0x14, 0x8d, 0x9d, 0xd8, 0x49, 0x2f, 0xe5, 0xa1, 0xa1, 0xaa, 0x46, 0x5e, 0x98, 0x08, 0x04, 0xca,
-	0x06, 0x17, 0x51, 0x81, 0x10, 0x52, 0x37, 0x91, 0x2a, 0x24, 0x04, 0x9b, 0x91, 0x60, 0xef, 0x38,
-	0xb7, 0xae, 0x55, 0xc7, 0x63, 0x66, 0xc6, 0xa8, 0xfe, 0x0b, 0xfe, 0x83, 0x7f, 0x60, 0x5d, 0x76,
-	0x5d, 0xb2, 0x42, 0x28, 0xf9, 0x11, 0xe4, 0x3b, 0x83, 0x79, 0x55, 0xa5, 0x12, 0xbb, 0x7b, 0xee,
-	0xcc, 0x39, 0xf7, 0x71, 0x66, 0xe0, 0xfa, 0x0a, 0xb5, 0x4e, 0x73, 0x4c, 0x6a, 0x25, 0x8d, 0x64,
-	0x3b, 0xb9, 0x4a, 0xeb, 0x63, 0xdd, 0x56, 0x59, 0xd2, 0x1f, 0x2c, 0xa2, 0x87, 0x79, 0x61, 0x8e,
-	0x9b, 0x45, 0x92, 0xc9, 0xd5, 0x5e, 0x2e, 0x73, 0xb9, 0x47, 0x97, 0x17, 0xcd, 0x11, 0x21, 0x02,
-	0x14, 0x59, 0x91, 0xbb, 0x9f, 0x42, 0x18, 0xbf, 0xb6, 0x6c, 0xf6, 0x08, 0x6e, 0x67, 0x72, 0x55,
-	0x97, 0x68, 0x50, 0xe0, 0xbb, 0x06, 0xb5, 0x79, 0x55, 0x68, 0xc3, 0xbd, 0xa9, 0x37, 0x9b, 0x88,
-	0x8b, 0x8e, 0xd8, 0x0b, 0x98, 0x28, 0x0b, 0x35, 0xf7, 0xa7, 0xc3, 0xd9, 0xb5, 0xc7, 0xf7, 0x93,
-	0x8b, 0xba, 0x4a, 0x5c, 0x89, 0xc4, 0x91, 0xe7, 0xa3, 0xb3, 0xaf, 0x77, 0x06, 0xa2, 0x27, 0xb3,
-	0x97, 0xb0, 0xa5, 0x50, 0xd7, 0xb2, 0xd2, 0xa8, 0xf9, 0x90, 0x94, 0x1e, 0xfc, 0x4b, 0xc9, 0x5e,
-	0x77, 0x52, 0x3f, 0xe9, 0xec, 0x00, 0x46, 0xcb, 0xd4, 0xa4, 0x7c, 0x44, 0x32, 0xf7, 0x2e, 0x97,
-	0x99, 0x97, 0x32, 0x3b, 0x71, 0x1a, 0x44, 0x8b, 0x3e, 0xfa, 0x30, 0x76, 0x6d, 0xb2, 0x1b, 0xe0,
-	0x17, 0x4b, 0x5a, 0x40, 0x20, 0xfc, 0x62, 0xc9, 0x18, 0x8c, 0x94, 0x94, 0x86, 0xfb, 0x53, 0x6f,
-	0xb6, 0x2d, 0x28, 0x66, 0x11, 0x4c, 0x34, 0x96, 0x98, 0x19, 0xa9, 0xf8, 0x90, 0xf2, 0x3d, 0x66,
-	0x6f, 0x00, 0xf0, 0xd4, 0x60, 0xa5, 0x0b, 0x59, 0x69, 0xd7, 0xd0, 0x93, 0x2b, 0x6d, 0x28, 0x39,
-	0xec, 0x79, 0x87, 0x95, 0x51, 0xad, 0xf8, 0x45, 0xa8, 0x2b, 0x59, 0xab, 0x42, 0xaa, 0xc2, 0xb4,
-	0x3c, 0xa0, 0xe6, 0x7a, 0xcc, 0x76, 0x21, 0xcc, 0xd2, 0x2a, 0xc3, 0x92, 0x87, 0xe4, 0x9b, 0x43,
-	0x5d, 0xbe, 0xa9, 0x97, 0xa9, 0x41, 0x3e, 0xb6, 0x79, 0x8b, 0xa2, 0x03, 0xb8, 0xf9, 0x47, 0x29,
-	0x76, 0x0b, 0x86, 0x27, 0xd8, 0xd2, 0xd8, 0x5b, 0xa2, 0x0b, 0xd9, 0x0e, 0x04, 0xef, 0xd3, 0xb2,
-	0x41, 0x37, 0xb8, 0x05, 0xcf, 0xfd, 0x67, 0x5e, 0xf4, 0xd9, 0x83, 0xc9, 0x0f, 0x2b, 0xfe, 0x5a,
-	0xd7, 0x2e, 0x84, 0xda, 0xa4, 0xa6, 0xd1, 0xc4, 0x0b, 0x84, 0x43, 0xec, 0xed, 0x6f, 0x6b, 0xb1,
-	0x76, 0x3f, 0xbd, 0x9a, 0xdd, 0x97, 0xed, 0xe5, 0x7f, 0x67, 0xd9, 0x87, 0x80, 0x9e, 0x43, 0xd7,
-	0x77, 0xad, 0xf0, 0xa8, 0x38, 0x25, 0xde, 0xb6, 0x70, 0xa8, 0xb3, 0x9f, 0x5e, 0x96, 0xb3, 0xbf,
-	0x8b, 0xe7, 0xfc, 0x6c, 0x1d, 0x7b, 0xe7, 0xeb, 0xd8, 0xfb, 0xb6, 0x8e, 0xbd, 0x0f, 0x9b, 0x78,
-	0x70, 0xbe, 0x89, 0x07, 0x5f, 0x36, 0xf1, 0x60, 0x11, 0xd2, 0x0f, 0xdb, 0xff, 0x1e, 0x00, 0x00,
-	0xff, 0xff, 0xaa, 0x5e, 0x01, 0x7e, 0xb7, 0x03, 0x00, 0x00,
-}


### PR DESCRIPTION
# Goals

Fix potential overflow errors in unmarshal code for protobuf messages

# Implementation

And older version of gogo-protobuf had generated our message.pb.go code which was lacking checks for negative indexes due to integer overflow issues.

I installed the latest version of protoc-gen-gogofaster (the version we use) and regenerated to get these changes, which insert checks for negative values.