### PR TITLE
Improve memory usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/ipld/go-ipld-prime-proto v0.1.0
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/jbenet/goprocess v0.1.4 // indirect
+	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/libp2p/go-libp2p v0.6.0
 	github.com/libp2p/go-libp2p-core v0.5.0
 	github.com/libp2p/go-libp2p-netutil v0.1.0

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
@@ -6,6 +6,10 @@ import (
 	ipld "github.com/ipld/go-ipld-prime"
 )
 
+type settableWriter interface {
+	SetBytes([]byte) error
+}
+
 // UnverifiedBlockStore holds an in memory cache of receied blocks from the network
 // that have not been verified to be part of a traversal
 type UnverifiedBlockStore struct {
@@ -55,7 +59,11 @@ func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	_, err = buffer.Write(data)
+	if settable, ok := buffer.(settableWriter); ok {
+		err = settable.SetBytes(data)
+	} else {
+		_, err = buffer.Write(data)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/storeutil/storeutil.go
+++ b/storeutil/storeutil.go
@@ -31,7 +31,7 @@ func LoaderForBlockstore(bs bstore.Blockstore) ipld.Loader {
 // from an IPFS blockstore
 func StorerForBlockstore(bs bstore.Blockstore) ipld.Storer {
 	return func(lnkCtx ipld.LinkContext) (io.Writer, ipld.StoreCommitter, error) {
-		var buffer bytes.Buffer
+		var buffer settableBuffer
 		committer := func(lnk ipld.Link) error {
 			asCidLink, ok := lnk.(cidlink.Link)
 			if !ok {
@@ -45,4 +45,23 @@ func StorerForBlockstore(bs bstore.Blockstore) ipld.Storer {
 		}
 		return &buffer, committer, nil
 	}
+}
+
+type settableBuffer struct {
+	bytes.Buffer
+	didSetData bool
+	data       []byte
+}
+
+func (sb *settableBuffer) SetBytes(data []byte) error {
+	sb.didSetData = true
+	sb.data = data
+	return nil
+}
+
+func (sb *settableBuffer) Bytes() []byte {
+	if sb.didSetData {
+		return sb.data
+	}
+	return sb.Buffer.Bytes()
 }


### PR DESCRIPTION
# Goals

Remove some unneccesary mem copies identified in testing. Specifically:

# Implementation

- The `go-ipld-prime` Storer interface has an unneccesary copy of block bytes due to the need to create a bytes.Buffer to mimic an io.Writer. This creates a shortcut around that and implements it by default for the StorerFromBlockstore method
- When we switched to google's protobuf library, we didn't implement logic to avoid temporary buffers when writing protobuff message. This implements that using go-buffer-bool (similar to go-bitswap)