### PR TITLE
Breakup messages w/ response codes

### DIFF
--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -63,6 +63,12 @@ func (rb *ResponseBuilder) AddResponseCode(requestID graphsync.RequestID, status
 	}
 }
 
+// HasResponseCode returns true if the given builder already has a response code for this request
+func (rb *ResponseBuilder) HasResponseCode(requestID graphsync.RequestID) bool {
+	_, ok := rb.completedResponses[requestID]
+	return ok
+}
+
 // Empty returns true if there is no content to send
 func (rb *ResponseBuilder) Empty() bool {
 	return len(rb.outgoingBlocks) == 0 && len(rb.outgoingResponses) == 0


### PR DESCRIPTION
# Goals

If a request is paused, that information should get transmitted somehow, even if the request is quickly unpaused. This changes a behavior where if you pause your request then quickly unpause the record of pausing might never be transmitted to the client. This presents problems to clients for whom the pausing may convey other semantic information.

# Implementation

- For any operation on Peer Response Sender, breakup to the next ResponseBuilder if there is already a explicit response code for the given request ID in the message.
- Add method to ResponseBuilder to query this information