### PR TITLE
Add cancel request and wait function

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -369,4 +369,7 @@ type GraphExchange interface {
 
 	// CancelResponse cancels an in progress response
 	CancelResponse(peer.ID, RequestID) error
+
+	// CancelRequest cancels an in progress response
+	CancelRequest(RequestID) error
 }

--- a/graphsync.go
+++ b/graphsync.go
@@ -371,6 +371,6 @@ type GraphExchange interface {
 	// CancelResponse cancels an in progress response
 	CancelResponse(peer.ID, RequestID) error
 
-	// CancelRequest cancels an in progress response
+	// CancelRequest cancels an in progress request
 	CancelRequest(context.Context, RequestID) error
 }

--- a/graphsync.go
+++ b/graphsync.go
@@ -94,11 +94,12 @@ const (
 	RequestCancelled = ResponseStatusCode(35)
 )
 
-// RequestContextCancelledErr is an error message received on the error channel when the request context given by the user is cancelled/times out
-type RequestContextCancelledErr struct{}
+// RequestClientCancelledErr is an error message received on the error channel when the request is cancelled on by the client code,
+// either by closing the passed request context or calling CancelRequest
+type RequestClientCancelledErr struct{}
 
-func (e RequestContextCancelledErr) Error() string {
-	return "Request Context Cancelled"
+func (e RequestClientCancelledErr) Error() string {
+	return "Request Cancelled By Client"
 }
 
 // RequestFailedBusyErr is an error message received on the error channel when the peer is busy

--- a/graphsync.go
+++ b/graphsync.go
@@ -372,5 +372,5 @@ type GraphExchange interface {
 	CancelResponse(peer.ID, RequestID) error
 
 	// CancelRequest cancels an in progress response
-	CancelRequest(RequestID) error
+	CancelRequest(context.Context, RequestID) error
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -195,7 +195,7 @@ func (gs *GraphSync) RegisterIncomingRequestHook(hook graphsync.OnIncomingReques
 	return gs.incomingRequestHooks.Register(hook)
 }
 
-// RegisterIncomingRequestHook adds a hook that runs when a new incoming request is added
+// RegisterIncomingRequestQueuedHook adds a hook that runs when a new incoming request is added
 // to the responder's task queue.
 func (gs *GraphSync) RegisterIncomingRequestQueuedHook(hook graphsync.OnIncomingRequestQueuedHook) graphsync.UnregisterHookFunc {
 	return gs.incomingRequestQueuedHooks.Register(hook)
@@ -294,6 +294,11 @@ func (gs *GraphSync) PauseResponse(p peer.ID, requestID graphsync.RequestID) err
 // CancelResponse cancels an in progress response
 func (gs *GraphSync) CancelResponse(p peer.ID, requestID graphsync.RequestID) error {
 	return gs.responseManager.CancelResponse(p, requestID)
+}
+
+// CancelRequest cancels an in progress request
+func (gs *GraphSync) CancelRequest(requestID graphsync.RequestID) error {
+	return gs.requestManager.CancelRequest(requestID)
 }
 
 type graphSyncReceiver GraphSync

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -297,8 +297,8 @@ func (gs *GraphSync) CancelResponse(p peer.ID, requestID graphsync.RequestID) er
 }
 
 // CancelRequest cancels an in progress request
-func (gs *GraphSync) CancelRequest(requestID graphsync.RequestID) error {
-	return gs.requestManager.CancelRequest(requestID)
+func (gs *GraphSync) CancelRequest(ctx context.Context, requestID graphsync.RequestID) error {
+	return gs.requestManager.CancelRequest(ctx, requestID)
 }
 
 type graphSyncReceiver GraphSync

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -617,7 +617,7 @@ func TestNetworkDisconnect(t *testing.T) {
 
 	testutil.AssertReceive(ctx, t, networkError, &err, "should receive network error")
 	testutil.AssertReceive(ctx, t, errChan, &err, "should receive an error")
-	require.EqualError(t, err, graphsync.RequestContextCancelledErr{}.Error())
+	require.EqualError(t, err, graphsync.RequestClientCancelledErr{}.Error())
 	testutil.AssertReceive(ctx, t, receiverError, &err, "should receive an error on receiver side")
 }
 
@@ -653,7 +653,7 @@ func TestConnectFail(t *testing.T) {
 	var err error
 	testutil.AssertReceive(ctx, t, reqNetworkError, &err, "should receive network error")
 	testutil.AssertReceive(ctx, t, errChan, &err, "should receive an error")
-	require.EqualError(t, err, graphsync.RequestContextCancelledErr{}.Error())
+	require.EqualError(t, err, graphsync.RequestClientCancelledErr{}.Error())
 }
 
 func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {

--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -10,6 +10,12 @@ import (
 	"github.com/ipld/go-ipld-prime/traversal/selector"
 )
 
+/* TODO: This traverser creates an extra go-routine and is quite complicated, in order to give calling code control of
+a selector traversal. If it were implemented inside of go-ipld-primes traversal library, with access to private functions,
+it could be done without an extra go-routine, avoiding the possibility of races and simplifying implementation. This has
+been documented here: https://github.com/ipld/go-ipld-prime/issues/213 -- and when this issue is implemented, this traverser
+can go away */
+
 var defaultVisitor traversal.AdvVisitFn = func(traversal.Progress, ipld.Node, traversal.VisitReason) error { return nil }
 
 // ContextCancelError is a sentinel that indicates the passed in context
@@ -137,6 +143,7 @@ func (t *traverser) writeDone(err error) {
 func (t *traverser) start() {
 	select {
 	case <-t.ctx.Done():
+		close(t.stopped)
 		return
 	case t.awaitRequest <- struct{}{}:
 	}

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -38,7 +38,7 @@ type ExecutionEnv struct {
 type RequestExecution struct {
 	Ctx                  context.Context
 	P                    peer.ID
-	NetworkError         chan error
+	TerminalError        chan error
 	Request              gsmsg.GraphSyncRequest
 	LastResponse         *atomic.Value
 	DoNotSendCids        *cid.Set
@@ -54,7 +54,7 @@ func (ee ExecutionEnv) Start(re RequestExecution) (chan graphsync.ResponseProgre
 		inProgressErr:    make(chan error),
 		ctx:              re.Ctx,
 		p:                re.P,
-		networkError:     re.NetworkError,
+		terminalError:    re.TerminalError,
 		request:          re.Request,
 		lastResponse:     re.LastResponse,
 		doNotSendCids:    re.DoNotSendCids,
@@ -73,7 +73,7 @@ type requestExecutor struct {
 	inProgressErr     chan error
 	ctx               context.Context
 	p                 peer.ID
-	networkError      chan error
+	terminalError     chan error
 	request           gsmsg.GraphSyncRequest
 	lastResponse      *atomic.Value
 	nodeStyleChooser  traversal.LinkTargetNodePrototypeChooser
@@ -153,9 +153,9 @@ func (re *requestExecutor) run() {
 		}
 	}
 	select {
-	case networkError := <-re.networkError:
+	case terminalError := <-re.terminalError:
 		select {
-		case re.inProgressErr <- networkError:
+		case re.inProgressErr <- terminalError:
 		case <-re.env.Ctx.Done():
 		}
 	default:

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -443,6 +443,12 @@ func (trm *terminateRequestMessage) handle(rm *RequestManager) {
 func (crm *cancelRequestMessage) handle(rm *RequestManager) {
 	inProgressRequestStatus, ok := rm.inProgressRequestStatuses[crm.requestID]
 	if !ok {
+		if crm.onTerminated != nil {
+			select {
+			case crm.onTerminated <- errors.New("request not found"):
+			case <-rm.ctx.Done():
+			}
+		}
 		return
 	}
 

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -268,7 +268,7 @@ func (rm *RequestManager) cancelRequest(requestID graphsync.RequestID,
 // CancelRequest cancels the given request ID and waits for the request to terminate
 func (rm *RequestManager) CancelRequest(requestID graphsync.RequestID) error {
 	terminated := make(chan error, 1)
-	return rm.sendSyncMessage(&cancelRequestMessage{requestID, false, terminated, graphsync.RequestContextCancelledErr{}}, terminated)
+	return rm.sendSyncMessage(&cancelRequestMessage{requestID, false, terminated, graphsync.RequestClientCancelledErr{}}, terminated)
 }
 
 type processResponseMessage struct {

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -315,6 +315,8 @@ func (rm *RequestManager) sendSyncMessage(message requestManagerMessage, respons
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("Context Cancelled")
+	case <-done:
+		return errors.New("Context Cancelled")
 	case rm.messages <- message:
 	}
 	select {

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -43,11 +43,12 @@ type inProgressRequestStatus struct {
 	startTime      time.Time
 	cancelFn       func()
 	p              peer.ID
-	networkError   chan error
+	terminalError  chan error
 	resumeMessages chan []graphsync.ExtensionData
 	pauseMessages  chan struct{}
 	paused         bool
 	lastResponse   atomic.Value
+	onTerminated   []chan error
 }
 
 // PeerHandler is an interface that can send requests to peers
@@ -234,8 +235,10 @@ func (rm *RequestManager) singleErrorResponse(err error) (chan graphsync.Respons
 }
 
 type cancelRequestMessage struct {
-	requestID graphsync.RequestID
-	isPause   bool
+	requestID     graphsync.RequestID
+	isPause       bool
+	onTerminated  chan error
+	terminalError error
 }
 
 func (rm *RequestManager) cancelRequest(requestID graphsync.RequestID,
@@ -244,7 +247,7 @@ func (rm *RequestManager) cancelRequest(requestID graphsync.RequestID,
 	cancelMessageChannel := rm.messages
 	for cancelMessageChannel != nil || incomingResponses != nil || incomingErrors != nil {
 		select {
-		case cancelMessageChannel <- &cancelRequestMessage{requestID, false}:
+		case cancelMessageChannel <- &cancelRequestMessage{requestID, false, nil, nil}:
 			cancelMessageChannel = nil
 		// clear out any remaining responses, in case and "incoming reponse"
 		// messages get processed before our cancel message
@@ -260,6 +263,12 @@ func (rm *RequestManager) cancelRequest(requestID graphsync.RequestID,
 			return
 		}
 	}
+}
+
+// CancelRequest cancels the given request ID and waits for the request to terminate
+func (rm *RequestManager) CancelRequest(requestID graphsync.RequestID) error {
+	terminated := make(chan error, 1)
+	return rm.sendSyncMessage(&cancelRequestMessage{requestID, false, terminated, graphsync.RequestContextCancelledErr{}}, terminated)
 }
 
 type processResponseMessage struct {
@@ -374,9 +383,9 @@ func (nrm *newRequestMessage) setupRequest(requestID graphsync.RequestID, rm *Re
 	p := nrm.p
 	resumeMessages := make(chan []graphsync.ExtensionData, 1)
 	pauseMessages := make(chan struct{}, 1)
-	networkError := make(chan error, 1)
+	terminalError := make(chan error, 1)
 	requestStatus := &inProgressRequestStatus{
-		ctx: ctx, startTime: time.Now(), cancelFn: cancel, p: p, resumeMessages: resumeMessages, pauseMessages: pauseMessages, networkError: networkError,
+		ctx: ctx, startTime: time.Now(), cancelFn: cancel, p: p, resumeMessages: resumeMessages, pauseMessages: pauseMessages, terminalError: terminalError,
 	}
 	lastResponse := &requestStatus.lastResponse
 	lastResponse.Store(gsmsg.NewResponse(request.ID(), graphsync.RequestAcknowledged))
@@ -392,7 +401,7 @@ func (nrm *newRequestMessage) setupRequest(requestID graphsync.RequestID, rm *Re
 			Ctx:                  ctx,
 			P:                    p,
 			Request:              request,
-			NetworkError:         networkError,
+			TerminalError:        terminalError,
 			LastResponse:         lastResponse,
 			DoNotSendCids:        doNotSendCids,
 			NodePrototypeChooser: hooksResult.CustomChooser,
@@ -421,12 +430,30 @@ func (trm *terminateRequestMessage) handle(rm *RequestManager) {
 	}
 	delete(rm.inProgressRequestStatuses, trm.requestID)
 	rm.asyncLoader.CleanupRequest(trm.requestID)
+	if ok {
+		for _, onTerminated := range ipr.onTerminated {
+			select {
+			case <-rm.ctx.Done():
+			case onTerminated <- nil:
+			}
+		}
+	}
 }
 
 func (crm *cancelRequestMessage) handle(rm *RequestManager) {
 	inProgressRequestStatus, ok := rm.inProgressRequestStatuses[crm.requestID]
 	if !ok {
 		return
+	}
+
+	if crm.onTerminated != nil {
+		inProgressRequestStatus.onTerminated = append(inProgressRequestStatus.onTerminated, crm.onTerminated)
+	}
+	if crm.terminalError != nil {
+		select {
+		case inProgressRequestStatus.terminalError <- crm.terminalError:
+		default:
+		}
 	}
 
 	rm.sendRequest(inProgressRequestStatus.p, gsmsg.CancelRequest(crm.requestID))
@@ -488,8 +515,8 @@ func (rm *RequestManager) processExtensionsForResponse(p peer.ID, response gsmsg
 		}
 		responseError := rm.generateResponseErrorFromStatus(graphsync.RequestFailedUnknown)
 		select {
-		case requestStatus.networkError <- responseError:
-		case <-requestStatus.ctx.Done():
+		case requestStatus.terminalError <- responseError:
+		default:
 		}
 		rm.sendRequest(p, gsmsg.CancelRequest(response.RequestID()))
 		requestStatus.cancelFn()
@@ -505,8 +532,8 @@ func (rm *RequestManager) processTerminations(responses []gsmsg.GraphSyncRespons
 				requestStatus := rm.inProgressRequestStatuses[response.RequestID()]
 				responseError := rm.generateResponseErrorFromStatus(response.Status())
 				select {
-				case requestStatus.networkError <- responseError:
-				case <-requestStatus.ctx.Done():
+				case requestStatus.terminalError <- responseError:
+				default:
 				}
 				requestStatus.cancelFn()
 			}
@@ -542,7 +569,7 @@ func (rm *RequestManager) processBlockHooks(p peer.ID, response graphsync.Respon
 		_, isPause := result.Err.(hooks.ErrPaused)
 		select {
 		case <-rm.ctx.Done():
-		case rm.messages <- &cancelRequestMessage{response.RequestID(), isPause}:
+		case rm.messages <- &cancelRequestMessage{response.RequestID(), isPause, nil, nil}:
 		}
 	}
 	return result.Err

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -212,7 +212,7 @@ func TestCancelRequestInProgress(t *testing.T) {
 
 	errors := testutil.CollectErrors(requestCtx, t, returnedErrorChan1)
 	require.Len(t, errors, 1)
-	_, ok := errors[0].(graphsync.RequestContextCancelledErr)
+	_, ok := errors[0].(graphsync.RequestClientCancelledErr)
 	require.True(t, ok)
 }
 func TestCancelRequestImperativeNoMoreBlocks(t *testing.T) {
@@ -258,7 +258,7 @@ func TestCancelRequestImperativeNoMoreBlocks(t *testing.T) {
 
 	errors := testutil.CollectErrors(requestCtx, t, returnedErrorChan1)
 	require.Len(t, errors, 1)
-	_, ok := errors[0].(graphsync.RequestContextCancelledErr)
+	_, ok := errors[0].(graphsync.RequestClientCancelledErr)
 	require.True(t, ok)
 	fmt.Println("here")
 	select {

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -245,9 +245,10 @@ func TestCancelRequestImperativeNoMoreBlocks(t *testing.T) {
 		td.requestManager.ProcessResponses(peers[0], firstResponses, firstBlocks)
 		td.fal.SuccessResponseOn(requestRecords[0].gsr.ID(), firstBlocks)
 	}()
-	fmt.Println("her")
 
-	err := td.requestManager.CancelRequest(requestRecords[0].gsr.ID())
+	timeoutCtx, timeoutCancel := context.WithTimeout(ctx, time.Second)
+	defer timeoutCancel()
+	err := td.requestManager.CancelRequest(timeoutCtx, requestRecords[0].gsr.ID())
 	require.NoError(t, err)
 	postCancel <- struct{}{}
 

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -261,13 +261,11 @@ func TestCancelRequestImperativeNoMoreBlocks(t *testing.T) {
 	require.Len(t, errors, 1)
 	_, ok := errors[0].(graphsync.RequestClientCancelledErr)
 	require.True(t, ok)
-	fmt.Println("here")
 	select {
 	case <-loadPostCancel:
 		t.Fatalf("Loaded block after cancel")
 	case <-requestCtx.Done():
 	}
-	fmt.Println("here2")
 }
 
 func TestCancelManagerExitsGracefully(t *testing.T) {

--- a/requestmanager/responsecollector.go
+++ b/requestmanager/responsecollector.go
@@ -85,7 +85,7 @@ func (rc *responseCollector) collectResponses(
 			case <-requestCtx.Done():
 				select {
 				case <-rc.ctx.Done():
-				case returnedErrors <- graphsync.RequestContextCancelledErr{}:
+				case returnedErrors <- graphsync.RequestClientCancelledErr{}:
 				}
 				return
 			case err, ok := <-incomingErrors:
@@ -97,7 +97,7 @@ func (rc *responseCollector) collectResponses(
 					case <-requestCtx.Done():
 						select {
 						case <-rc.ctx.Done():
-						case returnedErrors <- graphsync.RequestContextCancelledErr{}:
+						case returnedErrors <- graphsync.RequestClientCancelledErr{}:
 						}
 					default:
 					}


### PR DESCRIPTION
# Goals

Add an imperative method that cancels a graphsync request and does not return until no further blocks can load and the request is completely cleaned up

# Implementation

- Add top level CancelRequest method
- Add requestmanager CancelRequest method
- CancelRequest
    - cancels the internal request context (this will trigger running request routines to terminate)
    - sends a cancellation to the other peer
    - waits for any processing to complete by adding a notfication channel that gets written only when all processing is complete for the request
    - sending RequestClientCancelledErr (formerly RequestContextCancelledErr)
 - rename poorly named private var "network error" to "terminal error"
 - protect against multiple terminal errors by only writing once
 - Fix race in IPLD util traversal
 - Rename RequestContextCancelledErr
 
 # For Discussion
 
 Would it make sense to have CancelRequest take a context, where if that context expired the routine would return even if the request had not signaled it was done (just in case?)

Fixes https://github.com/ipfs/go-graphsync/issues/184