### PR TITLE
Add error listener on receiver

### DIFF
--- a/benchmarks/testnet/network_test.go
+++ b/benchmarks/testnet/network_test.go
@@ -89,7 +89,7 @@ func (lam *lambdaImpl) ReceiveMessage(ctx context.Context,
 	lam.f(ctx, p, incoming)
 }
 
-func (lam *lambdaImpl) ReceiveError(err error) {
+func (lam *lambdaImpl) ReceiveError(_ peer.ID, _ error) {
 	// TODO log error
 }
 

--- a/graphsync.go
+++ b/graphsync.go
@@ -343,6 +343,9 @@ type GraphExchange interface {
 	// RegisterNetworkErrorListener adds a listener for when errors occur sending data over the wire
 	RegisterNetworkErrorListener(listener OnNetworkErrorListener) UnregisterHookFunc
 
+	// RegisterNetworkErrorListener adds a listener for when errors occur sending data over the wire
+	RegisterReceiverNetworkErrorListener(listener OnReceiverNetworkErrorListener) UnregisterHookFunc
+
 	// UnpauseRequest unpauses a request that was paused in a block hook based request ID
 	// Can also send extensions with unpause
 	UnpauseRequest(RequestID, ...ExtensionData) error

--- a/graphsync.go
+++ b/graphsync.go
@@ -289,6 +289,9 @@ type OnBlockSentListener func(p peer.ID, request RequestData, block BlockData)
 // OnNetworkErrorListener runs when queued data is not able to be sent
 type OnNetworkErrorListener func(p peer.ID, request RequestData, err error)
 
+// OnNetworkErrorListener runs when queued data is not able to be received
+type OnReceiverNetworkErrorListener func(p peer.ID, err error)
+
 // OnResponseCompletedListener provides a way to listen for when responder has finished serving a response
 type OnResponseCompletedListener func(p peer.ID, request RequestData, status ResponseStatusCode)
 

--- a/graphsync.go
+++ b/graphsync.go
@@ -289,7 +289,7 @@ type OnBlockSentListener func(p peer.ID, request RequestData, block BlockData)
 // OnNetworkErrorListener runs when queued data is not able to be sent
 type OnNetworkErrorListener func(p peer.ID, request RequestData, err error)
 
-// OnNetworkErrorListener runs when queued data is not able to be received
+// OnReceiverNetworkErrorListener runs when errors occur receiving data over the wire
 type OnReceiverNetworkErrorListener func(p peer.ID, err error)
 
 // OnResponseCompletedListener provides a way to listen for when responder has finished serving a response

--- a/graphsync.go
+++ b/graphsync.go
@@ -343,7 +343,7 @@ type GraphExchange interface {
 	// RegisterNetworkErrorListener adds a listener for when errors occur sending data over the wire
 	RegisterNetworkErrorListener(listener OnNetworkErrorListener) UnregisterHookFunc
 
-	// RegisterNetworkErrorListener adds a listener for when errors occur sending data over the wire
+	// RegisterReceiverNetworkErrorListener adds a listener for when errors occur receiving data over the wire
 	RegisterReceiverNetworkErrorListener(listener OnReceiverNetworkErrorListener) UnregisterHookFunc
 
 	// UnpauseRequest unpauses a request that was paused in a block hook based request ID

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -51,7 +51,7 @@ type GraphSync struct {
 	requestorCancelledListeners *listeners.RequestorCancelledListeners
 	blockSentListeners          *listeners.BlockSentListeners
 	networkErrorListeners       *listeners.NetworkErrorListeners
-	receiverErrorListeners      *listeners.NetworkErrorListeners
+	receiverErrorListeners      *listeners.NetworkReceiverErrorListeners
 	incomingResponseHooks       *requestorhooks.IncomingResponseHooks
 	outgoingRequestHooks        *requestorhooks.OutgoingRequestHooks
 	incomingBlockHooks          *requestorhooks.IncomingBlockHooks
@@ -255,7 +255,7 @@ func (gs *GraphSync) RegisterNetworkErrorListener(listener graphsync.OnNetworkEr
 }
 
 // RegisterReceiverNetworkErrorListener adds a listener for when errors occur receiving data over the wire
-func (gs *GraphSync) RegisterReceiverNetworkErrorListener(listener graphsync.OnNetworkErrorListener) graphsync.UnregisterHookFunc {
+func (gs *GraphSync) RegisterReceiverNetworkErrorListener(listener graphsync.OnReceiverNetworkErrorListener) graphsync.UnregisterHookFunc {
 	return gs.receiverErrorListeners.Register(listener)
 }
 
@@ -305,7 +305,7 @@ func (gsr *graphSyncReceiver) ReceiveMessage(
 // errors from the network.
 func (gsr *graphSyncReceiver) ReceiveError(p peer.ID, err error) {
 	log.Infof("Graphsync ReceiveError from %s: %s", p, err)
-	gsr.receiverErrorListeners.NotifyReceiverNetworkErrorListeners(p, err)
+	gsr.receiverErrorListeners.NotifyNetworkErrorListeners(p, err)
 }
 
 // Connected is part of the networks 's Receiver interface and handles peers connecting

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -51,6 +51,7 @@ type GraphSync struct {
 	requestorCancelledListeners *listeners.RequestorCancelledListeners
 	blockSentListeners          *listeners.BlockSentListeners
 	networkErrorListeners       *listeners.NetworkErrorListeners
+	receiverErrorListeners      *listeners.NetworkErrorListeners
 	incomingResponseHooks       *requestorhooks.IncomingResponseHooks
 	outgoingRequestHooks        *requestorhooks.OutgoingRequestHooks
 	incomingBlockHooks          *requestorhooks.IncomingBlockHooks
@@ -115,6 +116,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	outgoingRequestHooks := requestorhooks.NewRequestHooks()
 	incomingBlockHooks := requestorhooks.NewBlockHooks()
 	networkErrorListeners := listeners.NewNetworkErrorListeners()
+	receiverErrorListeners := listeners.NewReceiverNetworkErrorListeners()
 	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
 	peerTaskQueue := peertaskqueue.New()
 
@@ -141,6 +143,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		requestorCancelledListeners: requestorCancelledListeners,
 		blockSentListeners:          blockSentListeners,
 		networkErrorListeners:       networkErrorListeners,
+		receiverErrorListeners:      receiverErrorListeners,
 		incomingResponseHooks:       incomingResponseHooks,
 		outgoingRequestHooks:        outgoingRequestHooks,
 		incomingBlockHooks:          incomingBlockHooks,
@@ -251,6 +254,11 @@ func (gs *GraphSync) RegisterNetworkErrorListener(listener graphsync.OnNetworkEr
 	return gs.networkErrorListeners.Register(listener)
 }
 
+// RegisterReceiverNetworkErrorListener adds a listener for when errors occur receiving data over the wire
+func (gs *GraphSync) RegisterReceiverNetworkErrorListener(listener graphsync.OnNetworkErrorListener) graphsync.UnregisterHookFunc {
+	return gs.receiverErrorListeners.Register(listener)
+}
+
 // UnpauseRequest unpauses a request that was paused in a block hook based request ID
 // Can also send extensions with unpause
 func (gs *GraphSync) UnpauseRequest(requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
@@ -295,10 +303,9 @@ func (gsr *graphSyncReceiver) ReceiveMessage(
 
 // ReceiveError is part of the network's Receiver interface and handles incoming
 // errors from the network.
-func (gsr *graphSyncReceiver) ReceiveError(err error) {
-	log.Infof("Graphsync ReceiveError: %s", err)
-	// TODO log the network error
-	// TODO bubble the network error up to the parent context/error logger
+func (gsr *graphSyncReceiver) ReceiveError(p peer.ID, err error) {
+	log.Infof("Graphsync ReceiveError from %s: %s", p, err)
+	gsr.receiverErrorListeners.NotifyReceiverNetworkErrorListeners(p, err)
 }
 
 // Connected is part of the networks 's Receiver interface and handles peers connecting

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -1131,7 +1131,7 @@ func (r *receiver) ReceiveMessage(
 	}
 }
 
-func (r *receiver) ReceiveError(err error) {
+func (r *receiver) ReceiveError(_ peer.ID, err error) {
 }
 
 func (r *receiver) Connected(p peer.ID) {

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -593,7 +593,7 @@ func TestNetworkDisconnect(t *testing.T) {
 	receiverError := make(chan error, 1)
 	requestor.RegisterReceiverNetworkErrorListener(func(p peer.ID, err error) {
 		select {
-		case networkError <- err:
+		case receiverError <- err:
 		default:
 		}
 	})
@@ -615,8 +615,8 @@ func TestNetworkDisconnect(t *testing.T) {
 
 	testutil.AssertReceive(ctx, t, networkError, &err, "should receive network error")
 	testutil.AssertReceive(ctx, t, errChan, &err, "should receive an error")
-	testutil.AssertReceive(ctx, t, receiverError, &err, "should receive an error on receiver side")
 	require.EqualError(t, err, graphsync.RequestContextCancelledErr{}.Error())
+	testutil.AssertReceive(ctx, t, receiverError, &err, "should receive an error on receiver side")
 }
 
 func TestConnectFail(t *testing.T) {

--- a/listeners/listeners.go
+++ b/listeners/listeners.go
@@ -138,7 +138,7 @@ func (nel *NetworkErrorListeners) NotifyNetworkErrorListeners(p peer.ID, request
 	_ = nel.pubSub.Publish(internalNetworkErrorEvent{p, request, err})
 }
 
-// ReceiverNetworkErrorListeners is a set of listeners for network errors on the receiving side
+// NetworkReceiverErrorListeners is a set of listeners for network errors on the receiving side
 type NetworkReceiverErrorListeners struct {
 	pubSub *pubsub.PubSub
 }

--- a/network/interface.go
+++ b/network/interface.go
@@ -23,7 +23,7 @@ type GraphSyncNetwork interface {
 		peer.ID,
 		gsmsg.GraphSyncMessage) error
 
-	// SetDelegate registers the Reciver to handle messages received from the
+	// SetDelegate registers the Receiver to handle messages received from the
 	// network.
 	SetDelegate(Receiver)
 
@@ -47,7 +47,7 @@ type Receiver interface {
 		sender peer.ID,
 		incoming gsmsg.GraphSyncMessage)
 
-	ReceiveError(error)
+	ReceiveError(p peer.ID, err error)
 
 	Connected(p peer.ID)
 	Disconnected(p peer.ID)

--- a/network/libp2p_impl.go
+++ b/network/libp2p_impl.go
@@ -134,16 +134,17 @@ func (gsnet *libp2pGraphSyncNetwork) handleNewStream(s network.Stream) {
 	reader := msgio.NewVarintReaderSize(s, network.MessageSizeMax)
 	for {
 		received, err := gsmsg.FromMsgReader(reader)
+		p := s.Conn().RemotePeer()
+
 		if err != nil {
 			if err != io.EOF {
 				_ = s.Reset()
-				go gsnet.receiver.ReceiveError(err)
+				go gsnet.receiver.ReceiveError(p, err)
 				log.Debugf("graphsync net handleNewStream from %s error: %s", s.Conn().RemotePeer(), err)
 			}
 			return
 		}
 
-		p := s.Conn().RemotePeer()
 		ctx := context.Background()
 		log.Debugf("graphsync net handleNewStream from %s", s.Conn().RemotePeer())
 		gsnet.receiver.ReceiveMessage(ctx, p, received)

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -37,7 +37,7 @@ func (r *receiver) ReceiveMessage(
 	}
 }
 
-func (r *receiver) ReceiveError(err error) {
+func (r *receiver) ReceiveError(_ peer.ID, _ error) {
 }
 
 func (r *receiver) Connected(p peer.ID) {


### PR DESCRIPTION
# Goals

fix #129 

# Implementation

- Add new RegisterReceiveNetworkErrorListener hook
- Modify ReceiveError method on network interface to pass peer
- Call ReceiverNetworkErrorListeners in ReceiveError callback