### PR TITLE
Resolve 175 race condition, no change to hook timing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/ipfs/go-ipfs-util v0.0.2
 	github.com/ipfs/go-ipld-cbor v0.0.4 // indirect
 	github.com/ipfs/go-ipld-format v0.2.0
-	github.com/ipfs/go-log v1.0.4
 	github.com/ipfs/go-log/v2 v2.1.1
 	github.com/ipfs/go-merkledag v0.3.1
 	github.com/ipfs/go-peertaskqueue v0.2.0

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -3,7 +3,7 @@ package graphsync
 import (
 	"context"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue"
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"

--- a/network/libp2p_impl.go
+++ b/network/libp2p_impl.go
@@ -6,7 +6,7 @@ import (
 	"io"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/libp2p/go-libp2p-core/peer"

--- a/requestmanager/asyncloader/responsecache/responsecache.go
+++ b/requestmanager/asyncloader/responsecache/responsecache.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 
 	blocks "github.com/ipfs/go-block-format"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
+
 	"github.com/hannahhoward/go-pubsub"
 	"golang.org/x/xerrors"
-	"sync/atomic"
 
 	blocks "github.com/ipfs/go-block-format"
 	"github.com/ipfs/go-cid"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -66,12 +67,12 @@ type AsyncLoader interface {
 // RequestManager tracks outgoing requests and processes incoming reponses
 // to them.
 type RequestManager struct {
-	ctx         context.Context
-	cancel      func()
-	messages    chan requestManagerMessage
-	peerHandler PeerHandler
-	rc          *responseCollector
-	asyncLoader AsyncLoader
+	ctx             context.Context
+	cancel          func()
+	messages        chan requestManagerMessage
+	peerHandler     PeerHandler
+	rc              *responseCollector
+	asyncLoader     AsyncLoader
 	disconnectNotif *pubsub.PubSub
 	// dont touch out side of run loop
 	nextRequestID             graphsync.RequestID

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -6,14 +6,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ipfs/go-cid"
 	ipld "github.com/ipld/go-ipld-prime"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-graphsync/cidset"
-	"github.com/ipfs/go-graphsync/dedupkey"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/notifications"
@@ -72,7 +68,7 @@ func (qe *queryExecutor) processQueriesWorker() {
 				log.Info("Empty task on peer request stack")
 				continue
 			}
-			status, err := qe.executeTask(key, taskData)
+			status, err := qe.executeQuery(key.p, taskData.request, taskData.loader, taskData.traverser, taskData.signals, taskData.subscriber)
 			isCancelled := err != nil && isContextErr(err)
 			if isCancelled {
 				qe.cancelledListeners.NotifyCancelledListeners(key.p, taskData.request)
@@ -83,123 +79,7 @@ func (qe *queryExecutor) processQueriesWorker() {
 			}
 		}
 		qe.queryQueue.TasksDone(pid, tasks...)
-
 	}
-
-}
-
-func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData) (graphsync.ResponseStatusCode, error) {
-	var err error
-	loader := taskData.loader
-	traverser := taskData.traverser
-	if loader == nil || traverser == nil {
-		var isPaused bool
-		loader, traverser, isPaused, err = qe.prepareQuery(taskData.ctx, key.p, taskData.request, taskData.signals, taskData.subscriber)
-		if err != nil {
-			return graphsync.RequestFailedUnknown, err
-		}
-		select {
-		case <-qe.ctx.Done():
-			return graphsync.RequestFailedUnknown, errors.New("context cancelled")
-		case qe.messages <- &setResponseDataRequest{key, loader, traverser}:
-		}
-		if isPaused {
-			log.Infof("Request is paused on initial setup: %d", key.requestID)
-			return graphsync.RequestPaused, hooks.ErrPaused{}
-		}
-	}
-	return qe.executeQuery(key.p, taskData.request, loader, traverser, taskData.signals, taskData.subscriber)
-}
-
-func (qe *queryExecutor) prepareQuery(ctx context.Context,
-	p peer.ID,
-	request gsmsg.GraphSyncRequest, signals signals, sub *notifications.TopicDataSubscriber) (ipld.Loader, ipldutil.Traverser, bool, error) {
-	log.Infof("Processing request hooks for request: %d", request.ID())
-	result := qe.requestHooks.ProcessRequestHooks(p, request)
-	var transactionError error
-	var isPaused bool
-	failNotifee := notifications.Notifee{Data: graphsync.RequestFailedUnknown, Subscriber: sub}
-	err := qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
-		for _, extension := range result.Extensions {
-			rb.SendExtensionData(extension)
-		}
-		if result.Err != nil || !result.IsValidated {
-			rb.FinishWithError(graphsync.RequestFailedUnknown)
-			rb.AddNotifee(failNotifee)
-			transactionError = errors.New("request not valid")
-		} else if result.IsPaused {
-			rb.PauseRequest()
-			isPaused = true
-		}
-		return nil
-	})
-	if err != nil {
-		return nil, nil, false, err
-	}
-	if transactionError != nil {
-		return nil, nil, false, transactionError
-	}
-	if err := qe.processDedupByKey(request, p, failNotifee); err != nil {
-		return nil, nil, false, err
-	}
-	if err := qe.processDoNoSendCids(request, p, failNotifee); err != nil {
-		return nil, nil, false, err
-	}
-	rootLink := cidlink.Link{Cid: request.Root()}
-	traverser := ipldutil.TraversalBuilder{
-		Root:     rootLink,
-		Selector: request.Selector(),
-		Chooser:  result.CustomChooser,
-	}.Start(ctx)
-	loader := result.CustomLoader
-	if loader == nil {
-		loader = qe.loader
-	}
-	return loader, traverser, isPaused, nil
-}
-
-func (qe *queryExecutor) processDedupByKey(request gsmsg.GraphSyncRequest, p peer.ID, failNotifee notifications.Notifee) error {
-	dedupData, has := request.Extension(graphsync.ExtensionDeDupByKey)
-	if !has {
-		return nil
-	}
-	key, err := dedupkey.DecodeDedupKey(dedupData)
-	if err != nil {
-		_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
-			rb.FinishWithError(graphsync.RequestFailedUnknown)
-			rb.AddNotifee(failNotifee)
-			return nil
-		})
-		return err
-	}
-	qe.responseAssembler.DedupKey(p, request.ID(), key)
-	return nil
-}
-
-func (qe *queryExecutor) processDoNoSendCids(request gsmsg.GraphSyncRequest, p peer.ID, failNotifee notifications.Notifee) error {
-	doNotSendCidsData, has := request.Extension(graphsync.ExtensionDoNotSendCIDs)
-	if !has {
-		return nil
-	}
-	cidSet, err := cidset.DecodeCidSet(doNotSendCidsData)
-	if err != nil {
-		_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
-			rb.FinishWithError(graphsync.RequestFailedUnknown)
-			rb.AddNotifee(failNotifee)
-			return nil
-		})
-		return err
-	}
-	links := make([]ipld.Link, 0, cidSet.Len())
-	err = cidSet.ForEach(func(c cid.Cid) error {
-		links = append(links, cidlink.Link{Cid: c})
-		return nil
-	})
-	if err != nil {
-		return err
-	}
-	qe.responseAssembler.IgnoreBlocks(p, request.ID(), links)
-	return nil
 }
 
 func (qe *queryExecutor) executeQuery(

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -114,7 +114,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	p peer.ID,
 	request gsmsg.GraphSyncRequest, signals signals, sub *notifications.TopicDataSubscriber) (ipld.Loader, ipldutil.Traverser, bool, error) {
-	log.Infof("Processing request hooks for request: %d", request.ID)
+	log.Infof("Processing request hooks for request: %d", request.ID())
 	result := qe.requestHooks.ProcessRequestHooks(p, request)
 	var transactionError error
 	var isPaused bool

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -22,12 +22,10 @@ var errCancelledByCommand = errors.New("response cancelled by responder")
 
 // TODO: Move this into a seperate module and fully seperate from the ResponseManager
 type queryExecutor struct {
-	requestHooks       RequestHooks
 	blockHooks         BlockHooks
 	updateHooks        UpdateHooks
 	cancelledListeners CancelledListeners
 	responseAssembler  ResponseAssembler
-	loader             ipld.Loader
 	queryQueue         QueryQueue
 	messages           chan responseManagerMessage
 	ctx                context.Context

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -104,7 +104,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 		case qe.messages <- &setResponseDataRequest{key, loader, traverser}:
 		}
 		if isPaused {
-			log.Debug("Request is paused on initial setup: %d", key.requestID)
+			log.Infof("Request is paused on initial setup: %d", key.requestID)
 			return graphsync.RequestPaused, hooks.ErrPaused{}
 		}
 	}
@@ -114,7 +114,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	p peer.ID,
 	request gsmsg.GraphSyncRequest, signals signals, sub *notifications.TopicDataSubscriber) (ipld.Loader, ipldutil.Traverser, bool, error) {
-	log.Debug("Processing request hooks for request: %d", request.ID)
+	log.Infof("Processing request hooks for request: %d", request.ID)
 	result := qe.requestHooks.ProcessRequestHooks(p, request)
 	var transactionError error
 	var isPaused bool

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -104,6 +104,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 		case qe.messages <- &setResponseDataRequest{key, loader, traverser}:
 		}
 		if isPaused {
+			log.Debug("Request is paused on initial setup: %d", key.requestID)
 			return graphsync.RequestPaused, hooks.ErrPaused{}
 		}
 	}
@@ -113,6 +114,7 @@ func (qe *queryExecutor) executeTask(key responseKey, taskData responseTaskData)
 func (qe *queryExecutor) prepareQuery(ctx context.Context,
 	p peer.ID,
 	request gsmsg.GraphSyncRequest, signals signals, sub *notifications.TopicDataSubscriber) (ipld.Loader, ipldutil.Traverser, bool, error) {
+	log.Debug("Processing request hooks for request: %d", request.ID)
 	result := qe.requestHooks.ProcessRequestHooks(p, request)
 	var transactionError error
 	var isPaused bool

--- a/responsemanager/querypreparer.go
+++ b/responsemanager/querypreparer.go
@@ -1,0 +1,115 @@
+package responsemanager
+
+import (
+	"context"
+	"errors"
+
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-graphsync"
+	"github.com/ipfs/go-graphsync/cidset"
+	"github.com/ipfs/go-graphsync/dedupkey"
+	"github.com/ipfs/go-graphsync/ipldutil"
+	gsmsg "github.com/ipfs/go-graphsync/message"
+	"github.com/ipfs/go-graphsync/notifications"
+	"github.com/ipfs/go-graphsync/responsemanager/responseassembler"
+	ipld "github.com/ipld/go-ipld-prime"
+	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/libp2p/go-libp2p-core/peer"
+)
+
+type queryPreparer struct {
+	requestHooks      RequestHooks
+	responseAssembler ResponseAssembler
+	loader            ipld.Loader
+}
+
+func (qe *queryPreparer) prepareQuery(ctx context.Context,
+	p peer.ID,
+	request gsmsg.GraphSyncRequest, signals signals, sub *notifications.TopicDataSubscriber) (ipld.Loader, ipldutil.Traverser, bool, error) {
+	log.Infof("Processing request hooks for request: %d", request.ID())
+	result := qe.requestHooks.ProcessRequestHooks(p, request)
+	var transactionError error
+	var isPaused bool
+	failNotifee := notifications.Notifee{Data: graphsync.RequestFailedUnknown, Subscriber: sub}
+	err := qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
+		for _, extension := range result.Extensions {
+			rb.SendExtensionData(extension)
+		}
+		if result.Err != nil || !result.IsValidated {
+			rb.FinishWithError(graphsync.RequestFailedUnknown)
+			rb.AddNotifee(failNotifee)
+			transactionError = errors.New("request not valid")
+		} else if result.IsPaused {
+			rb.PauseRequest()
+			isPaused = true
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if transactionError != nil {
+		return nil, nil, false, transactionError
+	}
+	if err := qe.processDedupByKey(request, p, failNotifee); err != nil {
+		return nil, nil, false, err
+	}
+	if err := qe.processDoNoSendCids(request, p, failNotifee); err != nil {
+		return nil, nil, false, err
+	}
+	rootLink := cidlink.Link{Cid: request.Root()}
+	traverser := ipldutil.TraversalBuilder{
+		Root:     rootLink,
+		Selector: request.Selector(),
+		Chooser:  result.CustomChooser,
+	}.Start(ctx)
+	loader := result.CustomLoader
+	if loader == nil {
+		loader = qe.loader
+	}
+	return loader, traverser, isPaused, nil
+}
+
+func (qe *queryPreparer) processDedupByKey(request gsmsg.GraphSyncRequest, p peer.ID, failNotifee notifications.Notifee) error {
+	dedupData, has := request.Extension(graphsync.ExtensionDeDupByKey)
+	if !has {
+		return nil
+	}
+	key, err := dedupkey.DecodeDedupKey(dedupData)
+	if err != nil {
+		_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
+			rb.FinishWithError(graphsync.RequestFailedUnknown)
+			rb.AddNotifee(failNotifee)
+			return nil
+		})
+		return err
+	}
+	qe.responseAssembler.DedupKey(p, request.ID(), key)
+	return nil
+}
+
+func (qe *queryPreparer) processDoNoSendCids(request gsmsg.GraphSyncRequest, p peer.ID, failNotifee notifications.Notifee) error {
+	doNotSendCidsData, has := request.Extension(graphsync.ExtensionDoNotSendCIDs)
+	if !has {
+		return nil
+	}
+	cidSet, err := cidset.DecodeCidSet(doNotSendCidsData)
+	if err != nil {
+		_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
+			rb.FinishWithError(graphsync.RequestFailedUnknown)
+			rb.AddNotifee(failNotifee)
+			return nil
+		})
+		return err
+	}
+	links := make([]ipld.Link, 0, cidSet.Len())
+	err = cidSet.ForEach(func(c cid.Cid) error {
+		links = append(links, cidlink.Link{Cid: c})
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	qe.responseAssembler.IgnoreBlocks(p, request.ID(), links)
+	return nil
+}

--- a/responsemanager/responseassembler/responseBuilder.go
+++ b/responsemanager/responseassembler/responseBuilder.go
@@ -2,7 +2,7 @@ package responseassembler
 
 import (
 	blocks "github.com/ipfs/go-block-format"
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -450,7 +450,7 @@ func (prm *processRequestMessage) handle(rm *ResponseManager) {
 		loader, traverser, isPaused, err := (&queryPreparer{rm.qe.requestHooks, rm.responseAssembler, rm.qe.loader}).prepareQuery(ctx, key.p, request, signals, sub)
 		if err != nil {
 			cancelFn()
-			return
+			continue
 		}
 		rm.inProgressResponses[key] =
 			&inProgressResponseStatus{
@@ -465,7 +465,7 @@ func (prm *processRequestMessage) handle(rm *ResponseManager) {
 			}
 		// TODO: Use a better work estimation metric.
 		if isPaused {
-			return
+			continue
 		}
 
 		rm.queryQueue.PushTasks(prm.p, peertask.Task{Topic: key, Priority: int(request.Priority()), Work: 1})

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -6,7 +6,7 @@ import (
 	"math"
 	"time"
 
-	logging "github.com/ipfs/go-log"
+	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -362,7 +362,7 @@ func (rm *ResponseManager) processUpdate(key responseKey, update gsmsg.GraphSync
 }
 
 func (rm *ResponseManager) unpauseRequest(p peer.ID, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
-	log.Debug("Unpause request called: %d", requestID)
+	log.Infof("Unpause request called: %d", requestID)
 	key := responseKey{p, requestID}
 	inProgressResponse, ok := rm.inProgressResponses[key]
 	if !ok {
@@ -485,7 +485,7 @@ func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 		return
 	}
 	if _, ok := ftr.err.(hooks.ErrPaused); ok {
-		log.Debug("Request finished on pause: %d", ftr.key.requestID)
+		log.Infof("Request finished on pause: %d", ftr.key.requestID)
 		response.isPaused = true
 		return
 	}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -362,7 +362,6 @@ func (rm *ResponseManager) processUpdate(key responseKey, update gsmsg.GraphSync
 }
 
 func (rm *ResponseManager) unpauseRequest(p peer.ID, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
-	log.Infof("Unpause request called: %d", requestID)
 	key := responseKey{p, requestID}
 	inProgressResponse, ok := rm.inProgressResponses[key]
 	if !ok {
@@ -432,6 +431,7 @@ func (prm *processRequestMessage) handle(rm *ResponseManager) {
 			rm.processUpdate(key, request)
 			continue
 		}
+		rm.requestQueuedHooks.ProcessRequestQueuedHooks(prm.p, request)
 		ctx, cancelFn := context.WithCancel(rm.ctx)
 		sub := notifications.NewTopicDataSubscriber(&subscriber{
 			p:                     key.p,
@@ -497,7 +497,6 @@ func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 		return
 	}
 	if _, ok := ftr.err.(hooks.ErrPaused); ok {
-		log.Infof("Request finished on pause: %d", ftr.key.requestID)
 		response.isPaused = true
 		return
 	}

--- a/responsemanager/responsemanager.go
+++ b/responsemanager/responsemanager.go
@@ -362,6 +362,7 @@ func (rm *ResponseManager) processUpdate(key responseKey, update gsmsg.GraphSync
 }
 
 func (rm *ResponseManager) unpauseRequest(p peer.ID, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
+	log.Debug("Unpause request called: %d", requestID)
 	key := responseKey{p, requestID}
 	inProgressResponse, ok := rm.inProgressResponses[key]
 	if !ok {
@@ -484,6 +485,7 @@ func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 		return
 	}
 	if _, ok := ftr.err.(hooks.ErrPaused); ok {
+		log.Debug("Request finished on pause: %d", ftr.key.requestID)
 		response.isPaused = true
 		return
 	}

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -115,6 +115,7 @@ func TestEarlyCancellation(t *testing.T) {
 	defer td.cancel()
 	td.queryQueue.popWait.Add(1)
 	responseManager := td.newResponseManager()
+	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
 	responseManager.Startup()
 	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -426,6 +426,27 @@ func TestValidationAndExtensions(t *testing.T) {
 			td.assertCompleteRequestWithSuccess()
 		})
 
+		t.Run("if started paused, unpausing always works", func(t *testing.T) {
+			td := newTestData(t)
+			defer td.cancel()
+			responseManager := td.newResponseManager()
+			responseManager.Startup()
+			advance := make(chan struct{})
+			td.requestHooks.Register(func(p peer.ID, requestData graphsync.RequestData, hookActions graphsync.IncomingRequestHookActions) {
+				hookActions.ValidateRequest()
+				hookActions.PauseResponse()
+				close(advance)
+			})
+			go func() {
+				<-advance
+				err := responseManager.UnpauseResponse(td.p, td.requestID)
+				require.NoError(t, err)
+			}()
+			responseManager.ProcessRequests(td.ctx, td.p, td.requests)
+			td.assertPausedRequest()
+			td.verifyNResponses(td.blockChainLength)
+			td.assertCompleteRequestWithSuccess()
+		})
 	})
 
 	t.Run("test update hook processing", func(t *testing.T) {


### PR DESCRIPTION
# Goals

fix #175

# Implementation

This builds of #176 but avoids moving hooks around in terms of timing in any substantive way. Rather, it cleans up hook processing to insure that request hooks are processed only on the main response manager thread, so that there aren't races with any calls made during hook processing.