### PR TITLE
Prune blocks more intelligently

### DIFF
--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -52,8 +52,14 @@ func BenchmarkRoundtripSuccess(b *testing.B) {
 	b.Run("test-20-10000", func(b *testing.B) {
 		subtestDistributeAndFetch(ctx, b, 20, delay.Fixed(0), time.Duration(0), allFilesUniformSize(10000, defaultUnixfsChunkSize, defaultUnixfsLinksPerLevel), tdm)
 	})
+	b.Run("test-20-128MB", func(b *testing.B) {
+		subtestDistributeAndFetch(ctx, b, 10, delay.Fixed(0), time.Duration(0), allFilesUniformSize(128*(1<<20), defaultUnixfsChunkSize, defaultUnixfsLinksPerLevel), tdm)
+	})
 	b.Run("test-p2p-stress-10-128MB", func(b *testing.B) {
 		p2pStrestTest(ctx, b, 20, allFilesUniformSize(128*(1<<20), 1<<20, 1024), tdm)
+	})
+	b.Run("test-p2p-stress-10-128MB-1KB-chunks", func(b *testing.B) {
+		p2pStrestTest(ctx, b, 10, allFilesUniformSize(128*(1<<20), 1<<10, 1024), tdm)
 	})
 }
 

--- a/requestmanager/asyncloader/responsecache/responsecache_test.go
+++ b/requestmanager/asyncloader/responsecache/responsecache_test.go
@@ -31,6 +31,10 @@ func (ubs *fakeUnverifiedBlockStore) PruneBlocks(shouldPrune func(ipld.Link) boo
 	}
 }
 
+func (ubs *fakeUnverifiedBlockStore) PruneBlock(link ipld.Link) {
+	delete(ubs.inMemoryBlocks, link)
+}
+
 func (ubs *fakeUnverifiedBlockStore) VerifyBlock(lnk ipld.Link) ([]byte, error) {
 	data, ok := ubs.inMemoryBlocks[lnk]
 	if !ok {

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
@@ -38,6 +38,11 @@ func (ubs *UnverifiedBlockStore) PruneBlocks(shouldPrune func(ipld.Link) bool) {
 	}
 }
 
+// PruneBlock deletes an individual block from the store
+func (ubs *UnverifiedBlockStore) PruneBlock(link ipld.Link) {
+	delete(ubs.inMemoryBlocks, link)
+}
+
 // VerifyBlock verifies the data for the given link as being part of a traversal,
 // removes it from the unverified store, and writes it to permaneant storage.
 func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link) ([]byte, error) {


### PR DESCRIPTION
# Goals

We've witnessed high CPU usage in UnverifiedBlockStore.PruneBlocks in the wild. Prune blocks is used to make sure that blocks received from a remote peer for a traversal do not accumulate in memory. This happens at two points:

1. If they appear in a message, but are not attached to metadata for a response in the message, they are pruned.
2. If a response terminates without the traversal consuming the block, they are pruned

The problem here is that when we do #1, which is run after every message received, we currently loop through all blocks in the store -- meaning that if they were part of a previous message and didn't get pruned cause they were referenced in metadata, but the selector traversal hasn't caught up and removed the block from the store, we still iterate over them blocks.

# Implementation

For pruning  step 1, instead of iterating over all blocks, iterate only over those blocks that were part of the message we just processed. Any other blocks are either already pruned or they wouldn't get pruned in this step. You can think of it as a very very basic kind of generational GC -- we only see if we can garbage collect the most recent stuff, and we're luck enough to know the exact rules around whether we can garbage collect them.

This results in removing this CPU bottleneck by drastically shortening this map iteration:

Pre-CPU-profile:
![preprofile](https://user-images.githubusercontent.com/1450680/94975558-ecee2d80-04c6-11eb-8f90-a39d3a69bfff.png)

Post-CPU-profile: (not UnverifiedBlockStore.PruneBlocks gone as a hot spot)
![postprofile](https://user-images.githubusercontent.com/1450680/94975605-0ee7b000-04c7-11eb-84fb-1c6ba93a74b9.png)


