### PR TITLE
move block allocation into message queue

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -141,7 +141,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	asyncLoader := asyncloader.New(ctx, loader, storer)
 	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
-	responseAssembler := responseassembler.New(ctx, allocator, peerManager)
+	responseAssembler := responseassembler.New(ctx, peerManager)
 	peerTaskQueue := peertaskqueue.New()
 	responseManager := responsemanager.New(ctx, loader, responseAssembler, peerTaskQueue, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressRequests)
 	graphSync := &GraphSync{

--- a/peermanager/peermessagemanager.go
+++ b/peermanager/peermessagemanager.go
@@ -12,7 +12,7 @@ import (
 // PeerQueue is a process that sends messages to a peer
 type PeerQueue interface {
 	PeerProcess
-	BuildMessage(blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee)
+	AllocateAndBuildMessage(blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee)
 }
 
 // PeerQueueFactory provides a function that will create a PeerQueue.
@@ -33,7 +33,8 @@ func NewMessageManager(ctx context.Context, createPeerQueue PeerQueueFactory) *P
 }
 
 // BuildMessage allows you to modify the next message that is sent for the given peer
-func (pmm *PeerMessageManager) BuildMessage(p peer.ID, blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee) {
+// If blkSize > 0, message building may block until enough memory has been freed from the queues to allocate the message.
+func (pmm *PeerMessageManager) AllocateAndBuildMessage(p peer.ID, blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee) {
 	pq := pmm.GetProcess(p).(PeerQueue)
-	pq.BuildMessage(blkSize, buildMessageFn, notifees)
+	pq.AllocateAndBuildMessage(blkSize, buildMessageFn, notifees)
 }

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -29,7 +29,7 @@ type fakePeer struct {
 	messagesSent chan messageSent
 }
 
-func (fp *fakePeer) BuildMessage(blkSize uint64, buildMessage func(b *gsmsg.Builder), notifees []notifications.Notifee) {
+func (fp *fakePeer) AllocateAndBuildMessage(blkSize uint64, buildMessage func(b *gsmsg.Builder), notifees []notifications.Notifee) {
 	builder := gsmsg.NewBuilder(gsmsg.Topic(0))
 	buildMessage(builder)
 	message, err := builder.Build()
@@ -76,14 +76,14 @@ func TestSendingMessagesToPeers(t *testing.T) {
 	peerManager := NewMessageManager(ctx, peerQueueFactory)
 
 	request := gsmsg.NewRequest(id, root, selector, priority)
-	peerManager.BuildMessage(tp[0], 0, func(b *gsmsg.Builder) {
+	peerManager.AllocateAndBuildMessage(tp[0], 0, func(b *gsmsg.Builder) {
 		b.AddRequest(request)
 	}, []notifications.Notifee{})
-	peerManager.BuildMessage(tp[1], 0, func(b *gsmsg.Builder) {
+	peerManager.AllocateAndBuildMessage(tp[1], 0, func(b *gsmsg.Builder) {
 		b.AddRequest(request)
 	}, []notifications.Notifee{})
 	cancelRequest := gsmsg.CancelRequest(id)
-	peerManager.BuildMessage(tp[0], 0, func(b *gsmsg.Builder) {
+	peerManager.AllocateAndBuildMessage(tp[0], 0, func(b *gsmsg.Builder) {
 		b.AddRequest(cancelRequest)
 	}, []notifications.Notifee{})
 

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -47,7 +47,7 @@ type inProgressRequestStatus struct {
 
 // PeerHandler is an interface that can send requests to peers
 type PeerHandler interface {
-	BuildMessage(p peer.ID, blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee)
+	AllocateAndBuildMessage(p peer.ID, blkSize uint64, buildMessageFn func(*gsmsg.Builder), notifees []notifications.Notifee)
 }
 
 // AsyncLoader is an interface for loading links asynchronously, returning
@@ -566,7 +566,7 @@ const requestNetworkError = "request_network_error"
 func (rm *RequestManager) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
 	sub := notifications.NewTopicDataSubscriber(&reqSubscriber{p, request, rm.networkErrorListeners})
 	failNotifee := notifications.Notifee{Data: requestNetworkError, Subscriber: sub}
-	rm.peerHandler.BuildMessage(p, 0, func(builder *gsmsg.Builder) {
+	rm.peerHandler.AllocateAndBuildMessage(p, 0, func(builder *gsmsg.Builder) {
 		builder.AddRequest(request)
 	}, []notifications.Notifee{failNotifee})
 }

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -35,7 +35,7 @@ type fakePeerHandler struct {
 	requestRecordChan chan requestRecord
 }
 
-func (fph *fakePeerHandler) BuildMessage(p peer.ID, blkSize uint64,
+func (fph *fakePeerHandler) AllocateAndBuildMessage(p peer.ID, blkSize uint64,
 	requestBuilder func(b *gsmsg.Builder), notifees []notifications.Notifee) {
 	builder := gsmsg.NewBuilder(gsmsg.Topic(0))
 	requestBuilder(builder)


### PR DESCRIPTION
### Motivation

Currently block allocation is split between allocation in the response builder and release in the message queue. This works, but only if the components cooperate, and it is fragile in the long term. The PR brings allocation and release into the  message queue.

### Proposed Changes

* Add a context.Context to the BuildMessage function (in all interfaces and implementations)
* Add the AllocateBlockMemory function to the MessageQueue Allocator interface.
* Move the delay logic from ResponseAssembler.execute to MessageQueue.AllocateAndBuildMessage and remove the ResponseAssembler Allocator interface.
* Document the possible block in AllocateAndBuildMessage functions.