### PR TITLE
Fix error codes

### DIFF
--- a/message/message.go
+++ b/message/message.go
@@ -33,7 +33,8 @@ func IsTerminalFailureCode(status graphsync.ResponseStatusCode) bool {
 		status == graphsync.RequestFailedContentNotFound ||
 		status == graphsync.RequestFailedLegal ||
 		status == graphsync.RequestFailedUnknown ||
-		status == graphsync.RequestCancelled
+		status == graphsync.RequestCancelled ||
+		status == graphsync.RequestRejected
 }
 
 // IsTerminalResponseCode returns true if the response code signals

--- a/responsemanager/queryexecutor.go
+++ b/responsemanager/queryexecutor.go
@@ -129,12 +129,14 @@ func (qe *queryExecutor) executeQuery(
 				code = graphsync.RequestFailedUnknown
 				return nil
 			}
-			if err == errCancelledByCommand {
+			if err == runtraversal.ErrFirstBlockLoad {
+				code = graphsync.RequestFailedContentNotFound
+			} else if err == errCancelledByCommand {
 				code = graphsync.RequestCancelled
 			} else {
 				code = graphsync.RequestFailedUnknown
 			}
-			rb.FinishWithError(graphsync.RequestCancelled)
+			rb.FinishWithError(code)
 		} else {
 			code = rb.FinishRequest()
 		}

--- a/responsemanager/runtraversal/runtraversal.go
+++ b/responsemanager/runtraversal/runtraversal.go
@@ -12,6 +12,15 @@ import (
 
 var logger = logging.Logger("gs-traversal")
 
+type errorString string
+
+func (e errorString) Error() string {
+	return string(e)
+}
+
+// ErrFirstBlockLoad indicates the traversal was unable to load the very first block in the traversal
+const ErrFirstBlockLoad = errorString("Unable to load first block")
+
 // ResponseSender sends responses over the network
 type ResponseSender func(
 	link ipld.Link,
@@ -30,6 +39,9 @@ func RunTraversal(
 		if isComplete {
 			if err != nil {
 				logger.Errorf("traversal completion check failed, nBlocksRead=%d, err=%s", traverser.NBlocksTraversed(), err)
+				if (traverser.NBlocksTraversed() == 0 && err == traversal.SkipMe{}) {
+					return ErrFirstBlockLoad
+				}
 			} else {
 				logger.Debugf("traversal completed successfully, nBlocksRead=%d", traverser.NBlocksTraversed())
 			}


### PR DESCRIPTION
# Goals

Enforce returning error codes that more closely match the graphsync spec

# Implementation

- Make sure requests that are not validated return ResponseRejected
- Make sure requests that fail to load first block return RequestFailedContentNotFound
- Fix inconsistencies in value given to CompletedResponseListener vs returned in request
- Add ResponseRejected to IsTerminalResponseCode (should have been there before)
- Enforce more specific response code tests in tests of the response manager