### PR TITLE
Additional changes to response assembler refactor

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -41,7 +41,7 @@ type GraphSync struct {
 	requestManager              *requestmanager.RequestManager
 	responseManager             *responsemanager.ResponseManager
 	asyncLoader                 *asyncloader.AsyncLoader
-	peerResponseManager         *responseassembler.ResponseAssembler
+	responseAssembler           *responseassembler.ResponseAssembler
 	peerTaskQueue               *peertaskqueue.PeerTaskQueue
 	peerManager                 *peermanager.PeerMessageManager
 	incomingRequestHooks        *responderhooks.IncomingRequestHooks
@@ -141,9 +141,9 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	asyncLoader := asyncloader.New(ctx, loader, storer)
 	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
-	peerResponseManager := responseassembler.New(ctx, allocator, peerManager)
+	responseAssembler := responseassembler.New(ctx, allocator, peerManager)
 	peerTaskQueue := peertaskqueue.New()
-	responseManager := responsemanager.New(ctx, loader, peerResponseManager, peerTaskQueue, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressRequests)
+	responseManager := responsemanager.New(ctx, loader, responseAssembler, peerTaskQueue, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressRequests)
 	graphSync := &GraphSync{
 		network:                     network,
 		loader:                      loader,
@@ -151,7 +151,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		requestManager:              requestManager,
 		responseManager:             responseManager,
 		asyncLoader:                 asyncLoader,
-		peerResponseManager:         peerResponseManager,
+		responseAssembler:           responseAssembler,
 		peerTaskQueue:               peerTaskQueue,
 		peerManager:                 peerManager,
 		incomingRequestHooks:        incomingRequestHooks,

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -135,6 +135,9 @@ func (mq *MessageQueue) runQueue() {
 		case <-mq.outgoingWork:
 			mq.sendMessage()
 		case <-mq.done:
+			// our queue is shutting down, so we should check for any pending messages, and propogate a network error
+			// a shutting down queue implies a network disconnect -- so it's important that anyone who is expecting these
+			// messages to go through is notified of the disconnect
 			select {
 			case <-mq.outgoingWork:
 				for {

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -267,3 +267,61 @@ func TestDedupingMessages(t *testing.T) {
 		}
 	}
 }
+
+func TestResponseAssemblerSendsVeryLargeBlocksResponses(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	peer := testutil.GeneratePeers(1)[0]
+	messagesSent := make(chan gsmsg.GraphSyncMessage)
+	resetChan := make(chan struct{}, 1)
+	fullClosedChan := make(chan struct{}, 1)
+	messageSender := &fakeMessageSender{nil, fullClosedChan, resetChan, messagesSent}
+	var waitGroup sync.WaitGroup
+	messageNetwork := &fakeMessageNetwork{nil, nil, messageSender, &waitGroup}
+	allocator := allocator2.NewAllocator(1<<30, 1<<30)
+
+	messageQueue := New(ctx, peer, messageNetwork, allocator)
+	messageQueue.Startup()
+	waitGroup.Add(1)
+
+	// generate large blocks before proceeding
+	blks := testutil.GenerateBlocksOfSize(5, 1000000)
+	messageQueue.BuildMessage(uint64(len(blks[0].RawData())), func(b *gsmsg.Builder) {
+		b.AddBlock(blks[0])
+	}, []notifications.Notifee{})
+	waitGroup.Wait()
+	var message gsmsg.GraphSyncMessage
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message did not send")
+
+	msgBlks := message.Blocks()
+	require.Len(t, msgBlks, 1, "number of blks in first message was not 1")
+	require.True(t, blks[0].Cid().Equals(msgBlks[0].Cid()))
+
+	// Send 3 very large blocks
+	messageQueue.BuildMessage(uint64(len(blks[1].RawData())), func(b *gsmsg.Builder) {
+		b.AddBlock(blks[1])
+	}, []notifications.Notifee{})
+	messageQueue.BuildMessage(uint64(len(blks[2].RawData())), func(b *gsmsg.Builder) {
+		b.AddBlock(blks[2])
+	}, []notifications.Notifee{})
+	messageQueue.BuildMessage(uint64(len(blks[3].RawData())), func(b *gsmsg.Builder) {
+		b.AddBlock(blks[3])
+	}, []notifications.Notifee{})
+
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message did not send")
+	msgBlks = message.Blocks()
+	require.Len(t, msgBlks, 1, "number of blks in first message was not 1")
+	require.True(t, blks[1].Cid().Equals(msgBlks[0].Cid()))
+
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message did not send")
+	msgBlks = message.Blocks()
+	require.Len(t, msgBlks, 1, "number of blks in first message was not 1")
+	require.True(t, blks[2].Cid().Equals(msgBlks[0].Cid()))
+
+	testutil.AssertReceive(ctx, t, messagesSent, &message, "message did not send")
+	msgBlks = message.Blocks()
+	require.Len(t, msgBlks, 1, "number of blks in first message was not 1")
+	require.True(t, blks[3].Cid().Equals(msgBlks[0].Cid()))
+}

--- a/responsemanager/responseassembler/peerresponsebuilder_test.go
+++ b/responsemanager/responseassembler/peerresponsebuilder_test.go
@@ -44,7 +44,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	var bd1, bd2 graphsync.BlockData
 
 	// send block 0 for request 1
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.AddNotifee(sendResponseNotifee1)
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
@@ -55,7 +55,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	fph.AssertNotifees(sendResponseNotifee1)
 
 	// send block 0 for request 2 (duplicate block should not be sent)
-	require.NoError(t, responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		b.AddNotifee(sendResponseNotifee2)
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
@@ -65,7 +65,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	fph.AssertNotifees(sendResponseNotifee2)
 
 	// send more to request 1 and finish request
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		// send block 1
 		bd1 = b.SendResponse(links[1], blks[1].RawData())
 		// block 2 is not found. Assert not sent
@@ -81,7 +81,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	})
 
 	// send more to request 2
-	require.NoError(t, responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[3], blks[3].RawData())
 		b.FinishRequest()
 		return nil
@@ -92,7 +92,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	})
 
 	// send to request 3
-	require.NoError(t, responseAssembler.Transaction(p, requestID3, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID3, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[4], blks[4].RawData())
 		return nil
 	}))
@@ -102,7 +102,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	})
 
 	// send 2 more to request 3
-	require.NoError(t, responseAssembler.Transaction(p, requestID3, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID3, func(b TransactionBuilder) error {
 		b.AddNotifee(sendResponseNotifee3)
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		bd1 = b.SendResponse(links[4], blks[4].RawData())
@@ -129,7 +129,7 @@ func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
 	allocator := allocator.NewAllocator(1<<30, 1<<30)
 	responseAssembler := New(ctx, allocator, fph)
 
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	}))
@@ -138,7 +138,7 @@ func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
 	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
 
 	// Send 3 very large blocks
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.SendResponse(links[1], blks[1].RawData())
 		b.SendResponse(links[2], blks[2].RawData())
 		b.SendResponse(links[3], blks[3].RawData())
@@ -149,7 +149,7 @@ func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
 	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
 
 	// Send one more block and finish the request
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.SendResponse(links[4], blks[4].RawData())
 		b.FinishRequest()
 		return nil
@@ -175,7 +175,7 @@ func TestPeerResponseSenderSendsExtensionData(t *testing.T) {
 	allocator := allocator.NewAllocator(1<<30, 1<<30)
 	responseAssembler := New(ctx, allocator, fph)
 
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	}))
@@ -195,7 +195,7 @@ func TestPeerResponseSenderSendsExtensionData(t *testing.T) {
 		Name: extensionName2,
 		Data: extensionData2,
 	}
-	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	require.NoError(t, responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		b.SendResponse(links[1], blks[1].RawData())
 		b.SendExtensionData(extension1)
 		b.SendExtensionData(extension2)
@@ -221,7 +221,7 @@ func TestPeerResponseSenderSendsResponsesInTransaction(t *testing.T) {
 	allocator := allocator.NewAllocator(1<<30, 1<<30)
 	responseAssembler := New(ctx, allocator, fph)
 	notifee, _ := testutil.NewTestNotifee("transaction", 10)
-	err := responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	err := responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		bd := b.SendResponse(links[0], blks[0].RawData())
 		assertSentOnWire(t, bd, blks[0])
 
@@ -263,7 +263,7 @@ func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
 	responseAssembler.IgnoreBlocks(p, requestID1, links)
 
 	var bd1, bd2, bd3 graphsync.BlockData
-	err := responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	err := responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	})
@@ -273,7 +273,7 @@ func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
 	fph.RefuteBlocks()
 	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
 
-	err = responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	})
@@ -282,7 +282,7 @@ func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
 		requestID2: graphsync.PartialResponse,
 	})
 
-	err = responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		bd2 = b.SendResponse(links[1], blks[1].RawData())
 		bd3 = b.SendResponse(links[2], blks[2].RawData())
 		b.FinishRequest()
@@ -299,7 +299,7 @@ func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
 		requestID1: graphsync.RequestCompletedFull,
 	})
 
-	err = responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		b.SendResponse(links[3], blks[3].RawData())
 		b.FinishRequest()
 		return nil
@@ -332,7 +332,7 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	responseAssembler.DedupKey(p, requestID3, "applesauce")
 
 	var bd1, bd2 graphsync.BlockData
-	err := responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	err := responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	})
@@ -342,14 +342,14 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	fph.AssertBlocks(blks[0])
 	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
 
-	err = responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
 		return nil
 	})
 	require.NoError(t, err)
 	assertSentOnWire(t, bd1, blks[0])
 
-	err = responseAssembler.Transaction(p, requestID1, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID1, func(b TransactionBuilder) error {
 		bd1 = b.SendResponse(links[1], blks[1].RawData())
 		bd2 = b.SendResponse(links[2], nil)
 		return nil
@@ -361,7 +361,7 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	fph.AssertBlocks(blks[1])
 	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
 
-	err = responseAssembler.Transaction(p, requestID2, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID2, func(b TransactionBuilder) error {
 		b.SendResponse(links[3], blks[3].RawData())
 		b.FinishRequest()
 		return nil
@@ -370,7 +370,7 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	fph.AssertBlocks(blks[3])
 	fph.AssertResponses(expectedResponses{requestID2: graphsync.RequestCompletedFull})
 
-	err = responseAssembler.Transaction(p, requestID3, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID3, func(b TransactionBuilder) error {
 		b.SendResponse(links[4], blks[4].RawData())
 		return nil
 	})
@@ -378,7 +378,7 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	fph.AssertBlocks(blks[4])
 	fph.AssertResponses(expectedResponses{requestID3: graphsync.PartialResponse})
 
-	err = responseAssembler.Transaction(p, requestID3, func(b PeerResponseTransactionBuilder) error {
+	err = responseAssembler.Transaction(p, requestID3, func(b TransactionBuilder) error {
 		b.SendResponse(links[0], blks[0].RawData())
 		b.SendResponse(links[4], blks[4].RawData())
 		return nil
@@ -406,7 +406,7 @@ func TestPeerResponseSenderSendsResponsesMemoryPressure(t *testing.T) {
 
 	finishes := make(chan string, 2)
 	go func() {
-		err := responseAssembler.Transaction(p, requestID1, func(peerResponseSender PeerResponseTransactionBuilder) error {
+		err := responseAssembler.Transaction(p, requestID1, func(peerResponseSender TransactionBuilder) error {
 			bd := peerResponseSender.SendResponse(links[0], blks[0].RawData())
 			assertSentOnWire(t, bd, blks[0])
 			bd = peerResponseSender.SendResponse(links[1], blks[1].RawData())
@@ -436,6 +436,7 @@ func TestPeerResponseSenderSendsResponsesMemoryPressure(t *testing.T) {
 
 	// assert transaction now completes within 200ms
 	ctx2, cancel2 = context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel2()
 	select {
 	case <-finishes:
 		cancel()

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -1,3 +1,10 @@
+/*
+Package responseassembler assembles responses that are queued for sending in outgoing messages
+
+The response assembler's Transaction method allows a caller to specify response actions that will go into a single
+libp2p2 message. The response assembler will also deduplicate blocks that have already been sent over the network in
+a previous message
+*/
 package responseassembler
 
 import (
@@ -15,7 +22,8 @@ import (
 // Transaction is a series of operations that should be send together in a single response
 type Transaction func(TransactionBuilder) error
 
-// TransactionBuilder is a limited interface for sending responses inside a transaction
+// TransactionBuilder is a limited interface for assembling responses inside a transaction, so that they are included
+// in the same message on the protocol
 type TransactionBuilder interface {
 	SendResponse(
 		link ipld.Link,
@@ -29,8 +37,7 @@ type TransactionBuilder interface {
 	AddNotifee(notifications.Notifee)
 }
 
-// PeerMessageHandler is an interface that can send a response for a given peer across
-// the network.
+// PeerMessageHandler is an interface that can queues a response for a given peer to go out over the network
 type PeerMessageHandler interface {
 	BuildMessage(p peer.ID, blkSize uint64, buildResponseFn func(*gsmsg.Builder), notifees []notifications.Notifee)
 }
@@ -40,7 +47,8 @@ type Allocator interface {
 	AllocateBlockMemory(p peer.ID, amount uint64) <-chan error
 }
 
-// ResponseAssembler manages message queues for peers
+// ResponseAssembler manages assembling responses to go out over the network
+// in libp2p messages
 type ResponseAssembler struct {
 	*peermanager.PeerManager
 	allocator   Allocator
@@ -48,7 +56,7 @@ type ResponseAssembler struct {
 	ctx         context.Context
 }
 
-// New generates a new peer manager for sending responses
+// New generates a new ResponseAssembler for sending responses
 func New(ctx context.Context, allocator Allocator, peerHandler PeerMessageHandler) *ResponseAssembler {
 	return &ResponseAssembler{
 		PeerManager: peermanager.New(ctx, func(ctx context.Context, p peer.ID) peermanager.PeerHandler {
@@ -60,40 +68,43 @@ func New(ctx context.Context, allocator Allocator, peerHandler PeerMessageHandle
 	}
 }
 
-func (prm *ResponseAssembler) DedupKey(p peer.ID, requestID graphsync.RequestID, key string) {
-	prm.GetProcess(p).(*peerLinkTracker).DedupKey(requestID, key)
+// DedupKey indicates that outgoing blocks should be deduplicated in a seperate bucket (only with requests that share
+// supplied key string)
+func (ra *ResponseAssembler) DedupKey(p peer.ID, requestID graphsync.RequestID, key string) {
+	ra.GetProcess(p).(*peerLinkTracker).DedupKey(requestID, key)
 }
 
-func (prm *ResponseAssembler) IgnoreBlocks(p peer.ID, requestID graphsync.RequestID, links []ipld.Link) {
-	prm.GetProcess(p).(*peerLinkTracker).IgnoreBlocks(requestID, links)
+// IgnoreBlocks indicates that a list of keys that should be ignored when sending blocks
+func (ra *ResponseAssembler) IgnoreBlocks(p peer.ID, requestID graphsync.RequestID, links []ipld.Link) {
+	ra.GetProcess(p).(*peerLinkTracker).IgnoreBlocks(requestID, links)
 }
 
-// Transaction Build A Response
-func (prm *ResponseAssembler) Transaction(p peer.ID, requestID graphsync.RequestID, transaction Transaction) error {
+// Transaction build a response, and queues it for sending in the next outgoing message
+func (ra *ResponseAssembler) Transaction(p peer.ID, requestID graphsync.RequestID, transaction Transaction) error {
 	prts := &transactionBuilder{
 		requestID:   requestID,
-		linkTracker: prm.GetProcess(p).(*peerLinkTracker),
+		linkTracker: ra.GetProcess(p).(*peerLinkTracker),
 	}
 	err := transaction(prts)
 	if err == nil {
-		prm.execute(p, prts.operations, prts.notifees)
+		ra.execute(p, prts.operations, prts.notifees)
 	}
 	return err
 }
 
-func (prs *ResponseAssembler) execute(p peer.ID, operations []responseOperation, notifees []notifications.Notifee) {
+func (ra *ResponseAssembler) execute(p peer.ID, operations []responseOperation, notifees []notifications.Notifee) {
 	size := uint64(0)
 	for _, op := range operations {
 		size += op.size()
 	}
 	if size > 0 {
 		select {
-		case <-prs.allocator.AllocateBlockMemory(p, size):
-		case <-prs.ctx.Done():
+		case <-ra.allocator.AllocateBlockMemory(p, size):
+		case <-ra.ctx.Done():
 			return
 		}
 	}
-	prs.peerHandler.BuildMessage(p, size, func(responseBuilder *gsmsg.Builder) {
+	ra.peerHandler.BuildMessage(p, size, func(responseBuilder *gsmsg.Builder) {
 		for _, op := range operations {
 			op.build(responseBuilder)
 		}

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -13,10 +13,10 @@ import (
 )
 
 // Transaction is a series of operations that should be send together in a single response
-type Transaction func(PeerResponseTransactionBuilder) error
+type Transaction func(TransactionBuilder) error
 
-// PeerResponseTransactionBuilder is a limited interface for sending responses inside a transaction
-type PeerResponseTransactionBuilder interface {
+// TransactionBuilder is a limited interface for sending responses inside a transaction
+type TransactionBuilder interface {
 	SendResponse(
 		link ipld.Link,
 		data []byte,

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ipfs/go-graphsync/testutil"
 )
 
-func TestPeerResponseSenderSendsResponses(t *testing.T) {
+func TestResponseAssemblerSendsResponses(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -113,7 +113,7 @@ func TestPeerResponseSenderSendsResponses(t *testing.T) {
 	fph.AssertResponses(expectedResponses{requestID3: graphsync.PartialResponse})
 }
 
-func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
+func TestResponseAssemblerSendsVeryLargeBlocksResponses(t *testing.T) {
 	p := testutil.GeneratePeers(1)[0]
 	requestID1 := graphsync.RequestID(rand.Int31())
 	// generate large blocks before proceeding
@@ -160,7 +160,7 @@ func TestPeerResponseSenderSendsVeryLargeBlocksResponses(t *testing.T) {
 
 }
 
-func TestPeerResponseSenderSendsExtensionData(t *testing.T) {
+func TestResponseAssemblerSendsExtensionData(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -206,7 +206,7 @@ func TestPeerResponseSenderSendsExtensionData(t *testing.T) {
 	fph.AssertExtensions([][]graphsync.ExtensionData{{extension1, extension2}})
 }
 
-func TestPeerResponseSenderSendsResponsesInTransaction(t *testing.T) {
+func TestResponseAssemblerSendsResponsesInTransaction(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -244,7 +244,7 @@ func TestPeerResponseSenderSendsResponsesInTransaction(t *testing.T) {
 	fph.AssertNotifees(notifee)
 }
 
-func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
+func TestResponseAssemblerIgnoreBlocks(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -311,7 +311,7 @@ func TestPeerResponseSenderIgnoreBlocks(t *testing.T) {
 
 }
 
-func TestPeerResponseSenderDupKeys(t *testing.T) {
+func TestResponseAssemblerDupKeys(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -389,7 +389,7 @@ func TestPeerResponseSenderDupKeys(t *testing.T) {
 	fph.AssertResponses(expectedResponses{requestID3: graphsync.PartialResponse})
 }
 
-func TestPeerResponseSenderSendsResponsesMemoryPressure(t *testing.T) {
+func TestResponseAssemblerSendsResponsesMemoryPressure(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
@@ -406,16 +406,16 @@ func TestPeerResponseSenderSendsResponsesMemoryPressure(t *testing.T) {
 
 	finishes := make(chan string, 2)
 	go func() {
-		err := responseAssembler.Transaction(p, requestID1, func(peerResponseSender TransactionBuilder) error {
-			bd := peerResponseSender.SendResponse(links[0], blks[0].RawData())
+		err := responseAssembler.Transaction(p, requestID1, func(transactionBuilder TransactionBuilder) error {
+			bd := transactionBuilder.SendResponse(links[0], blks[0].RawData())
 			assertSentOnWire(t, bd, blks[0])
-			bd = peerResponseSender.SendResponse(links[1], blks[1].RawData())
+			bd = transactionBuilder.SendResponse(links[1], blks[1].RawData())
 			assertSentOnWire(t, bd, blks[1])
-			bd = peerResponseSender.SendResponse(links[2], blks[2].RawData())
+			bd = transactionBuilder.SendResponse(links[2], blks[2].RawData())
 			assertSentOnWire(t, bd, blks[2])
-			bd = peerResponseSender.SendResponse(links[3], blks[3].RawData())
+			bd = transactionBuilder.SendResponse(links[3], blks[3].RawData())
 			assertSentOnWire(t, bd, blks[3])
-			peerResponseSender.FinishRequest()
+			transactionBuilder.FinishRequest()
 			return nil
 		})
 		require.NoError(t, err)


### PR DESCRIPTION
In this PR:
- Rename cleanups
- A bit more docs

More importantly:
- Moving the large block message breakup test over to message queue (since that is where that logic lives now)
- This actually revealed an actual bug in the refactor (see change to messagequeue.go)