### PR TITLE
Make sure linkcontext is passed

### DIFF
--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -166,7 +166,7 @@ func (t *traverser) checkState() {
 func (t *traverser) writeDone(err error) {
 	select {
 	case <-t.ctx.Done():
-	case t.stateChan <- state{true, err, nil, ipld.LinkContext{}}:
+	case t.stateChan <- state{true, err, nil, ipld.LinkContext{Ctx: t.ctx}}:
 	}
 }
 
@@ -179,7 +179,7 @@ func (t *traverser) start() {
 	}
 	go func() {
 		defer close(t.stopped)
-		ns, err := t.chooser(t.root, ipld.LinkContext{})
+		ns, err := t.chooser(t.root, ipld.LinkContext{Ctx: t.ctx})
 		if err != nil {
 			t.writeDone(err)
 			return

--- a/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
+++ b/requestmanager/asyncloader/loadattemptqueue/loadattemptqueue.go
@@ -13,10 +13,11 @@ import (
 // LoadRequest is a request to load the given link for the given request id,
 // with results returned to the given channel
 type LoadRequest struct {
-	p          peer.ID
-	requestID  graphsync.RequestID
-	link       ipld.Link
-	resultChan chan types.AsyncLoadResult
+	p           peer.ID
+	requestID   graphsync.RequestID
+	link        ipld.Link
+	linkContext ipld.LinkContext
+	resultChan  chan types.AsyncLoadResult
 }
 
 // NewLoadRequest returns a new LoadRequest for the given request id, link,
@@ -25,13 +26,14 @@ func NewLoadRequest(
 	p peer.ID,
 	requestID graphsync.RequestID,
 	link ipld.Link,
+	linkContext ipld.LinkContext,
 	resultChan chan types.AsyncLoadResult) LoadRequest {
-	return LoadRequest{p, requestID, link, resultChan}
+	return LoadRequest{p, requestID, link, linkContext, resultChan}
 }
 
 // LoadAttempter attempts to load a link to an array of bytes
 // and returns an async load result
-type LoadAttempter func(peer.ID, graphsync.RequestID, ipld.Link) types.AsyncLoadResult
+type LoadAttempter func(peer.ID, graphsync.RequestID, ipld.Link, ipld.LinkContext) types.AsyncLoadResult
 
 // LoadAttemptQueue attempts to load using the load attempter, and then can
 // place requests on a retry queue
@@ -50,7 +52,7 @@ func New(loadAttempter LoadAttempter) *LoadAttemptQueue {
 // AttemptLoad attempts to loads the given load request, and if retry is true
 // it saves the loadrequest for retrying later
 func (laq *LoadAttemptQueue) AttemptLoad(lr LoadRequest, retry bool) {
-	response := laq.loadAttempter(lr.p, lr.requestID, lr.link)
+	response := laq.loadAttempter(lr.p, lr.requestID, lr.link, lr.linkContext)
 	if response.Err != nil || response.Data != nil {
 		lr.resultChan <- response
 		close(lr.resultChan)

--- a/requestmanager/asyncloader/responsecache/responsecache.go
+++ b/requestmanager/asyncloader/responsecache/responsecache.go
@@ -21,7 +21,7 @@ var log = logging.Logger("graphsync")
 type UnverifiedBlockStore interface {
 	PruneBlocks(func(ipld.Link) bool)
 	PruneBlock(ipld.Link)
-	VerifyBlock(ipld.Link) ([]byte, error)
+	VerifyBlock(ipld.Link, ipld.LinkContext) ([]byte, error)
 	AddUnverifiedBlock(ipld.Link, []byte)
 }
 
@@ -55,13 +55,13 @@ func (rc *ResponseCache) FinishRequest(requestID graphsync.RequestID) {
 }
 
 // AttemptLoad attempts to laod the given block from the cache
-func (rc *ResponseCache) AttemptLoad(requestID graphsync.RequestID, link ipld.Link) ([]byte, error) {
+func (rc *ResponseCache) AttemptLoad(requestID graphsync.RequestID, link ipld.Link, linkContext ipld.LinkContext) ([]byte, error) {
 	rc.responseCacheLk.Lock()
 	defer rc.responseCacheLk.Unlock()
 	if rc.linkTracker.IsKnownMissingLink(requestID, link) {
 		return nil, fmt.Errorf("remote peer is missing block: %s", link.String())
 	}
-	data, _ := rc.unverifiedBlockStore.VerifyBlock(link)
+	data, _ := rc.unverifiedBlockStore.VerifyBlock(link, linkContext)
 	return data, nil
 }
 

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
@@ -59,7 +59,7 @@ func (ubs *UnverifiedBlockStore) PruneBlock(link ipld.Link) {
 
 // VerifyBlock verifies the data for the given link as being part of a traversal,
 // removes it from the unverified store, and writes it to permaneant storage.
-func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link) ([]byte, error) {
+func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link, linkContext ipld.LinkContext) ([]byte, error) {
 	data, ok := ubs.inMemoryBlocks[lnk]
 	if !ok {
 		return nil, fmt.Errorf("block not found")
@@ -68,7 +68,7 @@ func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link) ([]byte, error) {
 	ubs.dataSize = ubs.dataSize - uint64(len(data))
 	log.Debugw("verified block", "total_queued_bytes", ubs.dataSize)
 
-	buffer, committer, err := ubs.storer(ipld.LinkContext{})
+	buffer, committer, err := ubs.storer(linkContext)
 	if err != nil {
 		return nil, err
 	}

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
@@ -21,7 +21,7 @@ func TestVerifyBlockPresent(t *testing.T) {
 	require.Nil(t, reader)
 	require.Error(t, err, "block should not be loadable till it's verified and stored")
 
-	data, err := unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
+	data, err := unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
 	require.Nil(t, data)
 	require.Error(t, err, "block should not be verifiable till it's added as an unverifiable block")
 
@@ -30,7 +30,7 @@ func TestVerifyBlockPresent(t *testing.T) {
 	require.Nil(t, reader)
 	require.Error(t, err, "block should not be loadable till it's verified")
 
-	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
+	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
 	require.NoError(t, err)
 	require.Equal(t, block.RawData(), data, "block should be returned on verification if added")
 
@@ -40,7 +40,7 @@ func TestVerifyBlockPresent(t *testing.T) {
 	_, err = io.Copy(&buffer, reader)
 	require.NoError(t, err)
 	require.Equal(t, block.RawData(), buffer.Bytes(), "block should be stored and loadable after verification")
-	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()})
+	data, err = unverifiedBlockStore.VerifyBlock(cidlink.Link{Cid: block.Cid()}, ipld.LinkContext{})
 	require.Nil(t, data)
 	require.Error(t, err, "block cannot be verified twice")
 }

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -22,7 +22,7 @@ import (
 
 // AsyncLoadFn is a function which given a request id and an ipld.Link, returns
 // a channel which will eventually return data for the link or an err
-type AsyncLoadFn func(peer.ID, graphsync.RequestID, ipld.Link) <-chan types.AsyncLoadResult
+type AsyncLoadFn func(peer.ID, graphsync.RequestID, ipld.Link, ipld.LinkContext) <-chan types.AsyncLoadResult
 
 // ExecutionEnv are request parameters that last between requests
 type ExecutionEnv struct {
@@ -112,8 +112,8 @@ func (re *requestExecutor) traverse() error {
 		if isComplete {
 			return err
 		}
-		lnk, _ := traverser.CurrentRequest()
-		resultChan := re.env.Loader(re.p, re.request.ID(), lnk)
+		lnk, linkContext := traverser.CurrentRequest()
+		resultChan := re.env.Loader(re.p, re.request.ID(), lnk, linkContext)
 		var result types.AsyncLoadResult
 		select {
 		case result = <-resultChan:

--- a/requestmanager/requestmanager.go
+++ b/requestmanager/requestmanager.go
@@ -61,7 +61,7 @@ type AsyncLoader interface {
 	StartRequest(graphsync.RequestID, string) error
 	ProcessResponse(p peer.ID, responses map[graphsync.RequestID]metadata.Metadata,
 		blks []blocks.Block)
-	AsyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link) <-chan types.AsyncLoadResult
+	AsyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link, linkContext ipld.LinkContext) <-chan types.AsyncLoadResult
 	CompleteResponsesFor(requestID graphsync.RequestID)
 	CleanupRequest(requestID graphsync.RequestID)
 }

--- a/requestmanager/testloader/asyncloader.go
+++ b/requestmanager/testloader/asyncloader.go
@@ -102,7 +102,7 @@ func (fal *FakeAsyncLoader) VerifyStoreUsed(t *testing.T, requestID graphsync.Re
 	fal.storesRequestedLk.RUnlock()
 }
 
-func (fal *FakeAsyncLoader) asyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link) chan types.AsyncLoadResult {
+func (fal *FakeAsyncLoader) asyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link, linkContext ipld.LinkContext) chan types.AsyncLoadResult {
 	fal.responseChannelsLk.Lock()
 	responseChannel, ok := fal.responseChannels[requestKey{p, requestID, link}]
 	if !ok {
@@ -119,8 +119,8 @@ func (fal *FakeAsyncLoader) OnAsyncLoad(cb func(graphsync.RequestID, ipld.Link, 
 }
 
 // AsyncLoad simulates an asynchronous load with responses stubbed by ResponseOn & SuccessResponseOn
-func (fal *FakeAsyncLoader) AsyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link) <-chan types.AsyncLoadResult {
-	res := fal.asyncLoad(p, requestID, link)
+func (fal *FakeAsyncLoader) AsyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link, linkContext ipld.LinkContext) <-chan types.AsyncLoadResult {
+	res := fal.asyncLoad(p, requestID, link, linkContext)
 	if fal.cb != nil {
 		fal.cb(requestID, link, res)
 	}
@@ -146,7 +146,7 @@ func (fal *FakeAsyncLoader) CleanupRequest(requestID graphsync.RequestID) {
 // "asynchronous" load, this can be called AFTER the attempt to load this link -- and the client will only get
 // the response at that point
 func (fal *FakeAsyncLoader) ResponseOn(p peer.ID, requestID graphsync.RequestID, link ipld.Link, result types.AsyncLoadResult) {
-	responseChannel := fal.asyncLoad(p, requestID, link)
+	responseChannel := fal.asyncLoad(p, requestID, link, ipld.LinkContext{})
 	responseChannel <- result
 	close(responseChannel)
 }


### PR DESCRIPTION
# Goals

LinkContexts passed during selector traversals should always pass through our intercepted loading system so they make it to the base BlockReadOpener / BlockWriteOpener functions on the linksystem passed during setup

# Implementation

- Track everywhere we load in this system, and all locations where we are passing blank LinkContext
- Add parameters as needed to insure LinkContext is passed.