### PR TITLE
Include the size of metadata in estimated message size used to break up messages sent on the wire

### DIFF
--- a/message/builder_test.go
+++ b/message/builder_test.go
@@ -47,7 +47,12 @@ func TestMessageBuilding(t *testing.T) {
 		rb.AddBlock(block)
 	}
 
-	require.Equal(t, uint64(300), rb.BlockSize(), "did not calculate block size correctly")
+	require.Equal(t,
+		uint64(300)+
+			(metadata.ItemBinarySizeWithoutCID*8)+
+			uint64(links[0].(cidlink.Link).Cid.ByteLen()*2)+
+			uint64(links[1].(cidlink.Link).Cid.ByteLen()*4)+
+			uint64(links[2].(cidlink.Link).Cid.ByteLen()*2), rb.EstimatedMessageSize(), "did not calculate block size correctly")
 
 	extensionData1 := testutil.RandomBytes(100)
 	extensionName1 := graphsync.ExtensionName("AppleSauce/McGee")

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -19,8 +19,8 @@ var log = logging.Logger("graphsync")
 
 const maxRetries = 10
 
-// max block size is the maximum size for batching blocks in a single payload
-const maxBlockSize uint64 = 512 * 1024
+// maxEstimatedMessageSize is the maximum estimated size of batched items in a single message payload
+const maxEstimatedMessageSize uint64 = 512 * 1024
 
 type EventName uint64
 
@@ -117,7 +117,7 @@ func shouldBeginNewResponse(builders []*gsmsg.Builder, blkSize uint64) bool {
 	if blkSize == 0 {
 		return false
 	}
-	return builders[len(builders)-1].BlockSize()+blkSize > maxBlockSize
+	return builders[len(builders)-1].EstimatedMessageSize()+blkSize > maxEstimatedMessageSize
 }
 
 // Startup starts the processing of messages, and creates an initial message
@@ -198,7 +198,7 @@ func (mq *MessageQueue) extractOutgoingMessage() (gsmsg.GraphSyncMessage, *messa
 		return gsmsg.GraphSyncMessage{}, nil, errEmptyMessage
 	}
 	message, err := builder.Build()
-	return message, &messagePublisher{mq, builder.Topic(), builder.BlockSize()}, err
+	return message, &messagePublisher{mq, builder.Topic(), builder.EstimatedMessageSize()}, err
 }
 
 func (mq *MessageQueue) sendMessage() {

--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -9,6 +9,24 @@ import (
 	xerrors "golang.org/x/xerrors"
 )
 
+// ItemBinarySizeWithoutCID is the fixed binary size of each link item
+// added to the metadata, minus the CID itself which varies in length
+const ItemBinarySizeWithoutCID uint64 = (1 + //  w.Write([]byte{162})
+	1 + // cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("link")))
+	4 + // io.WriteString(w, "link")
+	2 + //  WriteMajorTypeHeaderBuf(buf, w, MajTag, 42)
+	2 + // WriteMajorTypeHeaderBuf(buf, w, MajByteString, uint64(c.ByteLen()+1))
+	1 + // w.Write(byteArrZero)
+	// left out: c.WriteBytes(w)
+	1 + // cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajTextString, uint64(len("blockPresent")))
+	13 + //io.WriteString(w, "blockPresent")
+	1) // cbg.WriteBool(w, t.BlockPresent)
+// == 26
+
+// 32768 * ~66bytes per link = ~2MB -- seems like a reasonable upper bound to
+// allocate
+const maxLinks = 1 << 15
+
 // Item is a single link traversed in a repsonse
 type Item struct {
 	Link         cid.Cid
@@ -33,7 +51,7 @@ func DecodeMetadata(data []byte) (Metadata, error) {
 		return nil, err
 	}
 
-	if extra > cbg.MaxLength {
+	if extra > maxLinks {
 		return nil, fmt.Errorf("t.Metadata: array too large (%d)", extra)
 	}
 
@@ -62,7 +80,7 @@ func DecodeMetadata(data []byte) (Metadata, error) {
 func EncodeMetadata(entries Metadata) ([]byte, error) {
 	w := new(bytes.Buffer)
 	scratch := make([]byte, 9)
-	if len(entries) > cbg.MaxLength {
+	if len(entries) > maxLinks {
 		return nil, xerrors.Errorf("Slice value was too long")
 	}
 	if err := cbg.WriteMajorTypeHeaderBuf(scratch, w, cbg.MajArray, uint64(len(entries))); err != nil {


### PR DESCRIPTION
# Goals

We are seeing messages erroring out with "Slice value was too long" taken from https://github.com/ipfs/go-graphsync/blob/main/metadata/metadata.go#L66. This suggests messages are being assembled with more than 8192 links in the metadata (cbg.MaxLength)

# Implementation

This PR does two things:
1. Estimates the size of the encoded metadata and includes it in the estimated message size. The estimated message size is used to break up messages before they get too large to send on the wire. This will prevent an super high number of links getting included in a message.
2. It increases the maximum allowed links for metadata. 8192 is potentially quite small. The scenario this could come up in is with a slow client, responding to a resumed data transfer request where most of the CIDs have already been sent. The responder is still going to send all the metadata for the blocks it traversed, even if it does not send the blocks themselves. Counting the size of the metadata in the estimated message size should keep too many links from getting sent in a single message (the message queue breaks up messages at 512KB). At the same time, the total could creep past 8192. (8192 * 64 bytes per link = 512KB -- links could be less than 64 bytes if the CIDS are shorts) Increasing the limit per message to 32768 seems like a sure fire way to prevent the number from getting too large -- the message will get broken up long before then with the new county of metadata in total message size.

# For discussion

These seem like a lot of sensistive constants. I've done my best to notate where they come from and their rationale but it still feels like there are a few hidden dependencies. But I'm not sure what else we can do.