### PR TITLE
testplan: remove default network params

### DIFF
--- a/testplans/graphsync/main.go
+++ b/testplans/graphsync/main.go
@@ -159,9 +159,6 @@ func parseNetworkConfig(runenv *runtime.RunEnv) []networkParams {
 	// prepend bandwidth=0 and latency=0 zero values; the first iteration will
 	// be a control iteration. The sidecar interprets zero values as no
 	// limitation on that attribute.
-	bandwidths = append([]uint64{0}, bandwidths...)
-	latencies = append([]time.Duration{0}, latencies...)
-
 	var ret []networkParams
 	for _, bandwidth := range bandwidths {
 		for _, latency := range latencies {


### PR DESCRIPTION
The graphsync test parses incoming network params from the composition and does a cartesian product of them with the defaults 0, 0 for bandwidth and latency, and runs that many rounds of the test.

It'd be nice to be able to run this test with larger files, and they take a lot of time (for example 2048MB currently takes 4:30min, because it appears bandwidth is around 50Mbps).

So this PR is remove the defaults in order not to get 4 rounds if we have specified only a single network configuration. 4 rounds * 4:30min == timeout on TaaS.

If we are interested on not limiting bandwidth and latencies, let's just add these to the composition file.