### PR TITLE
Shutdown notifications go routines

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -111,6 +111,8 @@ func (mq *MessageQueue) Shutdown() {
 }
 
 func (mq *MessageQueue) runQueue() {
+	defer mq.eventPublisher.Shutdown()
+	mq.eventPublisher.Startup()
 	for {
 		select {
 		case <-mq.outgoingWork:

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -147,6 +147,7 @@ func TestProcessingNotification(t *testing.T) {
 	messageNetwork := &fakeMessageNetwork{nil, nil, messageSender, &waitGroup}
 
 	messageQueue := New(ctx, peer, messageNetwork)
+	messageQueue.Startup()
 	waitGroup.Add(1)
 	blks := testutil.GenerateBlocksOfSize(3, 128)
 
@@ -164,7 +165,6 @@ func TestProcessingNotification(t *testing.T) {
 	messageQueue.AddResponses(newMessage.Responses(), blks, notifee)
 
 	// wait for send attempt
-	messageQueue.Startup()
 	waitGroup.Wait()
 
 	var message gsmsg.GraphSyncMessage

--- a/notifications/notifications_test.go
+++ b/notifications/notifications_test.go
@@ -143,7 +143,9 @@ func TestSubscribeOn(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 			defer cancel()
 			ps := notifications.NewPublisher()
+			ps.Startup()
 			testPublisher(ctx, t, ps)
+			ps.Shutdown()
 		})
 	}
 

--- a/notifications/publisher.go
+++ b/notifications/publisher.go
@@ -32,8 +32,11 @@ func NewPublisher() Publisher {
 		cmdChan: make(chan cmd),
 		closed:  make(chan struct{}),
 	}
-	go ps.start()
 	return ps
+}
+
+func (ps *publisher) Startup() {
+	go ps.start()
 }
 
 // Publish publishes an event for the given message id

--- a/notifications/types.go
+++ b/notifications/types.go
@@ -30,6 +30,7 @@ type Publisher interface {
 	Close(Topic)
 	Publish(Topic, Event)
 	Shutdown()
+	Startup()
 	Subscribable
 }
 

--- a/responsemanager/peerresponsemanager/peerresponsesender.go
+++ b/responsemanager/peerresponsemanager/peerresponsesender.go
@@ -416,6 +416,8 @@ func (prs *peerResponseSender) signalWork() {
 }
 
 func (prs *peerResponseSender) run() {
+	defer prs.publisher.Shutdown()
+	prs.publisher.Startup()
 	for {
 		select {
 		case <-prs.ctx.Done():


### PR DESCRIPTION
# Goals

Resolve go routine leak for notifications publishers

# Implementation

- write a benchmark that simulates the conditions where we are seeing this go routine leak
- add a Startup() method to the publisher and don't start go routine automatically (not essential but generally we try not to start go-routines in constructors
- call Shutdown() on the publisher whenever the module using it shuts down (MessageQueue & PeerResponseSender)

Benchmark results before:

```
go test -v -bench=BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000$ --memprofile=profile.out --cpuprofile=cpu.out
goos: darwin
goarch: amd64
pkg: github.com/ipfs/go-graphsync/benchmarks
BenchmarkRoundtripSuccess
BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000
    benchmark_test.go:130: Number of running go-routines: 866
    benchmark_test.go:130: Number of running go-routines: 2447
    benchmark_test.go:130: Number of running go-routines: 9548
    benchmark_test.go:130: Number of running go-routines: 25369
    benchmark_test.go:130: Number of running go-routines: 44630
BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000-16         	     231	   5326464 ns/op	 4678319 B/op	   69275 allocs/op
PASS
ok  	github.com/ipfs/go-graphsync/benchmarks	5.007s
```

Benchmark results afterward (wonder what is causing the remaining go routines to still be running... though also this may be coming from some of the dependencies and not graphsync itself):

```
go test -v -bench=BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000$ --memprofile=profile.out --cpuprofile=cpu.out
goos: darwin
goarch: amd64
pkg: github.com/ipfs/go-graphsync/benchmarks
BenchmarkRoundtripSuccess
BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000
    benchmark_test.go:130: Number of running go-routines: 26
    benchmark_test.go:130: Number of running go-routines: 47
    benchmark_test.go:130: Number of running go-routines: 68
    benchmark_test.go:130: Number of running go-routines: 89
BenchmarkRoundtripSuccess/test-repeated-disconnects-20-10000-16         	     213	   4750892 ns/op	 4646892 B/op	   69192 allocs/op
PASS
ok  	github.com/ipfs/go-graphsync/benchmarks	2.819s
```