### PR TITLE
RegisterNetworkErrorListener should fire when there's an error connecting to the peer

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -113,7 +113,8 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	incomingResponseHooks := requestorhooks.NewResponseHooks()
 	outgoingRequestHooks := requestorhooks.NewRequestHooks()
 	incomingBlockHooks := requestorhooks.NewBlockHooks()
-	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks)
+	networkErrorListeners := responderhooks.NewNetworkErrorListeners()
+	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
 	peerTaskQueue := peertaskqueue.New()
 
 	persistenceOptions := persistenceoptions.New()
@@ -123,7 +124,6 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	completedResponseListeners := responderhooks.NewCompletedResponseListeners()
 	requestorCancelledListeners := responderhooks.NewRequestorCancelledListeners()
 	blockSentListeners := responderhooks.NewBlockSentListeners()
-	networkErrorListeners := responderhooks.NewNetworkErrorListeners()
 	unregisterDefaultValidator := incomingRequestHooks.Register(selectorvalidator.SelectorValidator(maxRecursionDepth))
 	graphSync := &GraphSync{
 		network:                     network,

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -9,6 +9,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/listeners"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/messagequeue"
 	gsnet "github.com/ipfs/go-graphsync/network"
@@ -46,10 +47,10 @@ type GraphSync struct {
 	incomingRequestHooks        *responderhooks.IncomingRequestHooks
 	outgoingBlockHooks          *responderhooks.OutgoingBlockHooks
 	requestUpdatedHooks         *responderhooks.RequestUpdatedHooks
-	completedResponseListeners  *responderhooks.CompletedResponseListeners
-	requestorCancelledListeners *responderhooks.RequestorCancelledListeners
-	blockSentListeners          *responderhooks.BlockSentListeners
-	networkErrorListeners       *responderhooks.NetworkErrorListeners
+	completedResponseListeners  *listeners.CompletedResponseListeners
+	requestorCancelledListeners *listeners.RequestorCancelledListeners
+	blockSentListeners          *listeners.BlockSentListeners
+	networkErrorListeners       *listeners.NetworkErrorListeners
 	incomingResponseHooks       *requestorhooks.IncomingResponseHooks
 	outgoingRequestHooks        *requestorhooks.OutgoingRequestHooks
 	incomingBlockHooks          *requestorhooks.IncomingBlockHooks
@@ -113,7 +114,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	incomingResponseHooks := requestorhooks.NewResponseHooks()
 	outgoingRequestHooks := requestorhooks.NewRequestHooks()
 	incomingBlockHooks := requestorhooks.NewBlockHooks()
-	networkErrorListeners := responderhooks.NewNetworkErrorListeners()
+	networkErrorListeners := listeners.NewNetworkErrorListeners()
 	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
 	peerTaskQueue := peertaskqueue.New()
 
@@ -121,9 +122,9 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	incomingRequestHooks := responderhooks.NewRequestHooks(persistenceOptions)
 	outgoingBlockHooks := responderhooks.NewBlockHooks()
 	requestUpdatedHooks := responderhooks.NewUpdateHooks()
-	completedResponseListeners := responderhooks.NewCompletedResponseListeners()
-	requestorCancelledListeners := responderhooks.NewRequestorCancelledListeners()
-	blockSentListeners := responderhooks.NewBlockSentListeners()
+	completedResponseListeners := listeners.NewCompletedResponseListeners()
+	requestorCancelledListeners := listeners.NewRequestorCancelledListeners()
+	blockSentListeners := listeners.NewBlockSentListeners()
 	unregisterDefaultValidator := incomingRequestHooks.Register(selectorvalidator.SelectorValidator(maxRecursionDepth))
 	graphSync := &GraphSync{
 		network:                     network,

--- a/listeners/listeners.go
+++ b/listeners/listeners.go
@@ -1,4 +1,4 @@
-package hooks
+package listeners
 
 import (
 	"github.com/hannahhoward/go-pubsub"

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
-	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/requestmanager/executor"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/testloader"
@@ -378,7 +377,7 @@ func (ree *requestExecutionEnv) waitForResume() ([]graphsync.ExtensionData, erro
 	return extensions, nil
 }
 
-func (ree *requestExecutionEnv) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest, notifees ...notifications.Notifee) {
+func (ree *requestExecutionEnv) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
 	ree.requestsSent = append(ree.requestsSent, requestSent{p, request})
 	if ree.currentWaitForResumeResult < len(ree.loaderRanges) && !request.IsCancel() {
 		ree.configureLoader(ree.p, ree.request.ID(), ree.tbc, ree.fal, ree.loaderRanges[ree.currentWaitForResumeResult])

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -562,9 +562,11 @@ func (r *reqSubscriber) OnNext(topic notifications.Topic, event notifications.Ev
 func (r reqSubscriber) OnClose(topic notifications.Topic) {
 }
 
+const requestNetworkError = "request_network_error"
+
 func (rm *RequestManager) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
-	sub := notifications.NewMappableSubscriber(&reqSubscriber{p, request, rm.networkErrorListeners}, notifications.IdentityTransform)
-	failNotifee := notifications.Notifee{Topic: messagequeue.Error, Subscriber: sub}
+	sub := notifications.NewTopicDataSubscriber(&reqSubscriber{p, request, rm.networkErrorListeners})
+	failNotifee := notifications.Notifee{Data: requestNetworkError, Subscriber: sub}
 	rm.peerHandler.SendRequest(p, request, failNotifee)
 }
 

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-graphsync/listeners"
-	"github.com/ipfs/go-graphsync/responsemanager"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipld/go-ipld-prime"
@@ -878,7 +877,7 @@ type testData struct {
 	extensionName2        graphsync.ExtensionName
 	extensionData2        []byte
 	extension2            graphsync.ExtensionData
-	networkErrorListeners responsemanager.NetworkErrorListeners
+	networkErrorListeners *listeners.NetworkErrorListeners
 }
 
 func newTestData(ctx context.Context, t *testing.T) *testData {

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/ipfs/go-graphsync/responsemanager"
-	responderhooks "github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"testing"
 	"time"
+
+	"github.com/ipfs/go-graphsync/listeners"
+	"github.com/ipfs/go-graphsync/responsemanager"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipld/go-ipld-prime"
@@ -888,7 +889,7 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td.requestHooks = hooks.NewRequestHooks()
 	td.responseHooks = hooks.NewResponseHooks()
 	td.blockHooks = hooks.NewBlockHooks()
-	td.networkErrorListeners = responderhooks.NewNetworkErrorListeners()
+	td.networkErrorListeners = listeners.NewNetworkErrorListeners()
 	td.requestManager = New(ctx, td.fal, td.requestHooks, td.responseHooks, td.blockHooks, td.networkErrorListeners)
 	td.requestManager.SetDelegate(td.fph)
 	td.requestManager.Startup()

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/ipfs/go-graphsync/responsemanager"
+	responderhooks "github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"testing"
 	"time"
 
@@ -858,23 +860,24 @@ func TestPauseResumeExternal(t *testing.T) {
 }
 
 type testData struct {
-	requestRecordChan chan requestRecord
-	fph               *fakePeerHandler
-	fal               *testloader.FakeAsyncLoader
-	requestHooks      *hooks.OutgoingRequestHooks
-	responseHooks     *hooks.IncomingResponseHooks
-	blockHooks        *hooks.IncomingBlockHooks
-	requestManager    *RequestManager
-	blockStore        map[ipld.Link][]byte
-	loader            ipld.Loader
-	storer            ipld.Storer
-	blockChain        *testutil.TestBlockChain
-	extensionName1    graphsync.ExtensionName
-	extensionData1    []byte
-	extension1        graphsync.ExtensionData
-	extensionName2    graphsync.ExtensionName
-	extensionData2    []byte
-	extension2        graphsync.ExtensionData
+	requestRecordChan     chan requestRecord
+	fph                   *fakePeerHandler
+	fal                   *testloader.FakeAsyncLoader
+	requestHooks          *hooks.OutgoingRequestHooks
+	responseHooks         *hooks.IncomingResponseHooks
+	blockHooks            *hooks.IncomingBlockHooks
+	requestManager        *RequestManager
+	blockStore            map[ipld.Link][]byte
+	loader                ipld.Loader
+	storer                ipld.Storer
+	blockChain            *testutil.TestBlockChain
+	extensionName1        graphsync.ExtensionName
+	extensionData1        []byte
+	extension1            graphsync.ExtensionData
+	extensionName2        graphsync.ExtensionName
+	extensionData2        []byte
+	extension2            graphsync.ExtensionData
+	networkErrorListeners responsemanager.NetworkErrorListeners
 }
 
 func newTestData(ctx context.Context, t *testing.T) *testData {
@@ -885,7 +888,8 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td.requestHooks = hooks.NewRequestHooks()
 	td.responseHooks = hooks.NewResponseHooks()
 	td.blockHooks = hooks.NewBlockHooks()
-	td.requestManager = New(ctx, td.fal, td.requestHooks, td.responseHooks, td.blockHooks)
+	td.networkErrorListeners = responderhooks.NewNetworkErrorListeners()
+	td.requestManager = New(ctx, td.fal, td.requestHooks, td.responseHooks, td.blockHooks, td.networkErrorListeners)
 	td.requestManager.SetDelegate(td.fph)
 	td.requestManager.Startup()
 	td.blockStore = make(map[ipld.Link][]byte)

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/dedupkey"
+	"github.com/ipfs/go-graphsync/listeners"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/responsemanager/hooks"
@@ -886,10 +887,10 @@ type testData struct {
 	requestHooks              *hooks.IncomingRequestHooks
 	blockHooks                *hooks.OutgoingBlockHooks
 	updateHooks               *hooks.RequestUpdatedHooks
-	completedListeners        *hooks.CompletedResponseListeners
-	cancelledListeners        *hooks.RequestorCancelledListeners
-	blockSentListeners        *hooks.BlockSentListeners
-	networkErrorListeners     *hooks.NetworkErrorListeners
+	completedListeners        *listeners.CompletedResponseListeners
+	cancelledListeners        *listeners.RequestorCancelledListeners
+	blockSentListeners        *listeners.BlockSentListeners
+	networkErrorListeners     *listeners.NetworkErrorListeners
 	notifeePublisher          *testutil.MockPublisher
 	blockSends                chan graphsync.BlockData
 	completedResponseStatuses chan graphsync.ResponseStatusCode
@@ -960,10 +961,10 @@ func newTestData(t *testing.T) testData {
 	td.requestHooks = hooks.NewRequestHooks(td.peristenceOptions)
 	td.blockHooks = hooks.NewBlockHooks()
 	td.updateHooks = hooks.NewUpdateHooks()
-	td.completedListeners = hooks.NewCompletedResponseListeners()
-	td.cancelledListeners = hooks.NewRequestorCancelledListeners()
-	td.blockSentListeners = hooks.NewBlockSentListeners()
-	td.networkErrorListeners = hooks.NewNetworkErrorListeners()
+	td.completedListeners = listeners.NewCompletedResponseListeners()
+	td.cancelledListeners = listeners.NewRequestorCancelledListeners()
+	td.blockSentListeners = listeners.NewBlockSentListeners()
+	td.networkErrorListeners = listeners.NewNetworkErrorListeners()
 	td.completedListeners.Register(func(p peer.ID, requestID graphsync.RequestData, status graphsync.ResponseStatusCode) {
 		select {
 		case td.completedResponseStatuses <- status:


### PR DESCRIPTION
Fixes https://github.com/ipfs/go-graphsync/issues/124

This PR adds a test case, and a WIP implementation.
@hannahhoward I'm not sure if the implementation follows the pattern for how these cases are normally handled to feel free to change.