### PR TITLE
Track actual network operations in a response

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -283,11 +283,17 @@ type OnOutgoingBlockHook func(p peer.ID, request RequestData, block BlockData, h
 // It receives an interface to taking further action on the response
 type OnRequestUpdatedHook func(p peer.ID, request RequestData, updateRequest RequestData, hookActions RequestUpdatedHookActions)
 
+// OnBlockSentListener runs when a block is sent over the wire
+type OnBlockSentListener func(p peer.ID, requestID RequestID, block BlockData)
+
+// OnNetworkErrorListener runs when queued data is not able to be sent
+type OnNetworkErrorListener func(p peer.ID, requestID RequestID, err error)
+
 // OnResponseCompletedListener provides a way to listen for when responder has finished serving a response
-type OnResponseCompletedListener func(p peer.ID, request RequestData, status ResponseStatusCode)
+type OnResponseCompletedListener func(p peer.ID, requestID RequestID, status ResponseStatusCode)
 
 // OnRequestorCancelledListener provides a way to listen for responses the requestor canncels
-type OnRequestorCancelledListener func(p peer.ID, request RequestData)
+type OnRequestorCancelledListener func(p peer.ID, requestID RequestID)
 
 // UnregisterHookFunc is a function call to unregister a hook that was previously registered
 type UnregisterHookFunc func()
@@ -327,6 +333,12 @@ type GraphExchange interface {
 	// RegisterRequestorCancelledListener adds a listener on the responder for
 	// responses cancelled by the requestor
 	RegisterRequestorCancelledListener(listener OnRequestorCancelledListener) UnregisterHookFunc
+
+	// RegisterBlockSentListener adds a listener for when blocks are actually sent over the wire
+	RegisterBlockSentListener(listener OnBlockSentListener) UnregisterHookFunc
+
+	// RegisterNetworkErrorListener adds a listener for when errors occur sending data over the wire
+	RegisterNetworkErrorListener(listener OnNetworkErrorListener) UnregisterHookFunc
 
 	// UnpauseRequest unpauses a request that was paused in a block hook based request ID
 	// Can also send extensions with unpause

--- a/graphsync.go
+++ b/graphsync.go
@@ -284,16 +284,16 @@ type OnOutgoingBlockHook func(p peer.ID, request RequestData, block BlockData, h
 type OnRequestUpdatedHook func(p peer.ID, request RequestData, updateRequest RequestData, hookActions RequestUpdatedHookActions)
 
 // OnBlockSentListener runs when a block is sent over the wire
-type OnBlockSentListener func(p peer.ID, requestID RequestID, block BlockData)
+type OnBlockSentListener func(p peer.ID, request RequestData, block BlockData)
 
 // OnNetworkErrorListener runs when queued data is not able to be sent
-type OnNetworkErrorListener func(p peer.ID, requestID RequestID, err error)
+type OnNetworkErrorListener func(p peer.ID, request RequestData, err error)
 
 // OnResponseCompletedListener provides a way to listen for when responder has finished serving a response
-type OnResponseCompletedListener func(p peer.ID, requestID RequestID, status ResponseStatusCode)
+type OnResponseCompletedListener func(p peer.ID, request RequestData, status ResponseStatusCode)
 
 // OnRequestorCancelledListener provides a way to listen for responses the requestor canncels
-type OnRequestorCancelledListener func(p peer.ID, requestID RequestID)
+type OnRequestorCancelledListener func(p peer.ID, request RequestData)
 
 // UnregisterHookFunc is a function call to unregister a hook that was previously registered
 type UnregisterHookFunc func()

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -210,7 +210,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	})
 
 	finalResponseStatusChan := make(chan graphsync.ResponseStatusCode, 1)
-	responder.RegisterCompletedResponseListener(func(p peer.ID, request graphsync.RequestID, status graphsync.ResponseStatusCode) {
+	responder.RegisterCompletedResponseListener(func(p peer.ID, request graphsync.RequestData, status graphsync.ResponseStatusCode) {
 		select {
 		case finalResponseStatusChan <- status:
 		default:
@@ -253,7 +253,7 @@ func TestGraphsyncRoundTripPartial(t *testing.T) {
 	responder := td.GraphSyncHost2()
 
 	finalResponseStatusChan := make(chan graphsync.ResponseStatusCode, 1)
-	responder.RegisterCompletedResponseListener(func(p peer.ID, request graphsync.RequestID, status graphsync.ResponseStatusCode) {
+	responder.RegisterCompletedResponseListener(func(p peer.ID, request graphsync.RequestData, status graphsync.ResponseStatusCode) {
 		select {
 		case finalResponseStatusChan <- status:
 		default:
@@ -584,7 +584,7 @@ func TestNetworkDisconnect(t *testing.T) {
 		}
 	})
 	networkError := make(chan error, 1)
-	responder.RegisterNetworkErrorListener(func(p peer.ID, requestID graphsync.RequestID, err error) {
+	responder.RegisterNetworkErrorListener(func(p peer.ID, request graphsync.RequestData, err error) {
 		select {
 		case networkError <- err:
 		default:

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -33,12 +33,7 @@ type Event struct {
 	Err  error
 }
 
-type TopicIndex uint64
-
-type Topic struct {
-	P     peer.ID
-	Index TopicIndex
-}
+type Topic uint64
 
 // MessageNetwork is any network that can connect peers and generate a message
 // sender.
@@ -60,7 +55,7 @@ type MessageQueue struct {
 	nextMessage        gsmsg.GraphSyncMessage
 	nextMessageTopic   Topic
 	nextMessageLk      sync.RWMutex
-	nextAvailableTopic TopicIndex
+	nextAvailableTopic Topic
 	processedNotifiers []chan struct{}
 	sender             gsnet.MessageSender
 	eventPublisher     notifications.Publisher
@@ -139,10 +134,7 @@ func (mq *MessageQueue) mutateNextMessage(mutator func(gsmsg.GraphSyncMessage), 
 	defer mq.nextMessageLk.Unlock()
 	if mq.nextMessage == nil {
 		mq.nextMessage = gsmsg.New()
-		mq.nextMessageTopic = Topic{
-			P:     mq.p,
-			Index: mq.nextAvailableTopic,
-		}
+		mq.nextMessageTopic = mq.nextAvailableTopic
 		mq.nextAvailableTopic++
 	}
 	mutator(mq.nextMessage)

--- a/notifications/mappable.go
+++ b/notifications/mappable.go
@@ -1,0 +1,47 @@
+package notifications
+
+import "sync"
+
+type mappableSubscriber struct {
+	idMapLk        sync.RWMutex
+	idMap          map[Topic]Topic
+	eventTransform EventTransform
+	Subscriber
+}
+
+// NewMappableSubscriber produces a subscriber that will transform
+// events and topics before passing them on to the given subscriber
+func NewMappableSubscriber(sub Subscriber, eventTransform EventTransform) MappableSubscriber {
+	return &mappableSubscriber{
+		Subscriber:     sub,
+		eventTransform: eventTransform,
+		idMap:          make(map[Topic]Topic),
+	}
+}
+
+func (m *mappableSubscriber) Map(id Topic, destinationID Topic) {
+	m.idMapLk.Lock()
+	m.idMap[id] = destinationID
+	m.idMapLk.Unlock()
+}
+
+func (m *mappableSubscriber) transform(id Topic) Topic {
+	m.idMapLk.RLock()
+	defer m.idMapLk.RUnlock()
+	destID, ok := m.idMap[id]
+	if !ok {
+		return id
+	}
+	return destID
+}
+
+func (m *mappableSubscriber) OnNext(topic Topic, ev Event) {
+	newTopic := m.transform(topic)
+	newEv := m.eventTransform(ev)
+	m.Subscriber.OnNext(newTopic, newEv)
+}
+
+func (m *mappableSubscriber) OnClose(topic Topic) {
+	newTopic := m.transform(topic)
+	m.Subscriber.OnClose(newTopic)
+}

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -1,0 +1,150 @@
+package notifications_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ipfs/go-graphsync/notifications"
+	"github.com/ipfs/go-graphsync/testutil"
+)
+
+func TestSubscribeOn(t *testing.T) {
+	ctx := context.Background()
+	testCases := map[string]func(ctx context.Context, t *testing.T, ps notifications.Publisher){
+		"SubscribeOn": func(ctx context.Context, t *testing.T, ps notifications.Publisher) {
+			destTopic := "t2"
+			notifee, verifier := testutil.NewTestNotifee(destTopic, 1)
+			notifications.SubscribeOn(ps, "t1", notifee)
+			ps.Publish("t1", "hi")
+			ps.Shutdown()
+			verifier.ExpectEvents(ctx, t, []notifications.Event{"hi"})
+			verifier.ExpectClose(ctx, t)
+		},
+		"Add subscriptions": func(ctx context.Context, t *testing.T, ps notifications.Publisher) {
+			sub1 := testutil.NewTestSubscriber(3)
+			sub2 := testutil.NewTestSubscriber(3)
+			ps.Subscribe("t1", sub1)
+			ps.Subscribe("t2", sub2)
+
+			ps.Publish("t1", "hi1")
+			ps.Publish("t2", "hi2")
+
+			ps.Subscribe("t2", sub1)
+			ps.Subscribe("t3", sub1)
+
+			ps.Publish("t2", "hi3")
+			ps.Publish("t3", "hi4")
+
+			ps.Shutdown()
+			sub1.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{
+					Topic: "t1",
+					Event: "hi1",
+				},
+				{
+					Topic: "t2",
+					Event: "hi3",
+				},
+				{
+					Topic: "t3",
+					Event: "hi4",
+				},
+			})
+			sub1.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1", "t2", "t3"})
+			sub2.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t2", Event: "hi2"}, {Topic: "t2", Event: "hi3"},
+			})
+			sub2.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t2"})
+		},
+		"Unsubscribe": func(ctx context.Context, t *testing.T, ps notifications.Publisher) {
+			sub1 := testutil.NewTestSubscriber(3)
+			sub2 := testutil.NewTestSubscriber(3)
+			ps.Subscribe("t1", sub1)
+			ps.Subscribe("t2", sub1)
+			ps.Subscribe("t3", sub1)
+			ps.Subscribe("t1", sub2)
+			ps.Subscribe("t3", sub2)
+			ps.Unsubscribe(sub1)
+			ps.Publish("t1", "hi")
+			ps.Shutdown()
+
+			sub2.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t1", Event: "hi"},
+			})
+			sub2.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1", "t3"})
+			sub1.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1", "t2", "t3"})
+			sub1.NoEventsReceived(t)
+		},
+		"Close": func(ctx context.Context, t *testing.T, ps notifications.Publisher) {
+			sub1 := testutil.NewTestSubscriber(3)
+			sub2 := testutil.NewTestSubscriber(3)
+			sub3 := testutil.NewTestSubscriber(3)
+			sub4 := testutil.NewTestSubscriber(3)
+			ps.Subscribe("t1", sub1)
+			ps.Subscribe("t1", sub2)
+			ps.Subscribe("t2", sub3)
+			ps.Subscribe("t3", sub4)
+
+			ps.Publish("t1", "hi")
+			ps.Publish("t2", "hello")
+			ps.Close("t1")
+			ps.Close("t2")
+
+			sub1.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t1", Event: "hi"},
+			})
+			sub1.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1"})
+			sub2.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t1", Event: "hi"},
+			})
+			sub2.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1"})
+			sub3.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t2", Event: "hello"},
+			})
+			sub3.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t2"})
+
+			// publishing on a topic after close should be like starting from scratch
+			// -- no one listening before should receive events
+			ps.Publish("t1", "hi")
+			ps.Publish("t2", "hi")
+
+			ps.Publish("t3", "welcome")
+			ps.Shutdown()
+
+			sub4.ExpectEvents(ctx, t, []testutil.DispatchedEvent{
+				{Topic: "t3", Event: "welcome"},
+			})
+			sub4.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t3"})
+			sub1.NoEventsReceived(t)
+			sub2.NoEventsReceived(t)
+			sub3.NoEventsReceived(t)
+		},
+		"Shutdown": func(ctx context.Context, t *testing.T, ps notifications.Publisher) {
+			sub1 := testutil.NewTestSubscriber(3)
+			sub2 := testutil.NewTestSubscriber(3)
+			ps.Subscribe("t1", sub1)
+			ps.Subscribe("t2", sub2)
+
+			ps.Shutdown()
+
+			// operations after shutdown have no effect
+			ps.Publish("t1", "hi")
+			ps.Publish("t2", "hello")
+			sub1.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t1"})
+			sub2.ExpectClosesAnyOrder(ctx, t, []notifications.Topic{"t2"})
+			time.Sleep(100 * time.Millisecond)
+			sub1.NoEventsReceived(t)
+			sub2.NoEventsReceived(t)
+		},
+	}
+	for testCase, testPublisher := range testCases {
+		t.Run(testCase, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+			defer cancel()
+			ps := notifications.NewPublisher()
+			testPublisher(ctx, t, ps)
+		})
+	}
+
+}

--- a/notifications/publisher.go
+++ b/notifications/publisher.go
@@ -1,0 +1,194 @@
+package notifications
+
+import "sync"
+
+type operation int
+
+const (
+	subscribe operation = iota
+	pub
+	unsubAll
+	closeTopic
+	shutdown
+)
+
+type cmd struct {
+	op     operation
+	topics []Topic
+	sub    Subscriber
+	msg    Event
+}
+
+// publisher is a publisher of events for
+type publisher struct {
+	lk      sync.RWMutex
+	closed  chan struct{}
+	cmdChan chan cmd
+}
+
+// NewPublisher returns a new message event publisher
+func NewPublisher() Publisher {
+	ps := &publisher{
+		cmdChan: make(chan cmd),
+		closed:  make(chan struct{}),
+	}
+	go ps.start()
+	return ps
+}
+
+// Publish publishes an event for the given message id
+func (ps *publisher) Publish(topic Topic, event Event) {
+	ps.lk.RLock()
+	defer ps.lk.RUnlock()
+	select {
+	case <-ps.closed:
+		return
+	default:
+	}
+
+	ps.cmdChan <- cmd{op: pub, topics: []Topic{topic}, msg: event}
+}
+
+// Shutdown shuts down all events and subscriptions
+func (ps *publisher) Shutdown() {
+	ps.lk.Lock()
+	defer ps.lk.Unlock()
+	select {
+	case <-ps.closed:
+		return
+	default:
+	}
+	close(ps.closed)
+	ps.cmdChan <- cmd{op: shutdown}
+}
+
+func (ps *publisher) Close(id Topic) {
+	ps.cmdChan <- cmd{op: closeTopic, topics: []Topic{id}}
+}
+
+func (ps *publisher) Subscribe(topic Topic, sub Subscriber) bool {
+	ps.lk.RLock()
+	defer ps.lk.RUnlock()
+
+	select {
+	case <-ps.closed:
+		return false
+	default:
+	}
+
+	ps.cmdChan <- cmd{op: subscribe, topics: []Topic{topic}, sub: sub}
+	return true
+}
+
+func (ps *publisher) Unsubscribe(sub Subscriber) bool {
+	ps.lk.RLock()
+	defer ps.lk.RUnlock()
+
+	select {
+	case <-ps.closed:
+		return false
+	default:
+	}
+
+	ps.cmdChan <- cmd{op: unsubAll, sub: sub}
+	return true
+}
+
+func (ps *publisher) start() {
+	reg := subscriberRegistry{
+		topics:    make(map[Topic]map[Subscriber]struct{}),
+		revTopics: make(map[Subscriber]map[Topic]struct{}),
+	}
+
+loop:
+	for cmd := range ps.cmdChan {
+		if cmd.topics == nil {
+			switch cmd.op {
+			case unsubAll:
+				reg.removeSubscriber(cmd.sub)
+
+			case shutdown:
+				break loop
+			}
+
+			continue loop
+		}
+
+		for _, topic := range cmd.topics {
+			switch cmd.op {
+			case subscribe:
+				reg.add(topic, cmd.sub)
+
+			case pub:
+				reg.send(topic, cmd.msg)
+
+			case closeTopic:
+				reg.removeTopic(topic)
+			}
+		}
+	}
+
+	for topic, subs := range reg.topics {
+		for sub := range subs {
+			reg.remove(topic, sub)
+		}
+	}
+}
+
+type subscriberRegistry struct {
+	topics    map[Topic]map[Subscriber]struct{}
+	revTopics map[Subscriber]map[Topic]struct{}
+}
+
+func (reg *subscriberRegistry) add(topic Topic, sub Subscriber) {
+	if reg.topics[topic] == nil {
+		reg.topics[topic] = make(map[Subscriber]struct{})
+	}
+	reg.topics[topic][sub] = struct{}{}
+
+	if reg.revTopics[sub] == nil {
+		reg.revTopics[sub] = make(map[Topic]struct{})
+	}
+	reg.revTopics[sub][topic] = struct{}{}
+}
+
+func (reg *subscriberRegistry) send(topic Topic, msg Event) {
+	for sub := range reg.topics[topic] {
+		sub.OnNext(topic, msg)
+	}
+}
+
+func (reg *subscriberRegistry) removeTopic(topic Topic) {
+	for sub := range reg.topics[topic] {
+		reg.remove(topic, sub)
+	}
+}
+
+func (reg *subscriberRegistry) removeSubscriber(sub Subscriber) {
+	for topic := range reg.revTopics[sub] {
+		reg.remove(topic, sub)
+	}
+}
+
+func (reg *subscriberRegistry) remove(topic Topic, sub Subscriber) {
+	if _, ok := reg.topics[topic]; !ok {
+		return
+	}
+
+	if _, ok := reg.topics[topic][sub]; !ok {
+		return
+	}
+
+	delete(reg.topics[topic], sub)
+	delete(reg.revTopics[sub], topic)
+
+	if len(reg.topics[topic]) == 0 {
+		delete(reg.topics, topic)
+	}
+
+	if len(reg.revTopics[sub]) == 0 {
+		delete(reg.revTopics, sub)
+	}
+
+	sub.OnClose(topic)
+}

--- a/notifications/types.go
+++ b/notifications/types.go
@@ -1,0 +1,55 @@
+package notifications
+
+// Topic is a topic that events appear on
+type Topic interface{}
+
+// Event is a publishable event
+type Event interface{}
+
+// Subscriber is a subscriber that can receive events
+type Subscriber interface {
+	OnNext(Topic, Event)
+	OnClose(Topic)
+}
+
+// MappableSubscriber is a subscriber that remaps events received to other topics
+// and events
+type MappableSubscriber interface {
+	Subscriber
+	Map(sourceID Topic, destinationID Topic)
+}
+
+// Subscribable is a stream that can be subscribed to
+type Subscribable interface {
+	Subscribe(topic Topic, sub Subscriber) bool
+	Unsubscribe(sub Subscriber) bool
+}
+
+// Publisher is an publisher of events that can be subscribed to
+type Publisher interface {
+	Close(Topic)
+	Publish(Topic, Event)
+	Shutdown()
+	Subscribable
+}
+
+// EventTransform if a fucntion transforms one kind of event to another
+type EventTransform func(Event) Event
+
+// Notifee is a mappable suscriber where you want events to appear
+// on this specified topic (used to call SubscribeOn to setup a remapping)
+type Notifee struct {
+	Topic      Topic
+	Subscriber MappableSubscriber
+}
+
+// SubscribeOn subscribes to the given subscribe on the given topic, but
+// maps to a differnt topic specified in a notifee which has a mappable
+// subscriber
+func SubscribeOn(p Subscribable, topic Topic, notifee Notifee) {
+	notifee.Subscriber.Map(topic, notifee.Topic)
+	p.Subscribe(topic, notifee.Subscriber)
+}
+
+// IdentityTransform sets up an event transform that makes no changes
+func IdentityTransform(ev Event) Event { return ev }

--- a/peermanager/peermessagemanager.go
+++ b/peermanager/peermessagemanager.go
@@ -7,13 +7,14 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 )
 
 // PeerQueue is a process that sends messages to a peer
 type PeerQueue interface {
 	PeerProcess
-	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest)
-	AddResponses(responses []gsmsg.GraphSyncResponse, blks []blocks.Block) <-chan struct{}
+	AddRequest(graphSyncRequest gsmsg.GraphSyncRequest, notifees ...notifications.Notifee)
+	AddResponses(responses []gsmsg.GraphSyncResponse, blks []blocks.Block, notifees ...notifications.Notifee)
 }
 
 // PeerQueueFactory provides a function that will create a PeerQueue.
@@ -34,14 +35,14 @@ func NewMessageManager(ctx context.Context, createPeerQueue PeerQueueFactory) *P
 }
 
 // SendRequest sends the given GraphSyncRequest to the given peer
-func (pmm *PeerMessageManager) SendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
+func (pmm *PeerMessageManager) SendRequest(p peer.ID, request gsmsg.GraphSyncRequest, notifees ...notifications.Notifee) {
 	pq := pmm.GetProcess(p).(PeerQueue)
-	pq.AddRequest(request)
+	pq.AddRequest(request, notifees...)
 }
 
 // SendResponse sends the given GraphSyncResponses and blocks to the given peer.
 func (pmm *PeerMessageManager) SendResponse(p peer.ID,
-	responses []gsmsg.GraphSyncResponse, blks []blocks.Block) <-chan struct{} {
+	responses []gsmsg.GraphSyncResponse, blks []blocks.Block, notifees ...notifications.Notifee) {
 	pq := pmm.GetProcess(p).(PeerQueue)
-	return pq.AddResponses(responses, blks)
+	pq.AddResponses(responses, blks, notifees...)
 }

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ipfs/go-graphsync"
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/testutil"
 )
 
@@ -30,14 +31,13 @@ type fakePeer struct {
 func (fp *fakePeer) Startup()  {}
 func (fp *fakePeer) Shutdown() {}
 
-func (fp *fakePeer) AddRequest(graphSyncRequest gsmsg.GraphSyncRequest) {
+func (fp *fakePeer) AddRequest(graphSyncRequest gsmsg.GraphSyncRequest, notifees ...notifications.Notifee) {
 	message := gsmsg.New()
 	message.AddRequest(graphSyncRequest)
 	fp.messagesSent <- messageSent{fp.p, message}
 }
 
-func (fp *fakePeer) AddResponses([]gsmsg.GraphSyncResponse, []blocks.Block) <-chan struct{} {
-	return nil
+func (fp *fakePeer) AddResponses([]gsmsg.GraphSyncResponse, []blocks.Block, ...notifications.Notifee) {
 }
 
 func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
 )
@@ -27,7 +28,7 @@ type AsyncLoadFn func(graphsync.RequestID, ipld.Link) <-chan types.AsyncLoadResu
 // ExecutionEnv are request parameters that last between requests
 type ExecutionEnv struct {
 	Ctx              context.Context
-	SendRequest      func(peer.ID, gsmsg.GraphSyncRequest)
+	SendRequest      func(peer.ID, gsmsg.GraphSyncRequest, ...notifications.Notifee)
 	RunBlockHooks    func(p peer.ID, response graphsync.ResponseData, blk graphsync.BlockData) error
 	TerminateRequest func(graphsync.RequestID)
 	WaitForMessages  func(ctx context.Context, resumeMessages chan graphsync.ExtensionData) ([]graphsync.ExtensionData, error)

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/requestmanager/executor"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/testloader"
@@ -377,7 +378,7 @@ func (ree *requestExecutionEnv) waitForResume() ([]graphsync.ExtensionData, erro
 	return extensions, nil
 }
 
-func (ree *requestExecutionEnv) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
+func (ree *requestExecutionEnv) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest, notifees ...notifications.Notifee) {
 	ree.requestsSent = append(ree.requestsSent, requestSent{p, request})
 	if ree.currentWaitForResumeResult < len(ree.loaderRanges) && !request.IsCancel() {
 		ree.configureLoader(ree.p, ree.request.ID(), ree.tbc, ree.fal, ree.loaderRanges[ree.currentWaitForResumeResult])

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -19,6 +19,7 @@ import (
 	ipldutil "github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/requestmanager/executor"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
@@ -44,7 +45,7 @@ type inProgressRequestStatus struct {
 
 // PeerHandler is an interface that can send requests to peers
 type PeerHandler interface {
-	SendRequest(p peer.ID, graphSyncRequest gsmsg.GraphSyncRequest)
+	SendRequest(p peer.ID, graphSyncRequest gsmsg.GraphSyncRequest, notifees ...notifications.Notifee)
 }
 
 // AsyncLoader is an interface for loading links asynchronously, returning

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ipfs/go-graphsync/dedupkey"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/testloader"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
@@ -34,7 +35,7 @@ type fakePeerHandler struct {
 }
 
 func (fph *fakePeerHandler) SendRequest(p peer.ID,
-	graphSyncRequest gsmsg.GraphSyncRequest) {
+	graphSyncRequest gsmsg.GraphSyncRequest, notifees ...notifications.Notifee) {
 	fph.requestRecordChan <- requestRecord{
 		gsr: graphSyncRequest,
 		p:   p,

--- a/responsemanager/hooks/listeners.go
+++ b/responsemanager/hooks/listeners.go
@@ -13,15 +13,15 @@ type CompletedResponseListeners struct {
 }
 
 type internalCompletedResponseEvent struct {
-	p         peer.ID
-	requestID graphsync.RequestID
-	status    graphsync.ResponseStatusCode
+	p       peer.ID
+	request graphsync.RequestData
+	status  graphsync.ResponseStatusCode
 }
 
 func completedResponseDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie := event.(internalCompletedResponseEvent)
 	listener := subscriberFn.(graphsync.OnResponseCompletedListener)
-	listener(ie.p, ie.requestID, ie.status)
+	listener(ie.p, ie.request, ie.status)
 	return nil
 }
 
@@ -36,8 +36,8 @@ func (crl *CompletedResponseListeners) Register(listener graphsync.OnResponseCom
 }
 
 // NotifyCompletedListeners runs notifies all completed listeners that a response has completed
-func (crl *CompletedResponseListeners) NotifyCompletedListeners(p peer.ID, requestID graphsync.RequestID, status graphsync.ResponseStatusCode) {
-	_ = crl.pubSub.Publish(internalCompletedResponseEvent{p, requestID, status})
+func (crl *CompletedResponseListeners) NotifyCompletedListeners(p peer.ID, request graphsync.RequestData, status graphsync.ResponseStatusCode) {
+	_ = crl.pubSub.Publish(internalCompletedResponseEvent{p, request, status})
 }
 
 // RequestorCancelledListeners is a set of listeners for when requestors cancel
@@ -46,14 +46,14 @@ type RequestorCancelledListeners struct {
 }
 
 type internalRequestorCancelledEvent struct {
-	p         peer.ID
-	requestID graphsync.RequestID
+	p       peer.ID
+	request graphsync.RequestData
 }
 
 func requestorCancelledDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie := event.(internalRequestorCancelledEvent)
 	listener := subscriberFn.(graphsync.OnRequestorCancelledListener)
-	listener(ie.p, ie.requestID)
+	listener(ie.p, ie.request)
 	return nil
 }
 
@@ -68,8 +68,8 @@ func (rcl *RequestorCancelledListeners) Register(listener graphsync.OnRequestorC
 }
 
 // NotifyCancelledListeners notifies all listeners that a requestor cancelled a response
-func (rcl *RequestorCancelledListeners) NotifyCancelledListeners(p peer.ID, requestID graphsync.RequestID) {
-	_ = rcl.pubSub.Publish(internalRequestorCancelledEvent{p, requestID})
+func (rcl *RequestorCancelledListeners) NotifyCancelledListeners(p peer.ID, request graphsync.RequestData) {
+	_ = rcl.pubSub.Publish(internalRequestorCancelledEvent{p, request})
 }
 
 // BlockSentListeners is a set of listeners for when requestors cancel
@@ -78,15 +78,15 @@ type BlockSentListeners struct {
 }
 
 type internalBlockSentEvent struct {
-	p         peer.ID
-	requestID graphsync.RequestID
-	block     graphsync.BlockData
+	p       peer.ID
+	request graphsync.RequestData
+	block   graphsync.BlockData
 }
 
 func blockSentDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie := event.(internalBlockSentEvent)
 	listener := subscriberFn.(graphsync.OnBlockSentListener)
-	listener(ie.p, ie.requestID, ie.block)
+	listener(ie.p, ie.request, ie.block)
 	return nil
 }
 
@@ -101,8 +101,8 @@ func (bsl *BlockSentListeners) Register(listener graphsync.OnBlockSentListener) 
 }
 
 // NotifyBlockSentListeners notifies all listeners that a requestor cancelled a response
-func (bsl *BlockSentListeners) NotifyBlockSentListeners(p peer.ID, requestID graphsync.RequestID, block graphsync.BlockData) {
-	_ = bsl.pubSub.Publish(internalBlockSentEvent{p, requestID, block})
+func (bsl *BlockSentListeners) NotifyBlockSentListeners(p peer.ID, request graphsync.RequestData, block graphsync.BlockData) {
+	_ = bsl.pubSub.Publish(internalBlockSentEvent{p, request, block})
 }
 
 // NetworkErrorListeners is a set of listeners for when requestors cancel
@@ -111,15 +111,15 @@ type NetworkErrorListeners struct {
 }
 
 type internalNetworkErrorEvent struct {
-	p         peer.ID
-	requestID graphsync.RequestID
-	err       error
+	p       peer.ID
+	request graphsync.RequestData
+	err     error
 }
 
 func networkErrorDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie := event.(internalNetworkErrorEvent)
 	listener := subscriberFn.(graphsync.OnNetworkErrorListener)
-	listener(ie.p, ie.requestID, ie.err)
+	listener(ie.p, ie.request, ie.err)
 	return nil
 }
 
@@ -134,6 +134,6 @@ func (nel *NetworkErrorListeners) Register(listener graphsync.OnNetworkErrorList
 }
 
 // NotifyNetworkErrorListeners notifies all listeners that a requestor cancelled a response
-func (nel *NetworkErrorListeners) NotifyNetworkErrorListeners(p peer.ID, requestID graphsync.RequestID, err error) {
-	_ = nel.pubSub.Publish(internalNetworkErrorEvent{p, requestID, err})
+func (nel *NetworkErrorListeners) NotifyNetworkErrorListeners(p peer.ID, request graphsync.RequestData, err error) {
+	_ = nel.pubSub.Publish(internalNetworkErrorEvent{p, request, err})
 }

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -43,12 +43,6 @@ type Event struct {
 	Err  error
 }
 
-// Topic is a topic for the peer response sender
-type Topic struct {
-	P     peer.ID
-	Index responsebuilder.Index
-}
-
 // PeerMessageHandler is an interface that can send a response for a given peer across
 // the network.
 type PeerMessageHandler interface {
@@ -71,8 +65,8 @@ type peerResponseSender struct {
 	dedupKeys          map[graphsync.RequestID]string
 	responseBuildersLk sync.RWMutex
 	responseBuilders   []*responsebuilder.ResponseBuilder
-	nextBuilderTopic   responsebuilder.Index
-	queuedMessages     chan responsebuilder.Index
+	nextBuilderTopic   responsebuilder.Topic
+	queuedMessages     chan responsebuilder.Topic
 	subscriber         notifications.MappableSubscriber
 	publisher          notifications.Publisher
 }
@@ -126,7 +120,7 @@ func NewResponseSender(ctx context.Context, p peer.ID, peerHandler PeerMessageHa
 		linkTracker:    linktracker.New(),
 		dedupKeys:      make(map[graphsync.RequestID]string),
 		altTrackers:    make(map[string]*linktracker.LinkTracker),
-		queuedMessages: make(chan responsebuilder.Index, 1),
+		queuedMessages: make(chan responsebuilder.Topic, 1),
 		publisher:      notifications.NewPublisher(),
 	}
 	prs.subscriber = notifications.NewMappableSubscriber(&subscriber{prs}, notifications.IdentityTransform)
@@ -399,7 +393,7 @@ func (prs *peerResponseSender) buildResponse(blkSize uint64, buildResponseFn fun
 	responseBuilder := prs.responseBuilders[len(prs.responseBuilders)-1]
 	buildResponseFn(responseBuilder)
 	for _, notifee := range notifees {
-		notifications.SubscribeOn(prs.publisher, Topic{P: prs.p, Index: responseBuilder.Index()}, notifee)
+		notifications.SubscribeOn(prs.publisher, responseBuilder.Topic(), notifee)
 	}
 	return !responseBuilder.Empty()
 }
@@ -448,16 +442,16 @@ func (prs *peerResponseSender) sendResponseMessages() {
 		}
 
 		prs.peerHandler.SendResponse(prs.p, responses, blks, notifications.Notifee{
-			Topic:      Topic{P: prs.p, Index: builder.Index()},
+			Topic:      builder.Topic(),
 			Subscriber: prs.subscriber,
 		})
 
 		// wait for message to be processed
-		prs.waitForMessageQueud(builder.Index())
+		prs.waitForMessageQueud(builder.Topic())
 	}
 }
 
-func (prs *peerResponseSender) waitForMessageQueud(topic responsebuilder.Index) {
+func (prs *peerResponseSender) waitForMessageQueud(topic responsebuilder.Topic) {
 	for {
 		select {
 		case <-prs.ctx.Done():
@@ -475,7 +469,7 @@ type subscriber struct {
 }
 
 func (s *subscriber) OnNext(topic notifications.Topic, event notifications.Event) {
-	builderTopic, ok := topic.(Topic)
+	builderTopic, ok := topic.(responsebuilder.Topic)
 	if !ok {
 		return
 	}
@@ -490,7 +484,7 @@ func (s *subscriber) OnNext(topic notifications.Topic, event notifications.Event
 		s.prs.publisher.Publish(builderTopic, Event{Name: Error, Err: fmt.Errorf("error sending message: %w", msgEvent.Err)})
 	case messagequeue.Queued:
 		select {
-		case s.prs.queuedMessages <- builderTopic.Index:
+		case s.prs.queuedMessages <- builderTopic:
 		case <-s.prs.ctx.Done():
 		}
 	}

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ipfs/go-graphsync/dedupkey"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
 	"github.com/ipfs/go-graphsync/responsemanager/runtraversal"
@@ -28,7 +29,6 @@ type queryExecutor struct {
 	requestHooks       RequestHooks
 	blockHooks         BlockHooks
 	updateHooks        UpdateHooks
-	completedListeners CompletedListeners
 	cancelledListeners CancelledListeners
 	peerManager        PeerManager
 	loader             ipld.Loader
@@ -37,6 +37,7 @@ type queryExecutor struct {
 	ctx                context.Context
 	workSignal         chan struct{}
 	ticker             *time.Ticker
+	sub                notifications.MappableSubscriber
 }
 
 func (qe *queryExecutor) processQueriesWorker() {
@@ -73,12 +74,9 @@ func (qe *queryExecutor) processQueriesWorker() {
 				continue
 			}
 			status, err := qe.executeTask(key, taskData)
-			_, isPaused := err.(hooks.ErrPaused)
 			isCancelled := err != nil && isContextErr(err)
 			if isCancelled {
-				qe.cancelledListeners.NotifyCancelledListeners(key.p, taskData.request)
-			} else if !isPaused {
-				qe.completedListeners.NotifyCompletedListeners(key.p, taskData.request, status)
+				qe.cancelledListeners.NotifyCancelledListeners(key.p, taskData.request.ID())
 			}
 			select {
 			case qe.messages <- &finishTaskRequest{key, status, err}:
@@ -97,7 +95,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 	traverser := taskData.traverser
 	if loader == nil || traverser == nil {
 		var isPaused bool
-		loader, traverser, isPaused, err = qe.prepareQuery(taskData.ctx, key.p, taskData.request)
+		loader, traverser, isPaused, err = qe.prepareQuery(taskData.ctx, key.p, taskData.request, taskData.signals)
 		if err != nil {
 			return graphsync.RequestFailedUnknown, err
 		}
@@ -115,17 +113,19 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 
 func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	p peer.ID,
-	request gsmsg.GraphSyncRequest) (ipld.Loader, ipldutil.Traverser, bool, error) {
+	request gsmsg.GraphSyncRequest, signals signals) (ipld.Loader, ipldutil.Traverser, bool, error) {
 	result := qe.requestHooks.ProcessRequestHooks(p, request)
 	peerResponseSender := qe.peerManager.SenderForPeer(p)
 	var transactionError error
 	var isPaused bool
+	failNotifee := notifications.Notifee{Topic: statusNotification{p, request.ID(), graphsync.RequestFailedUnknown}, Subscriber: qe.sub}
 	err := peerResponseSender.Transaction(request.ID(), func(transaction peerresponsemanager.PeerResponseTransactionSender) error {
 		for _, extension := range result.Extensions {
 			transaction.SendExtensionData(extension)
 		}
 		if result.Err != nil || !result.IsValidated {
 			transaction.FinishWithError(graphsync.RequestFailedUnknown)
+			transaction.AddNotifee(failNotifee)
 			transactionError = errors.New("request not valid")
 		} else if result.IsPaused {
 			transaction.PauseRequest()
@@ -139,10 +139,10 @@ func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	if transactionError != nil {
 		return nil, nil, false, transactionError
 	}
-	if err := qe.processDedupByKey(request, peerResponseSender); err != nil {
+	if err := qe.processDedupByKey(request, peerResponseSender, failNotifee); err != nil {
 		return nil, nil, false, err
 	}
-	if err := qe.processDoNoSendCids(request, peerResponseSender); err != nil {
+	if err := qe.processDoNoSendCids(request, peerResponseSender, failNotifee); err != nil {
 		return nil, nil, false, err
 	}
 	rootLink := cidlink.Link{Cid: request.Root()}
@@ -158,28 +158,28 @@ func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	return loader, traverser, isPaused, nil
 }
 
-func (qe *queryExecutor) processDedupByKey(request gsmsg.GraphSyncRequest, peerResponseSender peerresponsemanager.PeerResponseSender) error {
+func (qe *queryExecutor) processDedupByKey(request gsmsg.GraphSyncRequest, peerResponseSender peerresponsemanager.PeerResponseSender, failNotifee notifications.Notifee) error {
 	dedupData, has := request.Extension(graphsync.ExtensionDeDupByKey)
 	if !has {
 		return nil
 	}
 	key, err := dedupkey.DecodeDedupKey(dedupData)
 	if err != nil {
-		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
+		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown, failNotifee)
 		return err
 	}
 	peerResponseSender.DedupKey(request.ID(), key)
 	return nil
 }
 
-func (qe *queryExecutor) processDoNoSendCids(request gsmsg.GraphSyncRequest, peerResponseSender peerresponsemanager.PeerResponseSender) error {
+func (qe *queryExecutor) processDoNoSendCids(request gsmsg.GraphSyncRequest, peerResponseSender peerresponsemanager.PeerResponseSender, failNotifee notifications.Notifee) error {
 	doNotSendCidsData, has := request.Extension(graphsync.ExtensionDoNotSendCIDs)
 	if !has {
 		return nil
 	}
 	cidSet, err := cidset.DecodeCidSet(doNotSendCidsData)
 	if err != nil {
-		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
+		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown, failNotifee)
 		return err
 	}
 	links := make([]ipld.Link, 0, cidSet.Len())
@@ -210,6 +210,7 @@ func (qe *queryExecutor) executeQuery(
 				return nil
 			}
 			blockData := transaction.SendResponse(link, data)
+			transaction.AddNotifee(notifications.Notifee{Topic: blockSentNotification{p, request.ID(), blockData}, Subscriber: qe.sub})
 			if blockData.BlockSize() > 0 {
 				result := qe.blockHooks.ProcessBlockHooks(p, request, blockData)
 				for _, extension := range result.Extensions {
@@ -226,23 +227,36 @@ func (qe *queryExecutor) executeQuery(
 		})
 		return err
 	})
-	if err != nil {
-		_, isPaused := err.(hooks.ErrPaused)
-		if isPaused {
-			return graphsync.RequestPaused, err
+	var code graphsync.ResponseStatusCode
+	_ = peerResponseSender.Transaction(request.ID(), func(peerResponseSender peerresponsemanager.PeerResponseTransactionSender) error {
+		if err != nil {
+			_, isPaused := err.(hooks.ErrPaused)
+			if isPaused {
+				code = graphsync.RequestPaused
+				return nil
+			}
+			if isContextErr(err) {
+				peerResponseSender.FinishWithCancel()
+				code = graphsync.RequestCancelled
+				return nil
+			}
+			if err == errNetworkError {
+				code = graphsync.RequestFailedUnknown
+				return nil
+			}
+			if err == errCancelledByCommand {
+				code = graphsync.RequestCancelled
+			} else {
+				code = graphsync.RequestFailedUnknown
+			}
+			peerResponseSender.FinishWithError(graphsync.RequestCancelled)
+		} else {
+			code = peerResponseSender.FinishRequest()
 		}
-		if isContextErr(err) {
-			peerResponseSender.FinishWithCancel(request.ID())
-			return graphsync.RequestCancelled, err
-		}
-		if err == errCancelledByCommand {
-			peerResponseSender.FinishWithError(request.ID(), graphsync.RequestCancelled)
-			return graphsync.RequestCancelled, err
-		}
-		peerResponseSender.FinishWithError(request.ID(), graphsync.RequestFailedUnknown)
-		return graphsync.RequestFailedUnknown, err
-	}
-	return peerResponseSender.FinishRequest(request.ID()), nil
+		peerResponseSender.AddNotifee(notifications.Notifee{Topic: statusNotification{p, request.ID(), code}, Subscriber: qe.sub})
+		return nil
+	})
+	return code, err
 }
 
 func (qe *queryExecutor) checkForUpdates(
@@ -253,14 +267,11 @@ func (qe *queryExecutor) checkForUpdates(
 	peerResponseSender peerresponsemanager.PeerResponseTransactionSender) error {
 	for {
 		select {
-		case selfCancelled := <-signals.stopSignal:
-			if selfCancelled {
-				return errCancelledByCommand
-			}
-			return ipldutil.ContextCancelError{}
 		case <-signals.pauseSignal:
 			peerResponseSender.PauseRequest()
 			return hooks.ErrPaused{}
+		case err := <-signals.errSignal:
+			return err
 		case <-signals.updateSignal:
 			select {
 			case qe.messages <- &responseUpdateRequest{responseKey{p, request.ID()}, updateChan}:

--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -14,7 +14,7 @@ import (
 // requests for a given peer and then generates the corresponding
 // GraphSync message components once responses are ready to send.
 type ResponseBuilder struct {
-	topic              Topic
+	topic              Index
 	outgoingBlocks     []blocks.Block
 	blkSize            uint64
 	completedResponses map[graphsync.RequestID]graphsync.ResponseStatusCode
@@ -22,11 +22,11 @@ type ResponseBuilder struct {
 	extensions         map[graphsync.RequestID][]graphsync.ExtensionData
 }
 
-// Topic is an identifier for notifications about this response builder
-type Topic uint64
+// Index is an identifier for notifications about this response builder
+type Index uint64
 
 // New generates a new ResponseBuilder.
-func New(topic Topic) *ResponseBuilder {
+func New(topic Index) *ResponseBuilder {
 	return &ResponseBuilder{
 		topic:              topic,
 		completedResponses: make(map[graphsync.RequestID]graphsync.ResponseStatusCode),
@@ -92,8 +92,8 @@ func (rb *ResponseBuilder) Build() ([]gsmsg.GraphSyncResponse, []blocks.Block, e
 	return responses, rb.outgoingBlocks, nil
 }
 
-// Topic returns the identifier for notifications sent about this response builder
-func (rb *ResponseBuilder) Topic() Topic {
+// Index returns the identifier for notifications sent about this response builder
+func (rb *ResponseBuilder) Index() Index {
 	return rb.topic
 }
 

--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -14,6 +14,7 @@ import (
 // requests for a given peer and then generates the corresponding
 // GraphSync message components once responses are ready to send.
 type ResponseBuilder struct {
+	topic              Topic
 	outgoingBlocks     []blocks.Block
 	blkSize            uint64
 	completedResponses map[graphsync.RequestID]graphsync.ResponseStatusCode
@@ -21,9 +22,13 @@ type ResponseBuilder struct {
 	extensions         map[graphsync.RequestID][]graphsync.ExtensionData
 }
 
+// Topic is an identifier for notifications about this response builder
+type Topic uint64
+
 // New generates a new ResponseBuilder.
-func New() *ResponseBuilder {
+func New(topic Topic) *ResponseBuilder {
 	return &ResponseBuilder{
+		topic:              topic,
 		completedResponses: make(map[graphsync.RequestID]graphsync.ResponseStatusCode),
 		outgoingResponses:  make(map[graphsync.RequestID]metadata.Metadata),
 		extensions:         make(map[graphsync.RequestID][]graphsync.ExtensionData),
@@ -85,6 +90,11 @@ func (rb *ResponseBuilder) Build() ([]gsmsg.GraphSyncResponse, []blocks.Block, e
 		responses = append(responses, gsmsg.NewResponse(requestID, responseCode(status, isComplete), rb.extensions[requestID]...))
 	}
 	return responses, rb.outgoingBlocks, nil
+}
+
+// Topic returns the identifier for notifications sent about this response builder
+func (rb *ResponseBuilder) Topic() Topic {
+	return rb.topic
 }
 
 func responseCode(status graphsync.ResponseStatusCode, isComplete bool) graphsync.ResponseStatusCode {

--- a/responsemanager/responsebuilder/responsebuilder.go
+++ b/responsemanager/responsebuilder/responsebuilder.go
@@ -14,7 +14,7 @@ import (
 // requests for a given peer and then generates the corresponding
 // GraphSync message components once responses are ready to send.
 type ResponseBuilder struct {
-	topic              Index
+	topic              Topic
 	outgoingBlocks     []blocks.Block
 	blkSize            uint64
 	completedResponses map[graphsync.RequestID]graphsync.ResponseStatusCode
@@ -22,11 +22,11 @@ type ResponseBuilder struct {
 	extensions         map[graphsync.RequestID][]graphsync.ExtensionData
 }
 
-// Index is an identifier for notifications about this response builder
-type Index uint64
+// Topic is an identifier for notifications about this response builder
+type Topic uint64
 
 // New generates a new ResponseBuilder.
-func New(topic Index) *ResponseBuilder {
+func New(topic Topic) *ResponseBuilder {
 	return &ResponseBuilder{
 		topic:              topic,
 		completedResponses: make(map[graphsync.RequestID]graphsync.ResponseStatusCode),
@@ -92,8 +92,8 @@ func (rb *ResponseBuilder) Build() ([]gsmsg.GraphSyncResponse, []blocks.Block, e
 	return responses, rb.outgoingBlocks, nil
 }
 
-// Index returns the identifier for notifications sent about this response builder
-func (rb *ResponseBuilder) Index() Index {
+// Topic returns the identifier for notifications sent about this response builder
+func (rb *ResponseBuilder) Topic() Topic {
 	return rb.topic
 }
 

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMessageBuilding(t *testing.T) {
-	rb := New(Topic(0))
+	rb := New(Index(0))
 	blocks := testutil.GenerateBlocksOfSize(3, 100)
 	links := make([]ipld.Link, 0, len(blocks))
 	for _, block := range blocks {

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMessageBuilding(t *testing.T) {
-	rb := New(Index(0))
+	rb := New(Topic(0))
 	blocks := testutil.GenerateBlocksOfSize(3, 100)
 	links := make([]ipld.Link, 0, len(blocks))
 	for _, block := range blocks {

--- a/responsemanager/responsebuilder/responsebuilder_test.go
+++ b/responsemanager/responsebuilder/responsebuilder_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestMessageBuilding(t *testing.T) {
-	rb := New()
+	rb := New(Topic(0))
 	blocks := testutil.GenerateBlocksOfSize(3, 100)
 	links := make([]ipld.Link, 0, len(blocks))
 	for _, block := range blocks {

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/dedupkey"
 	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
 	"github.com/ipfs/go-graphsync/responsemanager/persistenceoptions"
@@ -150,6 +151,7 @@ func (fprs *fakePeerResponseSender) SendResponse(
 	requestID graphsync.RequestID,
 	link ipld.Link,
 	data []byte,
+	_ ...notifications.Notifee,
 ) graphsync.BlockData {
 	fprs.sentResponses <- sentResponse{requestID, link, data}
 	return fakeBlkData{link, uint64(len(data))}
@@ -158,20 +160,21 @@ func (fprs *fakePeerResponseSender) SendResponse(
 func (fprs *fakePeerResponseSender) SendExtensionData(
 	requestID graphsync.RequestID,
 	extension graphsync.ExtensionData,
+	_ ...notifications.Notifee,
 ) {
 	fprs.sentExtensions <- sentExtension{requestID, extension}
 }
 
-func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID) graphsync.ResponseStatusCode {
+func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID, _ ...notifications.Notifee) graphsync.ResponseStatusCode {
 	fprs.lastCompletedRequest <- completedRequest{requestID, graphsync.RequestCompletedFull}
 	return graphsync.RequestCompletedFull
 }
 
-func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode) {
+func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode, _ ...notifications.Notifee) {
 	fprs.lastCompletedRequest <- completedRequest{requestID, status}
 }
 
-func (fprs *fakePeerResponseSender) PauseRequest(requestID graphsync.RequestID) {
+func (fprs *fakePeerResponseSender) PauseRequest(requestID graphsync.RequestID, _ ...notifications.Notifee) {
 	fprs.pausedRequests <- pausedRequest{requestID}
 }
 
@@ -179,7 +182,7 @@ func (fprs *fakePeerResponseSender) FinishWithCancel(requestID graphsync.Request
 	fprs.cancelledRequests <- cancelledRequest{requestID}
 }
 
-func (fprs *fakePeerResponseSender) Transaction(requestID graphsync.RequestID, transaction peerresponsemanager.Transaction) error {
+func (fprs *fakePeerResponseSender) Transaction(requestID graphsync.RequestID, transaction peerresponsemanager.Transaction, _ ...notifications.Notifee) error {
 	fprts := &fakePeerResponseTransactionSender{requestID, fprs}
 	return transaction(fprts)
 }

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
@@ -27,6 +28,630 @@ import (
 	"github.com/ipfs/go-graphsync/selectorvalidator"
 	"github.com/ipfs/go-graphsync/testutil"
 )
+
+func TestIncomingQuery(t *testing.T) {
+	td := newTestData(t)
+	defer td.cancel()
+	blks := td.blockChain.AllBlocks()
+
+	responseManager := td.newResponseManager()
+	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
+	responseManager.Startup()
+
+	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+	testutil.AssertDoesReceive(td.ctx, t, td.completedRequestChan, "Should have completed request but didn't")
+	for i := 0; i < len(blks); i++ {
+		td.assertSendBlock()
+	}
+}
+
+func TestCancellationQueryInProgress(t *testing.T) {
+	td := newTestData(t)
+	defer td.cancel()
+	responseManager := td.newResponseManager()
+	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
+	cancelledListenerCalled := make(chan struct{}, 1)
+	td.cancelledListeners.Register(func(p peer.ID, request graphsync.RequestID) {
+		cancelledListenerCalled <- struct{}{}
+	})
+	responseManager.Startup()
+	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+
+	// read one block
+	td.assertSendBlock()
+
+	// send a cancellation
+	cancelRequests := []gsmsg.GraphSyncRequest{
+		gsmsg.CancelRequest(td.requestID),
+	}
+	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
+	responseManager.synchronize()
+
+	testutil.AssertDoesReceive(td.ctx, t, cancelledListenerCalled, "should call cancelled listener")
+
+	td.assertCancelledRequest()
+}
+
+func TestCancellationViaCommand(t *testing.T) {
+	td := newTestData(t)
+	defer td.cancel()
+	responseManager := td.newResponseManager()
+	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
+	responseManager.Startup()
+	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+
+	// read one block
+	td.assertSendBlock()
+
+	// send a cancellation
+	err := responseManager.CancelResponse(td.p, td.requestID)
+	require.NoError(t, err)
+
+	td.assertCompleteRequestWithFailure()
+}
+
+func TestEarlyCancellation(t *testing.T) {
+	td := newTestData(t)
+	defer td.cancel()
+	td.queryQueue.popWait.Add(1)
+	responseManager := td.newResponseManager()
+	responseManager.Startup()
+	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+
+	// send a cancellation
+	cancelRequests := []gsmsg.GraphSyncRequest{
+		gsmsg.CancelRequest(td.requestID),
+	}
+	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
+
+	responseManager.synchronize()
+
+	// unblock popping from queue
+	td.queryQueue.popWait.Done()
+
+	td.assertNoResponses()
+}
+
+func TestValidationAndExtensions(t *testing.T) {
+	t.Run("on its own, should fail validation", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithFailure()
+	})
+
+	t.Run("if non validating hook succeeds, does not pass validation", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.SendExtensionData(td.extensionResponse)
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithFailure()
+		td.assertReceiveExtensionResponse()
+	})
+
+	t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+			hookActions.SendExtensionData(td.extensionResponse)
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertReceiveExtensionResponse()
+	})
+
+	t.Run("if any hook fails, should fail", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.SendExtensionData(td.extensionResponse)
+			hookActions.TerminateWithError(errors.New("everything went to crap"))
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithFailure()
+		td.assertReceiveExtensionResponse()
+	})
+
+	t.Run("hooks can be unregistered", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		unregister := td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+			hookActions.SendExtensionData(td.extensionResponse)
+		})
+
+		// hook validates request
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertReceiveExtensionResponse()
+
+		// unregister
+		unregister()
+
+		// now same request should fail
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithFailure()
+	})
+
+	t.Run("hooks can alter the loader", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.alternateLoaderResponseManager()
+		responseManager.Startup()
+		// add validating hook -- so the request SHOULD succeed
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+
+		// request fails with base loader reading from block store that's missing data
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithFailure()
+
+		err := td.peristenceOptions.Register("chainstore", td.loader)
+		require.NoError(t, err)
+		// register hook to use different loader
+		_ = td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			if _, found := requestData.Extension(td.extensionName); found {
+				hookActions.UsePersistenceOption("chainstore")
+				hookActions.SendExtensionData(td.extensionResponse)
+			}
+		})
+		// hook uses different loader that should make request succeed
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertReceiveExtensionResponse()
+	})
+
+	t.Run("hooks can alter the node builder chooser", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+
+		customChooserCallCount := 0
+		customChooser := func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
+			customChooserCallCount++
+			return basicnode.Prototype.Any, nil
+		}
+
+		// add validating hook -- so the request SHOULD succeed
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+
+		// with default chooser, customer chooser not called
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithSuccess()
+		require.Equal(t, 0, customChooserCallCount)
+
+		// register hook to use custom chooser
+		_ = td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			if _, found := requestData.Extension(td.extensionName); found {
+				hookActions.UseLinkTargetNodePrototypeChooser(customChooser)
+				hookActions.SendExtensionData(td.extensionResponse)
+			}
+		})
+
+		// verify now that request succeeds and uses custom chooser
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertReceiveExtensionResponse()
+		require.Equal(t, 5, customChooserCallCount)
+	})
+
+	t.Run("do-not-send-cids extension", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		set := cid.NewSet()
+		blks := td.blockChain.Blocks(0, 5)
+		for _, blk := range blks {
+			set.Add(blk.Cid())
+		}
+		data, err := cidset.EncodeCidSet(set)
+		require.NoError(t, err)
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(td.requestID, td.blockChain.TipLink.(cidlink.Link).Cid, td.blockChain.Selector(), graphsync.Priority(0),
+				graphsync.ExtensionData{
+					Name: graphsync.ExtensionDoNotSendCIDs,
+					Data: data,
+				}),
+		}
+		responseManager.ProcessRequests(td.ctx, td.p, requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertIgnoredCids(set)
+	})
+	t.Run("dedup-by-key extension", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		data, err := dedupkey.EncodeDedupKey("applesauce")
+		require.NoError(t, err)
+		requests := []gsmsg.GraphSyncRequest{
+			gsmsg.NewRequest(td.requestID, td.blockChain.TipLink.(cidlink.Link).Cid, td.blockChain.Selector(), graphsync.Priority(0),
+				graphsync.ExtensionData{
+					Name: graphsync.ExtensionDeDupByKey,
+					Data: data,
+				}),
+		}
+		responseManager.ProcessRequests(td.ctx, td.p, requests)
+		td.assertCompleteRequestWithSuccess()
+		td.assertDedupKey("applesauce")
+	})
+	t.Run("test pause/resume", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+			hookActions.PauseResponse()
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertPausedRequest()
+		td.assertRequestDoesNotCompleteWhilePaused()
+		testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
+		err := responseManager.UnpauseResponse(td.p, td.requestID)
+		require.NoError(t, err)
+		td.assertCompleteRequestWithSuccess()
+	})
+	t.Run("test block hook processing", func(t *testing.T) {
+		t.Run("can send extension data", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+			})
+			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+				hookActions.SendExtensionData(td.extensionResponse)
+			})
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertCompleteRequestWithSuccess()
+			for i := 0; i < td.blockChainLength; i++ {
+				td.assertReceiveExtensionResponse()
+			}
+		})
+
+		t.Run("can send errors", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+			})
+			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+				hookActions.TerminateWithError(errors.New("failed"))
+			})
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertCompleteRequestWithFailure()
+		})
+
+		t.Run("can pause/unpause", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+			})
+			blkIndex := 0
+			blockCount := 3
+			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+				blkIndex++
+				if blkIndex == blockCount {
+					hookActions.PauseResponse()
+				}
+			})
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertRequestDoesNotCompleteWhilePaused()
+			td.verifyNResponses(blockCount)
+			td.assertPausedRequest()
+			err := responseManager.UnpauseResponse(td.p, td.requestID, td.extensionResponse)
+			require.NoError(t, err)
+			td.assertReceiveExtensionResponse()
+			td.assertCompleteRequestWithSuccess()
+		})
+
+		t.Run("can pause/unpause externally", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+			})
+			blkIndex := 0
+			blockCount := 3
+			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+				blkIndex++
+				if blkIndex == blockCount {
+					err := responseManager.PauseResponse(p, requestData.ID())
+					require.NoError(t, err)
+				}
+			})
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertRequestDoesNotCompleteWhilePaused()
+			td.verifyNResponses(blockCount + 1)
+			td.assertPausedRequest()
+			err := responseManager.UnpauseResponse(td.p, td.requestID)
+			require.NoError(t, err)
+			td.verifyNResponses(td.blockChainLength - (blockCount + 1))
+			td.assertCompleteRequestWithSuccess()
+		})
+
+	})
+
+	t.Run("test update hook processing", func(t *testing.T) {
+
+		t.Run("can pause/unpause", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+			})
+			blkIndex := 0
+			blockCount := 3
+			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+				blkIndex++
+				if blkIndex == blockCount {
+					hookActions.PauseResponse()
+				}
+			})
+			td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+				if _, found := updateData.Extension(td.extensionName); found {
+					hookActions.UnpauseResponse()
+				}
+			})
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertRequestDoesNotCompleteWhilePaused()
+			td.verifyNResponses(blockCount)
+			td.assertPausedRequest()
+
+			responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
+			td.assertCompleteRequestWithSuccess()
+		})
+
+		t.Run("can send extension data", func(t *testing.T) {
+			t.Run("when unpaused", func(t *testing.T) {
+				td := newTestData(t)
+				defer td.cancel()
+				responseManager := td.newResponseManager()
+				responseManager.Startup()
+				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+					hookActions.ValidateRequest()
+				})
+				blkIndex := 0
+				blockCount := 3
+				wait := make(chan struct{})
+				sent := make(chan struct{})
+				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+					blkIndex++
+					if blkIndex == blockCount {
+						close(sent)
+						<-wait
+					}
+				})
+				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+					if _, found := updateData.Extension(td.extensionName); found {
+						hookActions.SendExtensionData(td.extensionResponse)
+					}
+				})
+				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
+				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
+				responseManager.synchronize()
+				close(wait)
+				td.assertCompleteRequestWithSuccess()
+				td.assertReceiveExtensionResponse()
+			})
+
+			t.Run("when paused", func(t *testing.T) {
+				td := newTestData(t)
+				defer td.cancel()
+				responseManager := td.newResponseManager()
+				responseManager.Startup()
+				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+					hookActions.ValidateRequest()
+				})
+				blkIndex := 0
+				blockCount := 3
+				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+					blkIndex++
+					if blkIndex == blockCount {
+						hookActions.PauseResponse()
+					}
+				})
+				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+					if _, found := updateData.Extension(td.extensionName); found {
+						hookActions.SendExtensionData(td.extensionResponse)
+					}
+				})
+				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+				td.verifyNResponses(blockCount)
+				td.assertPausedRequest()
+
+				// send update
+				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
+
+				// receive data
+				td.assertReceiveExtensionResponse()
+
+				// should still be paused
+				td.assertRequestDoesNotCompleteWhilePaused()
+			})
+		})
+
+		t.Run("can send errors", func(t *testing.T) {
+			t.Run("when unpaused", func(t *testing.T) {
+				td := newTestData(t)
+				defer td.cancel()
+				responseManager := td.newResponseManager()
+				responseManager.Startup()
+				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+					hookActions.ValidateRequest()
+				})
+				blkIndex := 0
+				blockCount := 3
+				wait := make(chan struct{})
+				sent := make(chan struct{})
+				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+					blkIndex++
+					if blkIndex == blockCount {
+						close(sent)
+						<-wait
+					}
+				})
+				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+					if _, found := updateData.Extension(td.extensionName); found {
+						hookActions.TerminateWithError(errors.New("something went wrong"))
+					}
+				})
+				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
+				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
+				responseManager.synchronize()
+				close(wait)
+				td.assertCompleteRequestWithFailure()
+			})
+
+			t.Run("when paused", func(t *testing.T) {
+				td := newTestData(t)
+				defer td.cancel()
+				responseManager := td.newResponseManager()
+				responseManager.Startup()
+				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+					hookActions.ValidateRequest()
+				})
+				blkIndex := 0
+				blockCount := 3
+				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+					blkIndex++
+					if blkIndex == blockCount {
+						hookActions.PauseResponse()
+					}
+				})
+				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
+					if _, found := updateData.Extension(td.extensionName); found {
+						hookActions.TerminateWithError(errors.New("something went wrong"))
+					}
+				})
+				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+				td.verifyNResponses(blockCount)
+				td.assertPausedRequest()
+
+				// send update
+				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
+				td.assertCompleteRequestWithFailure()
+
+				// cannot unpause
+				err := responseManager.UnpauseResponse(td.p, td.requestID)
+				require.Error(t, err)
+			})
+		})
+
+	})
+}
+
+func TestNetworkErrors(t *testing.T) {
+	t.Run("network error final status - success", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.verifyNResponses(td.blockChainLength)
+		td.assertOnlyCompleteProcessingWithSuccess()
+		err := errors.New("something went wrong")
+		td.notifyStatusMessagesNetworkError(err)
+		td.assertNetworkErrors(err, 1)
+		td.assertNoCompletedResponseStatuses()
+	})
+	t.Run("network error final status - failure", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertOnlyCompleteProcessingWithFailure()
+		err := errors.New("something went wrong")
+		td.notifyStatusMessagesNetworkError(err)
+		td.assertNetworkErrors(err, 1)
+		td.assertNoCompletedResponseStatuses()
+	})
+	t.Run("network error block send", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertSendBlock()
+		err := errors.New("something went wrong")
+		td.notifyBlockSendsNetworkError(err)
+		td.assertHasNetworkErrors(err)
+		td.assertNoCompletedResponseStatuses()
+	})
+	t.Run("network error while paused", func(t *testing.T) {
+		td := newTestData(t)
+		defer td.cancel()
+		responseManager := td.newResponseManager()
+		responseManager.Startup()
+		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+			hookActions.ValidateRequest()
+		})
+		blkIndex := 0
+		blockCount := 3
+		td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+			blkIndex++
+			if blkIndex == blockCount {
+				hookActions.PauseResponse()
+			}
+		})
+		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+		td.assertRequestDoesNotCompleteWhilePaused()
+		td.verifyNResponsesOnlyProcessing(blockCount)
+		td.assertPausedRequest()
+		err := errors.New("something went wrong")
+		td.notifyBlockSendsNetworkError(err)
+		td.assertNetworkErrors(err, blockCount)
+		err = responseManager.UnpauseResponse(td.p, td.requestID, td.extensionResponse)
+		require.Error(t, err)
+	})
+}
 
 type fakeQueryQueue struct {
 	popWait   sync.WaitGroup
@@ -116,6 +741,7 @@ type fakePeerResponseSender struct {
 	pausedRequests       chan pausedRequest
 	cancelledRequests    chan cancelledRequest
 	ignoredLinks         chan []ipld.Link
+	notifeePublisher     *testutil.MockPublisher
 	dedupKeys            chan string
 }
 
@@ -151,30 +777,36 @@ func (fprs *fakePeerResponseSender) SendResponse(
 	requestID graphsync.RequestID,
 	link ipld.Link,
 	data []byte,
-	_ ...notifications.Notifee,
+	notifees ...notifications.Notifee,
 ) graphsync.BlockData {
+	fprs.notifeePublisher.AddNotifees(notifees)
 	fprs.sentResponses <- sentResponse{requestID, link, data}
+
 	return fakeBlkData{link, uint64(len(data))}
 }
 
 func (fprs *fakePeerResponseSender) SendExtensionData(
 	requestID graphsync.RequestID,
 	extension graphsync.ExtensionData,
-	_ ...notifications.Notifee,
+	notifees ...notifications.Notifee,
 ) {
+	fprs.notifeePublisher.AddNotifees(notifees)
 	fprs.sentExtensions <- sentExtension{requestID, extension}
 }
 
-func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID, _ ...notifications.Notifee) graphsync.ResponseStatusCode {
+func (fprs *fakePeerResponseSender) FinishRequest(requestID graphsync.RequestID, notifees ...notifications.Notifee) graphsync.ResponseStatusCode {
+	fprs.notifeePublisher.AddNotifees(notifees)
 	fprs.lastCompletedRequest <- completedRequest{requestID, graphsync.RequestCompletedFull}
 	return graphsync.RequestCompletedFull
 }
 
-func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode, _ ...notifications.Notifee) {
+func (fprs *fakePeerResponseSender) FinishWithError(requestID graphsync.RequestID, status graphsync.ResponseStatusCode, notifees ...notifications.Notifee) {
+	fprs.notifeePublisher.AddNotifees(notifees)
 	fprs.lastCompletedRequest <- completedRequest{requestID, status}
 }
 
-func (fprs *fakePeerResponseSender) PauseRequest(requestID graphsync.RequestID, _ ...notifications.Notifee) {
+func (fprs *fakePeerResponseSender) PauseRequest(requestID graphsync.RequestID, notifees ...notifications.Notifee) {
+	fprs.notifeePublisher.AddNotifees(notifees)
 	fprs.pausedRequests <- pausedRequest{requestID}
 }
 
@@ -182,14 +814,15 @@ func (fprs *fakePeerResponseSender) FinishWithCancel(requestID graphsync.Request
 	fprs.cancelledRequests <- cancelledRequest{requestID}
 }
 
-func (fprs *fakePeerResponseSender) Transaction(requestID graphsync.RequestID, transaction peerresponsemanager.Transaction, _ ...notifications.Notifee) error {
-	fprts := &fakePeerResponseTransactionSender{requestID, fprs}
+func (fprs *fakePeerResponseSender) Transaction(requestID graphsync.RequestID, transaction peerresponsemanager.Transaction) error {
+	fprts := &fakePeerResponseTransactionSender{requestID, fprs, fprs.notifeePublisher}
 	return transaction(fprts)
 }
 
 type fakePeerResponseTransactionSender struct {
-	requestID graphsync.RequestID
-	prs       peerresponsemanager.PeerResponseSender
+	requestID        graphsync.RequestID
+	prs              peerresponsemanager.PeerResponseSender
+	notifeePublisher *testutil.MockPublisher
 }
 
 func (fprts *fakePeerResponseTransactionSender) SendResponse(link ipld.Link, data []byte) graphsync.BlockData {
@@ -215,781 +848,59 @@ func (fprts *fakePeerResponseTransactionSender) PauseRequest() {
 func (fprts *fakePeerResponseTransactionSender) FinishWithCancel() {
 	fprts.prs.FinishWithCancel(fprts.requestID)
 }
-func TestIncomingQuery(t *testing.T) {
-	td := newTestData(t)
-	defer td.cancel()
-	blks := td.blockChain.AllBlocks()
 
-	responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
-	responseManager.Startup()
-
-	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-	testutil.AssertDoesReceive(td.ctx, t, td.completedRequestChan, "Should have completed request but didn't")
-	for i := 0; i < len(blks); i++ {
-		var sentResponse sentResponse
-		testutil.AssertReceive(td.ctx, t, td.sentResponses, &sentResponse, "did not send responses")
-		k := sentResponse.link.(cidlink.Link)
-		blockIndex := testutil.IndexOf(blks, k.Cid)
-		require.NotEqual(t, blockIndex, -1, "sent incorrect link")
-		require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
-		require.Equal(t, td.requestID, sentResponse.requestID, "has incorrect response id")
-	}
-}
-
-func TestCancellationQueryInProgress(t *testing.T) {
-	td := newTestData(t)
-	defer td.cancel()
-	blks := td.blockChain.AllBlocks()
-	responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
-	cancelledListenerCalled := make(chan struct{}, 1)
-	td.cancelledListeners.Register(func(p peer.ID, request graphsync.RequestData) {
-		cancelledListenerCalled <- struct{}{}
-	})
-	responseManager.Startup()
-	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-
-	// read one block
-	var sentResponse sentResponse
-	testutil.AssertReceive(td.ctx, t, td.sentResponses, &sentResponse, "did not send response")
-	k := sentResponse.link.(cidlink.Link)
-	blockIndex := testutil.IndexOf(blks, k.Cid)
-	require.NotEqual(t, blockIndex, -1, "sent incorrect link")
-	require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
-	require.Equal(t, td.requestID, sentResponse.requestID, "has incorrect response id")
-
-	// send a cancellation
-	cancelRequests := []gsmsg.GraphSyncRequest{
-		gsmsg.CancelRequest(td.requestID),
-	}
-	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
-
-	responseManager.synchronize()
-
-	testutil.AssertDoesReceive(td.ctx, t, cancelledListenerCalled, "should call cancelled listener")
-
-	// at this point we should receive at most one more block, then traversal
-	// should complete
-	additionalBlocks := 0
-	for {
-		select {
-		case <-td.ctx.Done():
-			t.Fatal("should complete request before context closes")
-		case sentResponse = <-td.sentResponses:
-			k = sentResponse.link.(cidlink.Link)
-			blockIndex = testutil.IndexOf(blks, k.Cid)
-			require.NotEqual(t, blockIndex, -1, "did not send correct link")
-			require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
-			require.Equal(t, td.requestID, sentResponse.requestID, "incorrect response id")
-			additionalBlocks++
-		case <-td.cancelledRequests:
-			require.LessOrEqual(t, additionalBlocks, 1, "should send at most 1 additional block")
-			return
-		}
-	}
-}
-
-func TestCancellationViaCommand(t *testing.T) {
-	td := newTestData(t)
-	defer td.cancel()
-	blks := td.blockChain.AllBlocks()
-	responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
-	responseManager.Startup()
-	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-
-	// read one block
-	var sentResponse sentResponse
-	testutil.AssertReceive(td.ctx, t, td.sentResponses, &sentResponse, "did not send response")
-	k := sentResponse.link.(cidlink.Link)
-	blockIndex := testutil.IndexOf(blks, k.Cid)
-	require.NotEqual(t, blockIndex, -1, "sent incorrect link")
-	require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
-	require.Equal(t, td.requestID, sentResponse.requestID, "has incorrect response id")
-
-	// send a cancellation
-	err := responseManager.CancelResponse(td.p, td.requestID)
-	require.NoError(t, err)
-
-	// at this point we should receive at most one more block, then traversal
-	// should complete
-	additionalBlocks := 0
-	for {
-		select {
-		case <-td.ctx.Done():
-			t.Fatal("should complete request before context closes")
-		case sentResponse = <-td.sentResponses:
-			k = sentResponse.link.(cidlink.Link)
-			blockIndex = testutil.IndexOf(blks, k.Cid)
-			require.NotEqual(t, blockIndex, -1, "did not send correct link")
-			require.Equal(t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
-			require.Equal(t, td.requestID, sentResponse.requestID, "incorrect response id")
-			additionalBlocks++
-		case completed := <-td.completedRequestChan:
-			require.Equal(t, completed.result, graphsync.RequestCancelled)
-			require.LessOrEqual(t, additionalBlocks, 1, "should send at most 1 additional block")
-			return
-		}
-	}
-}
-
-func TestEarlyCancellation(t *testing.T) {
-	td := newTestData(t)
-	defer td.cancel()
-	td.queryQueue.popWait.Add(1)
-	responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-	responseManager.Startup()
-	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-
-	// send a cancellation
-	cancelRequests := []gsmsg.GraphSyncRequest{
-		gsmsg.CancelRequest(td.requestID),
-	}
-	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
-
-	responseManager.synchronize()
-
-	// unblock popping from queue
-	td.queryQueue.popWait.Done()
-
-	timer := time.NewTimer(200 * time.Millisecond)
-	// verify no responses processed
-	testutil.AssertDoesReceiveFirst(t, timer.C, "should not process more responses", td.sentResponses, td.completedRequestChan)
-}
-
-func TestValidationAndExtensions(t *testing.T) {
-	t.Run("on its own, should fail validation", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
-	})
-
-	t.Run("if non validating hook succeeds, does not pass validation", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.SendExtensionData(td.extensionResponse)
-		})
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-	})
-
-	t.Run("if validating hook succeeds, should pass validation", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-			hookActions.SendExtensionData(td.extensionResponse)
-		})
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-	})
-
-	t.Run("if any hook fails, should fail", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.SendExtensionData(td.extensionResponse)
-			hookActions.TerminateWithError(errors.New("everything went to crap"))
-		})
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-	})
-
-	t.Run("hooks can be unregistered", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		unregister := td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-			hookActions.SendExtensionData(td.extensionResponse)
-		})
-
-		// hook validates request
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-
-		// unregister
-		unregister()
-
-		// no same request should fail
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
-	})
-
-	t.Run("hooks can alter the loader", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		obs := make(map[ipld.Link][]byte)
-		oloader, _ := testutil.NewTestStore(obs)
-		responseManager := New(td.ctx, oloader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		// add validating hook -- so the request SHOULD succeed
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-
-		// request fails with base loader reading from block store that's missing data
-		var lastRequest completedRequest
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
-
-		err := td.peristenceOptions.Register("chainstore", td.loader)
-		require.NoError(t, err)
-		// register hook to use different loader
-		_ = td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			if _, found := requestData.Extension(td.extensionName); found {
-				hookActions.UsePersistenceOption("chainstore")
-				hookActions.SendExtensionData(td.extensionResponse)
-			}
-		})
-		// hook uses different loader that should make request succeed
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-	})
-
-	t.Run("hooks can alter the node builder chooser", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-
-		customChooserCallCount := 0
-		customChooser := func(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
-			customChooserCallCount++
-			return basicnode.Prototype.Any, nil
-		}
-
-		// add validating hook -- so the request SHOULD succeed
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-
-		// with default chooser, customer chooser not called
-		var lastRequest completedRequest
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		require.Equal(t, 0, customChooserCallCount)
-
-		// register hook to use custom chooser
-		_ = td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			if _, found := requestData.Extension(td.extensionName); found {
-				hookActions.UseLinkTargetNodePrototypeChooser(customChooser)
-				hookActions.SendExtensionData(td.extensionResponse)
-			}
-		})
-
-		// verify now that request succeeds and uses custom chooser
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var receivedExtension sentExtension
-		testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-		require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-		require.Equal(t, 5, customChooserCallCount)
-	})
-
-	t.Run("do-not-send-cids extension", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-		set := cid.NewSet()
-		blks := td.blockChain.Blocks(0, 5)
-		for _, blk := range blks {
-			set.Add(blk.Cid())
-		}
-		data, err := cidset.EncodeCidSet(set)
-		require.NoError(t, err)
-		requests := []gsmsg.GraphSyncRequest{
-			gsmsg.NewRequest(td.requestID, td.blockChain.TipLink.(cidlink.Link).Cid, td.blockChain.Selector(), graphsync.Priority(0),
-				graphsync.ExtensionData{
-					Name: graphsync.ExtensionDoNotSendCIDs,
-					Data: data,
-				}),
-		}
-		responseManager.ProcessRequests(td.ctx, td.p, requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var lastLinks []ipld.Link
-		testutil.AssertReceive(td.ctx, t, td.ignoredLinks, &lastLinks, "should send ignored links")
-		require.Len(t, lastLinks, set.Len())
-		for _, link := range lastLinks {
-			require.True(t, set.Has(link.(cidlink.Link).Cid))
-		}
-	})
-	t.Run("dedup-by-key extension", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-		data, err := dedupkey.EncodeDedupKey("applesauce")
-		require.NoError(t, err)
-		requests := []gsmsg.GraphSyncRequest{
-			gsmsg.NewRequest(td.requestID, td.blockChain.TipLink.(cidlink.Link).Cid, td.blockChain.Selector(), graphsync.Priority(0),
-				graphsync.ExtensionData{
-					Name: graphsync.ExtensionDeDupByKey,
-					Data: data,
-				}),
-		}
-		responseManager.ProcessRequests(td.ctx, td.p, requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var dedupKey string
-		testutil.AssertReceive(td.ctx, t, td.dedupKeys, &dedupKey, "should dedup by key")
-		require.Equal(t, dedupKey, "applesauce")
-	})
-	t.Run("test pause/resume", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-			hookActions.PauseResponse()
-		})
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var pauseRequest pausedRequest
-		testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pauseRequest, "should pause immediately")
-		timer := time.NewTimer(100 * time.Millisecond)
-		testutil.AssertDoesReceiveFirst(t, timer.C, "should not complete request while paused", td.completedRequestChan)
-		testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-		err := responseManager.UnpauseResponse(td.p, td.requestID)
-		require.NoError(t, err)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-	})
-	t.Run("test block hook processing", func(t *testing.T) {
-		t.Run("can send extension data", func(t *testing.T) {
-			td := newTestData(t)
-			defer td.cancel()
-			responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-			responseManager.Startup()
-			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-				hookActions.ValidateRequest()
-			})
-			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-				hookActions.SendExtensionData(td.extensionResponse)
-			})
-			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-			var lastRequest completedRequest
-			testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-			for i := 0; i < td.blockChainLength; i++ {
-				var receivedExtension sentExtension
-				testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-				require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-			}
-		})
-
-		t.Run("can send errors", func(t *testing.T) {
-			td := newTestData(t)
-			defer td.cancel()
-			responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-			responseManager.Startup()
-			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-				hookActions.ValidateRequest()
-			})
-			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-				hookActions.TerminateWithError(errors.New("failed"))
-			})
-			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-			var lastRequest completedRequest
-			testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-			require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "request should fail")
-		})
-
-		t.Run("can pause/unpause", func(t *testing.T) {
-			td := newTestData(t)
-			defer td.cancel()
-			responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-			responseManager.Startup()
-			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-				hookActions.ValidateRequest()
-			})
-			blkIndex := 0
-			blockCount := 3
-			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-				blkIndex++
-				if blkIndex == blockCount {
-					hookActions.PauseResponse()
-				}
-			})
-			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-			timer := time.NewTimer(100 * time.Millisecond)
-			testutil.AssertDoesReceiveFirst(t, timer.C, "should not complete request while paused", td.completedRequestChan)
-			for i := 0; i < blockCount; i++ {
-				testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should sent block")
-			}
-			testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-			var pausedRequest pausedRequest
-			testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pausedRequest, "should pause request")
-			err := responseManager.UnpauseResponse(td.p, td.requestID, td.extensionResponse)
-			require.NoError(t, err)
-			var sentExtension sentExtension
-			testutil.AssertReceive(td.ctx, t, td.sentExtensions, &sentExtension, "should send additional response")
-			require.Equal(t, td.extensionResponse, sentExtension.extension)
-			var lastRequest completedRequest
-			testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		})
-
-		t.Run("can pause/unpause externally", func(t *testing.T) {
-			td := newTestData(t)
-			defer td.cancel()
-			responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-			responseManager.Startup()
-			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-				hookActions.ValidateRequest()
-			})
-			blkIndex := 0
-			blockCount := 3
-			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-				blkIndex++
-				if blkIndex == blockCount {
-					err := responseManager.PauseResponse(p, requestData.ID())
-					require.NoError(t, err)
-				}
-			})
-			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-			timer := time.NewTimer(100 * time.Millisecond)
-			testutil.AssertDoesReceiveFirst(t, timer.C, "should not complete request while paused", td.completedRequestChan)
-			for i := 0; i < blockCount+1; i++ {
-				testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should sent block")
-			}
-			testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-			var pausedRequest pausedRequest
-			testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pausedRequest, "should pause request")
-			err := responseManager.UnpauseResponse(td.p, td.requestID)
-			require.NoError(t, err)
-			for i := blockCount + 1; i < td.blockChainLength; i++ {
-				testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should send block")
-			}
-			var lastRequest completedRequest
-			testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		})
-	})
-
-	t.Run("test update hook processing", func(t *testing.T) {
-
-		t.Run("can pause/unpause", func(t *testing.T) {
-			td := newTestData(t)
-			defer td.cancel()
-			responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-			responseManager.Startup()
-			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-				hookActions.ValidateRequest()
-			})
-			blkIndex := 0
-			blockCount := 3
-			td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-				blkIndex++
-				if blkIndex == blockCount {
-					hookActions.PauseResponse()
-				}
-			})
-			td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
-				if _, found := updateData.Extension(td.extensionName); found {
-					hookActions.UnpauseResponse()
-				}
-			})
-			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-			timer := time.NewTimer(100 * time.Millisecond)
-			testutil.AssertDoesReceiveFirst(t, timer.C, "should not complete request while paused", td.completedRequestChan)
-			var sentResponses []sentResponse
-			for i := 0; i < blockCount; i++ {
-				testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should sent block")
-			}
-			testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-			var pausedRequest pausedRequest
-			testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pausedRequest, "should pause request")
-			require.LessOrEqual(t, len(sentResponses), blockCount)
-			responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-			var lastRequest completedRequest
-			testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-			require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		})
-
-		t.Run("can send extension data", func(t *testing.T) {
-			t.Run("when unpaused", func(t *testing.T) {
-				td := newTestData(t)
-				defer td.cancel()
-				responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-				responseManager.Startup()
-				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-					hookActions.ValidateRequest()
-				})
-				blkIndex := 0
-				blockCount := 3
-				wait := make(chan struct{})
-				sent := make(chan struct{})
-				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-					blkIndex++
-					if blkIndex == blockCount {
-						close(sent)
-						<-wait
-					}
-				})
-				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
-					if _, found := updateData.Extension(td.extensionName); found {
-						hookActions.SendExtensionData(td.extensionResponse)
-					}
-				})
-				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
-				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.synchronize()
-				close(wait)
-				var lastRequest completedRequest
-				testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-				require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-				var receivedExtension sentExtension
-				testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-				require.Equal(t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
-			})
-
-			t.Run("when paused", func(t *testing.T) {
-				td := newTestData(t)
-				defer td.cancel()
-				responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-				responseManager.Startup()
-				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-					hookActions.ValidateRequest()
-				})
-				blkIndex := 0
-				blockCount := 3
-				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-					blkIndex++
-					if blkIndex == blockCount {
-						hookActions.PauseResponse()
-					}
-				})
-				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
-					if _, found := updateData.Extension(td.extensionName); found {
-						hookActions.SendExtensionData(td.extensionResponse)
-					}
-				})
-				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-				var sentResponses []sentResponse
-				for i := 0; i < blockCount; i++ {
-					testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should sent block")
-				}
-				testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-				var pausedRequest pausedRequest
-				testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pausedRequest, "should pause request")
-				require.LessOrEqual(t, len(sentResponses), blockCount)
-
-				// send update
-				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-
-				// receive data
-				var receivedExtension sentExtension
-				testutil.AssertReceive(td.ctx, t, td.sentExtensions, &receivedExtension, "should send extension response")
-
-				// should still be paused
-				timer := time.NewTimer(100 * time.Millisecond)
-				testutil.AssertDoesReceiveFirst(t, timer.C, "should not complete request while paused", td.completedRequestChan)
-			})
-		})
-
-		t.Run("can send errors", func(t *testing.T) {
-			t.Run("when unpaused", func(t *testing.T) {
-				td := newTestData(t)
-				defer td.cancel()
-				responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-				responseManager.Startup()
-				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-					hookActions.ValidateRequest()
-				})
-				blkIndex := 0
-				blockCount := 3
-				wait := make(chan struct{})
-				sent := make(chan struct{})
-				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-					blkIndex++
-					if blkIndex == blockCount {
-						close(sent)
-						<-wait
-					}
-				})
-				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
-					if _, found := updateData.Extension(td.extensionName); found {
-						hookActions.TerminateWithError(errors.New("something went wrong"))
-					}
-				})
-				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
-				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.synchronize()
-				close(wait)
-				var lastRequest completedRequest
-				testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-				require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "request should fail")
-			})
-
-			t.Run("when paused", func(t *testing.T) {
-				td := newTestData(t)
-				defer td.cancel()
-				responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-				responseManager.Startup()
-				td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-					hookActions.ValidateRequest()
-				})
-				blkIndex := 0
-				blockCount := 3
-				td.blockHooks.Register(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
-					blkIndex++
-					if blkIndex == blockCount {
-						hookActions.PauseResponse()
-					}
-				})
-				td.updateHooks.Register(func(p peer.ID, requestData graphsync.RequestData, updateData graphsync.RequestData, hookActions graphsync.RequestUpdatedHookActions) {
-					if _, found := updateData.Extension(td.extensionName); found {
-						hookActions.TerminateWithError(errors.New("something went wrong"))
-					}
-				})
-				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-				var sentResponses []sentResponse
-				for i := 0; i < blockCount; i++ {
-					testutil.AssertDoesReceive(td.ctx, t, td.sentResponses, "should sent block")
-				}
-				testutil.AssertChannelEmpty(t, td.sentResponses, "should not send more blocks")
-				var pausedRequest pausedRequest
-				testutil.AssertReceive(td.ctx, t, td.pausedRequests, &pausedRequest, "should pause request")
-				require.LessOrEqual(t, len(sentResponses), blockCount)
-
-				// send update
-				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-
-				// should terminate
-				var lastRequest completedRequest
-				testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-				require.True(t, gsmsg.IsTerminalFailureCode(lastRequest.result), "request should fail")
-
-				// cannot unpause
-				err := responseManager.UnpauseResponse(td.p, td.requestID)
-				require.Error(t, err)
-			})
-		})
-
-	})
-	t.Run("final response status listeners", func(t *testing.T) {
-		td := newTestData(t)
-		defer td.cancel()
-		responseManager := New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners)
-		responseManager.Startup()
-		td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
-			hookActions.ValidateRequest()
-		})
-		statusChan := make(chan graphsync.ResponseStatusCode, 1)
-		td.completedListeners.Register(func(p peer.ID, requestData graphsync.RequestData, status graphsync.ResponseStatusCode) {
-			select {
-			case statusChan <- status:
-			default:
-			}
-		})
-		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-		var lastRequest completedRequest
-		testutil.AssertReceive(td.ctx, t, td.completedRequestChan, &lastRequest, "should complete request")
-		require.True(t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
-		var status graphsync.ResponseStatusCode
-		testutil.AssertReceive(td.ctx, t, statusChan, &status, "should receive status")
-		require.True(t, gsmsg.IsTerminalSuccessCode(status), "request should succeed")
-	})
+func (fprts *fakePeerResponseTransactionSender) AddNotifee(notifee notifications.Notifee) {
+	fprts.notifeePublisher.AddNotifees([]notifications.Notifee{notifee})
 }
 
 type testData struct {
-	ctx                   context.Context
-	cancel                func()
-	blockStore            map[ipld.Link][]byte
-	loader                ipld.Loader
-	storer                ipld.Storer
-	blockChainLength      int
-	blockChain            *testutil.TestBlockChain
-	completedRequestChan  chan completedRequest
-	sentResponses         chan sentResponse
-	sentExtensions        chan sentExtension
-	pausedRequests        chan pausedRequest
-	cancelledRequests     chan cancelledRequest
-	ignoredLinks          chan []ipld.Link
-	dedupKeys             chan string
-	peerManager           *fakePeerManager
-	queryQueue            *fakeQueryQueue
-	extensionData         []byte
-	extensionName         graphsync.ExtensionName
-	extension             graphsync.ExtensionData
-	extensionResponseData []byte
-	extensionResponse     graphsync.ExtensionData
-	extensionUpdateData   []byte
-	extensionUpdate       graphsync.ExtensionData
-	requestID             graphsync.RequestID
-	requests              []gsmsg.GraphSyncRequest
-	updateRequests        []gsmsg.GraphSyncRequest
-	p                     peer.ID
-	peristenceOptions     *persistenceoptions.PersistenceOptions
-	requestHooks          *hooks.IncomingRequestHooks
-	blockHooks            *hooks.OutgoingBlockHooks
-	updateHooks           *hooks.RequestUpdatedHooks
-	completedListeners    *hooks.CompletedResponseListeners
-	cancelledListeners    *hooks.RequestorCancelledListeners
+	ctx                       context.Context
+	t                         *testing.T
+	cancel                    func()
+	blockStore                map[ipld.Link][]byte
+	loader                    ipld.Loader
+	storer                    ipld.Storer
+	blockChainLength          int
+	blockChain                *testutil.TestBlockChain
+	completedRequestChan      chan completedRequest
+	sentResponses             chan sentResponse
+	sentExtensions            chan sentExtension
+	pausedRequests            chan pausedRequest
+	cancelledRequests         chan cancelledRequest
+	ignoredLinks              chan []ipld.Link
+	dedupKeys                 chan string
+	peerManager               *fakePeerManager
+	queryQueue                *fakeQueryQueue
+	extensionData             []byte
+	extensionName             graphsync.ExtensionName
+	extension                 graphsync.ExtensionData
+	extensionResponseData     []byte
+	extensionResponse         graphsync.ExtensionData
+	extensionUpdateData       []byte
+	extensionUpdate           graphsync.ExtensionData
+	requestID                 graphsync.RequestID
+	requests                  []gsmsg.GraphSyncRequest
+	updateRequests            []gsmsg.GraphSyncRequest
+	p                         peer.ID
+	peristenceOptions         *persistenceoptions.PersistenceOptions
+	requestHooks              *hooks.IncomingRequestHooks
+	blockHooks                *hooks.OutgoingBlockHooks
+	updateHooks               *hooks.RequestUpdatedHooks
+	completedListeners        *hooks.CompletedResponseListeners
+	cancelledListeners        *hooks.RequestorCancelledListeners
+	blockSentListeners        *hooks.BlockSentListeners
+	networkErrorListeners     *hooks.NetworkErrorListeners
+	notifeePublisher          *testutil.MockPublisher
+	blockSends                chan graphsync.BlockData
+	completedResponseStatuses chan graphsync.ResponseStatusCode
+	networkErrorChan          chan error
+	allBlocks                 []blocks.Block
 }
 
 func newTestData(t *testing.T) testData {
 	ctx := context.Background()
 	td := testData{}
+	td.t = t
 	td.ctx, td.cancel = context.WithTimeout(ctx, 10*time.Second)
 
 	td.blockStore = make(map[ipld.Link][]byte)
@@ -1004,6 +915,10 @@ func newTestData(t *testing.T) testData {
 	td.cancelledRequests = make(chan cancelledRequest, 1)
 	td.ignoredLinks = make(chan []ipld.Link, 1)
 	td.dedupKeys = make(chan string, 1)
+	td.blockSends = make(chan graphsync.BlockData, td.blockChainLength*2)
+	td.completedResponseStatuses = make(chan graphsync.ResponseStatusCode, 1)
+	td.networkErrorChan = make(chan error, td.blockChainLength*2)
+	td.notifeePublisher = testutil.NewMockPublisher()
 	fprs := &fakePeerResponseSender{
 		lastCompletedRequest: td.completedRequestChan,
 		sentResponses:        td.sentResponses,
@@ -1012,6 +927,7 @@ func newTestData(t *testing.T) testData {
 		cancelledRequests:    td.cancelledRequests,
 		ignoredLinks:         td.ignoredLinks,
 		dedupKeys:            td.dedupKeys,
+		notifeePublisher:     td.notifeePublisher,
 	}
 	td.peerManager = &fakePeerManager{peerResponseSender: fprs}
 	td.queryQueue = &fakeQueryQueue{}
@@ -1046,5 +962,187 @@ func newTestData(t *testing.T) testData {
 	td.updateHooks = hooks.NewUpdateHooks()
 	td.completedListeners = hooks.NewCompletedResponseListeners()
 	td.cancelledListeners = hooks.NewRequestorCancelledListeners()
+	td.blockSentListeners = hooks.NewBlockSentListeners()
+	td.networkErrorListeners = hooks.NewNetworkErrorListeners()
+	td.completedListeners.Register(func(p peer.ID, requestID graphsync.RequestID, status graphsync.ResponseStatusCode) {
+		select {
+		case td.completedResponseStatuses <- status:
+		default:
+		}
+	})
+	td.blockSentListeners.Register(func(p peer.ID, requestID graphsync.RequestID, blockData graphsync.BlockData) {
+		select {
+		case td.blockSends <- blockData:
+		default:
+		}
+	})
+	td.networkErrorListeners.Register(func(p peer.ID, requestID graphsync.RequestID, err error) {
+		select {
+		case td.networkErrorChan <- err:
+		default:
+		}
+	})
 	return td
+}
+
+func (td *testData) newResponseManager() *ResponseManager {
+	return New(td.ctx, td.loader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners)
+}
+
+func (td *testData) alternateLoaderResponseManager() *ResponseManager {
+	obs := make(map[ipld.Link][]byte)
+	oloader, _ := testutil.NewTestStore(obs)
+	return New(td.ctx, oloader, td.peerManager, td.queryQueue, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners)
+}
+
+func (td *testData) assertPausedRequest() {
+	var pausedRequest pausedRequest
+	testutil.AssertReceive(td.ctx, td.t, td.pausedRequests, &pausedRequest, "should pause request")
+}
+
+func (td *testData) getAllBlocks() []blocks.Block {
+	if td.allBlocks == nil {
+		td.allBlocks = td.blockChain.AllBlocks()
+	}
+	return td.allBlocks
+}
+
+func (td *testData) verifyResponse(sentResponse sentResponse) {
+	k := sentResponse.link.(cidlink.Link)
+	blks := td.getAllBlocks()
+	blockIndex := testutil.IndexOf(blks, k.Cid)
+	require.NotEqual(td.t, blockIndex, -1, "sent incorrect link")
+	require.Equal(td.t, blks[blockIndex].RawData(), sentResponse.data, "sent incorrect data")
+	require.Equal(td.t, td.requestID, sentResponse.requestID, "has incorrect response id")
+}
+
+func (td *testData) assertSendBlock() {
+	var sentResponse sentResponse
+	testutil.AssertReceive(td.ctx, td.t, td.sentResponses, &sentResponse, "did not send response")
+	td.verifyResponse(sentResponse)
+}
+
+func (td *testData) assertNoResponses() {
+	timer := time.NewTimer(200 * time.Millisecond)
+	// verify no responses processed
+	testutil.AssertDoesReceiveFirst(td.t, timer.C, "should not process more responses", td.sentResponses, td.completedRequestChan)
+}
+
+func (td *testData) assertCompleteRequestWithFailure() {
+	td.assertOnlyCompleteProcessingWithFailure()
+	td.notifyStatusMessagesSent()
+	var status graphsync.ResponseStatusCode
+	testutil.AssertReceive(td.ctx, td.t, td.completedResponseStatuses, &status, "should receive status")
+	require.True(td.t, gsmsg.IsTerminalFailureCode(status), "request should succeed")
+}
+
+func (td *testData) assertCompleteRequestWithSuccess() {
+	td.assertOnlyCompleteProcessingWithSuccess()
+	td.notifyStatusMessagesSent()
+	var status graphsync.ResponseStatusCode
+	testutil.AssertReceive(td.ctx, td.t, td.completedResponseStatuses, &status, "should receive status")
+	require.True(td.t, gsmsg.IsTerminalSuccessCode(status), "request should succeed")
+}
+
+func (td *testData) assertOnlyCompleteProcessingWithSuccess() {
+	var lastRequest completedRequest
+	testutil.AssertReceive(td.ctx, td.t, td.completedRequestChan, &lastRequest, "should complete request")
+	require.True(td.t, gsmsg.IsTerminalSuccessCode(lastRequest.result), "request should succeed")
+}
+
+func (td *testData) assertCancelledRequest() {
+	testutil.AssertDoesReceive(td.ctx, td.t, td.cancelledRequests, "should cancel request")
+}
+
+func (td *testData) assertOnlyCompleteProcessingWithFailure() {
+	var lastRequest completedRequest
+	testutil.AssertReceive(td.ctx, td.t, td.completedRequestChan, &lastRequest, "should complete request")
+	require.True(td.t, gsmsg.IsTerminalFailureCode(lastRequest.result), "should terminate with failure")
+}
+
+func (td *testData) assertRequestDoesNotCompleteWhilePaused() {
+	timer := time.NewTimer(100 * time.Millisecond)
+	testutil.AssertDoesReceiveFirst(td.t, timer.C, "should not complete request while paused", td.completedRequestChan)
+}
+
+func (td *testData) assertReceiveExtensionResponse() {
+	var receivedExtension sentExtension
+	testutil.AssertReceive(td.ctx, td.t, td.sentExtensions, &receivedExtension, "should send extension response")
+	require.Equal(td.t, td.extensionResponse, receivedExtension.extension, "incorrect extension response sent")
+}
+
+func (td *testData) verifyNResponsesOnlyProcessing(blockCount int) {
+	for i := 0; i < blockCount; i++ {
+		testutil.AssertDoesReceive(td.ctx, td.t, td.sentResponses, "should sent block")
+	}
+	testutil.AssertChannelEmpty(td.t, td.sentResponses, "should not send more blocks")
+}
+
+func (td *testData) verifyNResponses(blockCount int) {
+	td.verifyNResponsesOnlyProcessing(blockCount)
+	td.notifyBlockSendsSent()
+	for i := 0; i < blockCount; i++ {
+		testutil.AssertDoesReceive(td.ctx, td.t, td.blockSends, "should sent block")
+	}
+	testutil.AssertChannelEmpty(td.t, td.blockSends, "should not send more blocks")
+}
+
+func (td *testData) assertDedupKey(key string) {
+	var dedupKey string
+	testutil.AssertReceive(td.ctx, td.t, td.dedupKeys, &dedupKey, "should dedup by key")
+	require.Equal(td.t, key, dedupKey)
+}
+
+func (td *testData) assertIgnoredCids(set *cid.Set) {
+	var lastLinks []ipld.Link
+	testutil.AssertReceive(td.ctx, td.t, td.ignoredLinks, &lastLinks, "should send ignored links")
+	require.Len(td.t, lastLinks, set.Len())
+	for _, link := range lastLinks {
+		require.True(td.t, set.Has(link.(cidlink.Link).Cid))
+	}
+}
+
+func (td *testData) notifyStatusMessagesSent() {
+	td.notifeePublisher.PublishMatchingEvents(func(topic notifications.Topic) bool {
+		_, isSn := topic.(statusNotification)
+		return isSn
+	}, []notifications.Event{peerresponsemanager.Event{Name: peerresponsemanager.Sent}})
+}
+
+func (td *testData) notifyBlockSendsSent() {
+	td.notifeePublisher.PublishMatchingEvents(func(topic notifications.Topic) bool {
+		_, isBsn := topic.(blockSentNotification)
+		return isBsn
+	}, []notifications.Event{peerresponsemanager.Event{Name: peerresponsemanager.Sent}})
+}
+
+func (td *testData) notifyStatusMessagesNetworkError(err error) {
+	td.notifeePublisher.PublishMatchingEvents(func(topic notifications.Topic) bool {
+		_, isSn := topic.(statusNotification)
+		return isSn
+	}, []notifications.Event{peerresponsemanager.Event{Name: peerresponsemanager.Error, Err: err}})
+}
+
+func (td *testData) notifyBlockSendsNetworkError(err error) {
+	td.notifeePublisher.PublishMatchingEvents(func(topic notifications.Topic) bool {
+		_, isBsn := topic.(blockSentNotification)
+		return isBsn
+	}, []notifications.Event{peerresponsemanager.Event{Name: peerresponsemanager.Error, Err: err}})
+}
+
+func (td *testData) assertNoCompletedResponseStatuses() {
+	testutil.AssertChannelEmpty(td.t, td.completedResponseStatuses, "should not send a complete notification")
+}
+
+func (td *testData) assertNetworkErrors(err error, count int) {
+	for i := 0; i < count; i++ {
+		td.assertHasNetworkErrors(err)
+	}
+	testutil.AssertChannelEmpty(td.t, td.networkErrorChan, "should not send more blocks")
+}
+
+func (td *testData) assertHasNetworkErrors(err error) {
+	var receivedErr error
+	testutil.AssertReceive(td.ctx, td.t, td.networkErrorChan, &receivedErr, "should sent block")
+	require.EqualError(td.t, receivedErr, err.Error())
 }

--- a/responsemanager/subscriber.go
+++ b/responsemanager/subscriber.go
@@ -1,0 +1,71 @@
+package responsemanager
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/notifications"
+	"github.com/ipfs/go-graphsync/responsemanager/peerresponsemanager"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+var errNetworkError = errors.New("network error")
+
+type subscriber struct {
+	ctx                   context.Context
+	messages              chan responseManagerMessage
+	blockSentListeners    BlockSentListeners
+	networkErrorListeners NetworkErrorListeners
+	completedListeners    CompletedListeners
+}
+
+type blockSentNotification struct {
+	p         peer.ID
+	requestID graphsync.RequestID
+	blockData graphsync.BlockData
+}
+
+type statusNotification struct {
+	p         peer.ID
+	requestID graphsync.RequestID
+	status    graphsync.ResponseStatusCode
+}
+
+func (s *subscriber) OnNext(topic notifications.Topic, event notifications.Event) {
+	responseEvent, ok := event.(peerresponsemanager.Event)
+	if !ok {
+		return
+	}
+	bsn, isBsn := topic.(blockSentNotification)
+	if isBsn {
+		switch responseEvent.Name {
+		case peerresponsemanager.Error:
+			s.networkErrorListeners.NotifyNetworkErrorListeners(bsn.p, bsn.requestID, responseEvent.Err)
+			select {
+			case s.messages <- &errorRequestMessage{bsn.p, bsn.requestID, errNetworkError, make(chan error, 1)}:
+			case <-s.ctx.Done():
+			}
+		case peerresponsemanager.Sent:
+			s.blockSentListeners.NotifyBlockSentListeners(bsn.p, bsn.requestID, bsn.blockData)
+		}
+		return
+	}
+	sn, isSn := topic.(statusNotification)
+	if isSn {
+		switch responseEvent.Name {
+		case peerresponsemanager.Error:
+			s.networkErrorListeners.NotifyNetworkErrorListeners(sn.p, sn.requestID, responseEvent.Err)
+			select {
+			case s.messages <- &errorRequestMessage{sn.p, sn.requestID, errNetworkError, make(chan error, 1)}:
+			case <-s.ctx.Done():
+			}
+		case peerresponsemanager.Sent:
+			s.completedListeners.NotifyCompletedListeners(sn.p, sn.requestID, sn.status)
+		}
+	}
+}
+
+func (s *subscriber) OnClose(topic notifications.Topic) {
+
+}

--- a/testutil/testnotifications.go
+++ b/testutil/testnotifications.go
@@ -1,0 +1,95 @@
+package testutil
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ipfs/go-graphsync/notifications"
+	"github.com/stretchr/testify/require"
+)
+
+type TestSubscriber struct {
+	expectedTopic  notifications.Topic
+	receivedEvents chan DispatchedEvent
+	closed         chan notifications.Topic
+}
+
+type DispatchedEvent struct {
+	Topic notifications.Topic
+	Event notifications.Event
+}
+
+func NewTestSubscriber(bufferSize int) *TestSubscriber {
+	return &TestSubscriber{
+		receivedEvents: make(chan DispatchedEvent, bufferSize),
+		closed:         make(chan notifications.Topic, bufferSize),
+	}
+}
+
+func (ts *TestSubscriber) OnNext(topic notifications.Topic, ev notifications.Event) {
+	ts.receivedEvents <- DispatchedEvent{topic, ev}
+}
+
+func (ts *TestSubscriber) OnClose(topic notifications.Topic) {
+	ts.closed <- topic
+}
+
+func (ts *TestSubscriber) ExpectEvents(ctx context.Context, t *testing.T, events []DispatchedEvent) {
+	for _, expectedEvent := range events {
+		var event DispatchedEvent
+		AssertReceive(ctx, t, ts.receivedEvents, &event, "should receive another event")
+		require.Equal(t, expectedEvent, event)
+	}
+}
+
+func (ts *TestSubscriber) NoEventsReceived(t *testing.T) {
+	AssertChannelEmpty(t, ts.receivedEvents, "should have received no events")
+}
+
+func (ts *TestSubscriber) ExpectClosesAnyOrder(ctx context.Context, t *testing.T, topics []notifications.Topic) {
+	expectedTopics := make(map[notifications.Topic]struct{})
+	receivedTopics := make(map[notifications.Topic]struct{})
+	for _, expectedTopic := range topics {
+		expectedTopics[expectedTopic] = struct{}{}
+		var topic notifications.Topic
+		AssertReceive(ctx, t, ts.closed, &topic, "should receive another event")
+		receivedTopics[topic] = struct{}{}
+	}
+	require.Equal(t, expectedTopics, receivedTopics)
+}
+
+func (ts *TestSubscriber) ExpectCloses(ctx context.Context, t *testing.T, topics []notifications.Topic) {
+	for _, expectedTopic := range topics {
+		var topic notifications.Topic
+		AssertReceive(ctx, t, ts.closed, &topic, "should receive another event")
+		require.Equal(t, expectedTopic, topic)
+	}
+}
+
+type NotifeeVerifier struct {
+	expectedTopic notifications.Topic
+	subscriber    *TestSubscriber
+}
+
+func (nv *NotifeeVerifier) ExpectEvents(ctx context.Context, t *testing.T, events []notifications.Event) {
+	dispatchedEvents := make([]DispatchedEvent, 0, len(events))
+	for _, ev := range events {
+		dispatchedEvents = append(dispatchedEvents, DispatchedEvent{nv.expectedTopic, ev})
+	}
+	nv.subscriber.ExpectEvents(ctx, t, dispatchedEvents)
+}
+
+func (nv *NotifeeVerifier) ExpectClose(ctx context.Context, t *testing.T) {
+	nv.subscriber.ExpectCloses(ctx, t, []notifications.Topic{nv.expectedTopic})
+}
+
+func NewTestNotifee(topic notifications.Topic, bufferSize int) (notifications.Notifee, *NotifeeVerifier) {
+	subscriber := NewTestSubscriber(bufferSize)
+	return notifications.Notifee{
+			Topic:      topic,
+			Subscriber: notifications.NewMappableSubscriber(subscriber, notifications.IdentityTransform),
+		}, &NotifeeVerifier{
+			expectedTopic: topic,
+			subscriber:    subscriber,
+		}
+}


### PR DESCRIPTION
# Goals

Provide a way on the responding side to know how much data has gone over the wire and to know when actual network errors occur

# Implementation

Essentially, or goal here is a pub-sub system to escalate asyncronous notifications back through the chain of callers to provide information to the response manager about what actually happened with data it attempted to send over the wire

- build a simple pub/sub topic system, with with a key feature -- the ability to remap topics -- I subscribe on one topic but receive notifications on another
- in the message queue, publish notifications when things happen with a message: it's queued, it's successfully sent, or an error occurs
- the the peer response sender use the queue event to insure one messages is processed at a time, and republish response sender events based of the message event
- in the response manager map semantically meaningful topics on to response sender events -- so that when we receive a sent or an error, we have all the information we need to react to it
- convert listeners to only taking the requestID -- it strikes me that someone listening should already have picked up the request ID from an incoming request hook. Also, this makes it much easier to pack relevant information into the topic
- listen for semantically meaningful events and now pass on to two new hooks -- OnBlockSentListener -- listens for when the block actually goes over the wire, and NetworkErrorListener -- listens for when a message going over the wire encounters an error
- refactor the peerresponsesender and response manager tests significantly -- these were both extremely verbose

# For Discussion

It's possible the notification system is unneccesarily complicated. It seems like a useful tool for the future though.