### PR TITLE
fix(notifications): fix lock in close

### DIFF
--- a/notifications/publisher.go
+++ b/notifications/publisher.go
@@ -66,6 +66,13 @@ func (ps *publisher) Shutdown() {
 }
 
 func (ps *publisher) Close(id Topic) {
+	ps.lk.RLock()
+	defer ps.lk.RUnlock()
+	select {
+	case <-ps.closed:
+		return
+	default:
+	}
 	ps.cmdChan <- cmd{op: closeTopic, topics: []Topic{id}}
 }
 


### PR DESCRIPTION
# Goals

To support shutdowns of the publisher we have a lock and channel check on every method of publisher. However, for Close we forgot... and this did lead to a lock.

# Implementation

add check if publisher is shutdown to Close method