### PR TITLE
Return Request context cancelled error

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -94,6 +94,13 @@ const (
 	RequestCancelled = ResponseStatusCode(35)
 )
 
+// RequestContextCancelledErr is an error message received on the error channel when the request context given by the user is cancelled/times out
+type RequestContextCancelledErr struct{}
+
+func (e RequestContextCancelledErr) Error() string {
+	return "Request Context Cancelled"
+}
+
 // RequestFailedBusyErr is an error message received on the error channel when the peer is busy
 type RequestFailedBusyErr struct{}
 

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -199,8 +199,13 @@ func TestCancelRequestInProgress(t *testing.T) {
 
 	testutil.VerifyEmptyResponse(requestCtx, t, returnedResponseChan1)
 	td.blockChain.VerifyWholeChain(requestCtx, returnedResponseChan2)
-	testutil.VerifyEmptyErrors(requestCtx, t, returnedErrorChan1)
+
 	testutil.VerifyEmptyErrors(requestCtx, t, returnedErrorChan2)
+
+	errors := testutil.CollectErrors(requestCtx, t, returnedErrorChan1)
+	require.Len(t, errors, 1)
+	_, ok := errors[0].(graphsync.RequestContextCancelledErr)
+	require.True(t, ok)
 }
 
 func TestCancelManagerExitsGracefully(t *testing.T) {

--- a/requestmanager/responsecollector.go
+++ b/requestmanager/responsecollector.go
@@ -88,6 +88,16 @@ func (rc *responseCollector) collectResponses(
 			case err, ok := <-incomingErrors:
 				if !ok {
 					incomingErrors = nil
+					// even if the `incomingErrors` channel is closed without any error,
+					// the context could still have timed out in which case we need to inform the caller of the same.
+					select {
+					case <-requestCtx.Done():
+						select {
+						case <-rc.ctx.Done():
+						case returnedErrors <- graphsync.RequestContextCancelledErr{}:
+						}
+					default:
+					}
 				} else {
 					receivedErrors = append(receivedErrors, err)
 				}

--- a/requestmanager/responsecollector.go
+++ b/requestmanager/responsecollector.go
@@ -80,6 +80,10 @@ func (rc *responseCollector) collectResponses(
 			case <-rc.ctx.Done():
 				return
 			case <-requestCtx.Done():
+				select {
+				case <-rc.ctx.Done():
+				case returnedErrors <- graphsync.RequestContextCancelledErr{}:
+				}
 				return
 			case err, ok := <-incomingErrors:
 				if !ok {


### PR DESCRIPTION
As discussed, if the user's request context is cancelled for whatever reason, we should write that error to the reponse error channel.

@hannahhoward Because we ignore context cancellation errors here:
https://github.com/ipfs/go-graphsync/blob/d88611c4c9698f8f72daf31f64908c52d8f42d24/requestmanager/executor/executor.go#L148

we had a race wherein we'd mark a request as "completed" even though the context is cancelled because we close the response error channel here without writing anything to it. Have fixed that as well.

LMKWYT.