### PR TITLE
Dedup by key extension

### DIFF
--- a/dedupkey/dedupkey.go
+++ b/dedupkey/dedupkey.go
@@ -1,0 +1,26 @@
+package dedupkey
+
+import (
+	"github.com/ipfs/go-graphsync/ipldutil"
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+)
+
+// EncodeDedupKey returns encoded cbor data for string key
+func EncodeDedupKey(key string) ([]byte, error) {
+	nb := basicnode.Style.String.NewBuilder()
+	err := nb.AssignString(key)
+	if err != nil {
+		return nil, err
+	}
+	nd := nb.Build()
+	return ipldutil.EncodeNode(nd)
+}
+
+// DecodeDedupKey returns a string key decoded from cbor data
+func DecodeDedupKey(data []byte) (string, error) {
+	nd, err := ipldutil.DecodeNode(data)
+	if err != nil {
+		return "", err
+	}
+	return nd.AsString()
+}

--- a/graphsync.go
+++ b/graphsync.go
@@ -42,6 +42,10 @@ const (
 	// https://github.com/ipld/specs/blob/master/block-layer/graphsync/known_extensions.md
 	ExtensionDoNotSendCIDs = ExtensionName("graphsync/do-not-send-cids")
 
+	// ExtensionDeDupByKey tells the responding peer to only deduplicate block sending
+	// for requests that have the same key. The data for the extension is a string key
+	ExtensionDeDupByKey = ExtensionName("graphsync/dedup-by-key")
+
 	// GraphSync Response Status Codes
 
 	// Informational Response Codes (partial)

--- a/linktracker/linktracker.go
+++ b/linktracker/linktracker.go
@@ -78,3 +78,8 @@ func (lt *LinkTracker) FinishRequest(requestID graphsync.RequestID) (hasAllBlock
 
 	return
 }
+
+// Empty returns true if the link tracker is empty
+func (lt *LinkTracker) Empty() bool {
+	return len(lt.missingBlocks) == 0 && len(lt.traversalsWithBlocksInProgress) == 0
+}

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/cidset"
+	"github.com/ipfs/go-graphsync/dedupkey"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
@@ -645,6 +646,12 @@ func TestOutgoingRequestHooks(t *testing.T) {
 	returnedResponseChan2, returnedErrorChan2 := td.requestManager.SendRequest(requestCtx, peers[0], td.blockChain.TipLink, td.blockChain.Selector())
 
 	requestRecords := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 2)
+
+	dedupData, has := requestRecords[0].gsr.Extension(graphsync.ExtensionDeDupByKey)
+	require.True(t, has)
+	key, err := dedupkey.DecodeDedupKey(dedupData)
+	require.NoError(t, err)
+	require.Equal(t, "chainstore", key)
 
 	md := metadataForBlocks(td.blockChain.AllBlocks(), true)
 	mdEncoded, err := metadata.EncodeMetadata(md)


### PR DESCRIPTION
# Goals

- provide a way to communicate that you don't want requests deduplicated across blocks

# Implementation

When you register alternate persistence stores, it's important to treat requests to those persistence stores as if they are a seperate peer.

This impliments a "dedup by key" extension which provides a way to say to a provider, for this peer, only dedup blocks in requests that also have this key.

On the provider, we simply use the alternate store name as the key
