### PR TITLE
Pass through linksystem

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -139,7 +139,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	}
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	asyncLoader := asyncloader.New(ctx, linkSystem)
-	requestManager := requestmanager.New(ctx, asyncLoader, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
+	requestManager := requestmanager.New(ctx, asyncLoader, linkSystem, outgoingRequestHooks, incomingResponseHooks, incomingBlockHooks, networkErrorListeners)
 	responseAssembler := responseassembler.New(ctx, peerManager)
 	peerTaskQueue := peertaskqueue.New()
 	responseManager := responsemanager.New(ctx, linkSystem, responseAssembler, peerTaskQueue, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressRequests)

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -32,6 +32,7 @@ type ExecutionEnv struct {
 	TerminateRequest func(graphsync.RequestID)
 	WaitForMessages  func(ctx context.Context, resumeMessages chan graphsync.ExtensionData) ([]graphsync.ExtensionData, error)
 	Loader           AsyncLoadFn
+	LinkSystem       ipld.LinkSystem
 }
 
 // RequestExecution are parameters for a single request execution
@@ -99,10 +100,11 @@ func (re *requestExecutor) visitor(tp traversal.Progress, node ipld.Node, tr tra
 
 func (re *requestExecutor) traverse() error {
 	traverser := ipldutil.TraversalBuilder{
-		Root:     cidlink.Link{Cid: re.request.Root()},
-		Selector: re.request.Selector(),
-		Visitor:  re.visitor,
-		Chooser:  re.nodeStyleChooser,
+		Root:       cidlink.Link{Cid: re.request.Root()},
+		Selector:   re.request.Selector(),
+		Visitor:    re.visitor,
+		Chooser:    re.nodeStyleChooser,
+		LinkSystem: re.env.LinkSystem,
 	}.Start(re.ctx)
 	defer traverser.Shutdown(context.Background())
 	for {

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -70,6 +70,7 @@ type RequestManager struct {
 	peerHandler PeerHandler
 	rc          *responseCollector
 	asyncLoader AsyncLoader
+	linkSystem  ipld.LinkSystem
 	// dont touch out side of run loop
 	nextRequestID             graphsync.RequestID
 	inProgressRequestStatuses map[graphsync.RequestID]*inProgressRequestStatus
@@ -101,6 +102,7 @@ type BlockHooks interface {
 // New generates a new request manager from a context, network, and selectorQuerier
 func New(ctx context.Context,
 	asyncLoader AsyncLoader,
+	linkSystem ipld.LinkSystem,
 	requestHooks RequestHooks,
 	responseHooks ResponseHooks,
 	blockHooks BlockHooks,
@@ -111,6 +113,7 @@ func New(ctx context.Context,
 		ctx:                       ctx,
 		cancel:                    cancel,
 		asyncLoader:               asyncLoader,
+		linkSystem:                linkSystem,
 		rc:                        newResponseCollector(ctx),
 		messages:                  make(chan requestManagerMessage, 16),
 		inProgressRequestStatuses: make(map[graphsync.RequestID]*inProgressRequestStatus),
@@ -343,6 +346,7 @@ func (nrm *newRequestMessage) setupRequest(requestID graphsync.RequestID, rm *Re
 		TerminateRequest: rm.terminateRequest,
 		RunBlockHooks:    rm.processBlockHooks,
 		Loader:           rm.asyncLoader.AsyncLoad,
+		LinkSystem:       rm.linkSystem,
 	}.Start(
 		executor.RequestExecution{
 			Ctx:                  ctx,

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -893,7 +893,7 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td.responseHooks = hooks.NewResponseHooks()
 	td.blockHooks = hooks.NewBlockHooks()
 	td.networkErrorListeners = listeners.NewNetworkErrorListeners()
-	td.requestManager = New(ctx, td.fal, td.requestHooks, td.responseHooks, td.blockHooks, td.networkErrorListeners)
+	td.requestManager = New(ctx, td.fal, cidlink.DefaultLinkSystem(), td.requestHooks, td.responseHooks, td.blockHooks, td.networkErrorListeners)
 	td.requestManager.SetDelegate(td.fph)
 	td.requestManager.Startup()
 	td.blockStore = make(map[ipld.Link][]byte)


### PR DESCRIPTION
# Goals

Make any customizations of the linksystem passed to Graphsync apply to the RequestManager (such as NodeReifier) -- this means if UnixFS reification is enabled on both sides you can do a directory path based selector query in Graphsync

# Implementation

Pass through the supplied linksystem down through the RequestManager to the underlying traverser.