### PR TITLE
propagate error when "request is not valid"

### DIFF
--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -3,6 +3,7 @@ package responsemanager
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -124,7 +125,7 @@ func (qe *queryExecutor) prepareQuery(ctx context.Context,
 		if result.Err != nil || !result.IsValidated {
 			rb.FinishWithError(graphsync.RequestFailedUnknown)
 			rb.AddNotifee(failNotifee)
-			transactionError = errors.New("request not valid")
+			transactionError = fmt.Errorf("request not valid: %w ; result.IsValidated: %v", result.Err, result.IsValidated)
 		} else if result.IsPaused {
 			rb.PauseRequest()
 			isPaused = true


### PR DESCRIPTION
It'd be nice for this to hit `go-graphsync`, because this error is quite useful - we noted that we have client/miner out of sync and trying to create deals with the same internal identifiers were causing problems.