### PR TITLE
Remove main thread block on allocation

### DIFF
--- a/requestmanager/asyncloader/asyncloader.go
+++ b/requestmanager/asyncloader/asyncloader.go
@@ -31,7 +31,6 @@ type alternateQueue struct {
 
 // Allocator indicates a mechanism for tracking memory used by a given peer
 type Allocator interface {
-	AllocateBlockMemory(p peer.ID, amount uint64) <-chan error
 	ReleaseBlockMemory(p peer.ID, amount uint64) error
 }
 
@@ -113,16 +112,8 @@ func (al *AsyncLoader) StartRequest(requestID graphsync.RequestID, persistenceOp
 
 // ProcessResponse injests new responses and completes asynchronous loads as
 // neccesary
-func (al *AsyncLoader) ProcessResponse(p peer.ID, responses map[graphsync.RequestID]metadata.Metadata,
+func (al *AsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
-	totalMemoryAllocated := uint64(0)
-	for _, blk := range blks {
-		totalMemoryAllocated += uint64(len(blk.RawData()))
-	}
-	select {
-	case <-al.allocator.AllocateBlockMemory(p, totalMemoryAllocated):
-	case <-al.ctx.Done():
-	}
 	select {
 	case <-al.ctx.Done():
 	case al.incomingMessages <- &newResponsesAvailableMessage{responses, blks}:

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -49,7 +49,7 @@ func TestAsyncLoadInitialLoadSucceedsResponsePresent(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(p, responses, blocks)
+		asyncLoader.ProcessResponse(responses, blocks)
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 
 		assertSuccessResponse(ctx, t, resultChan)
@@ -73,7 +73,7 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(p, responses, nil)
+		asyncLoader.ProcessResponse(responses, nil)
 
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 		assertFailResponse(ctx, t, resultChan)
@@ -117,7 +117,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(p, responses, blocks)
+		asyncLoader.ProcessResponse(responses, blocks)
 		assertSuccessResponse(ctx, t, resultChan)
 		st.AssertLocalLoads(t, 1)
 		st.AssertBlockStored(t, block)
@@ -145,7 +145,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(p, responses, nil)
+		asyncLoader.ProcessResponse(responses, nil)
 		assertFailResponse(ctx, t, resultChan)
 		st.AssertLocalLoads(t, 1)
 	})
@@ -183,7 +183,7 @@ func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(p, responses, blocks)
+		asyncLoader.ProcessResponse(responses, blocks)
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 
 		assertSuccessResponse(ctx, t, resultChan)
@@ -283,7 +283,7 @@ func TestRequestSplittingSameBlockTwoStores(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(p, responses, blocks)
+		asyncLoader.ProcessResponse(responses, blocks)
 
 		assertSuccessResponse(ctx, t, resultChan1)
 		assertSuccessResponse(ctx, t, resultChan2)
@@ -318,7 +318,7 @@ func TestRequestSplittingSameBlockOnlyOneResponse(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(p, responses, blocks)
+		asyncLoader.ProcessResponse(responses, blocks)
 		asyncLoader.CompleteResponsesFor(requestID1)
 
 		assertFailResponse(ctx, t, resultChan1)

--- a/requestmanager/testloader/asyncloader.go
+++ b/requestmanager/testloader/asyncloader.go
@@ -61,7 +61,7 @@ func (fal *FakeAsyncLoader) StartRequest(requestID graphsync.RequestID, name str
 }
 
 // ProcessResponse just records values passed to verify expectations later
-func (fal *FakeAsyncLoader) ProcessResponse(p peer.ID, responses map[graphsync.RequestID]metadata.Metadata,
+func (fal *FakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
 	fal.responses <- responses
 	fal.blks <- blks


### PR DESCRIPTION
# Goals

When memory backpressure for requests was introduced, it was introduced in such a way that not only blocks processing of further libp2p messages, but also blocks the main thread of the request manager. This may have serious side effects, as this effectively can cause the request manager to sieze up and not processing other commands like cancelling requests.

# Implementation

Move potentially blocking memory allocation out of the main AsyncLoader & the internals of the main RequestManager thread, and into the per-peer thread of the libp2p message handler. This has the same effect of blocking reading further libp2p messages on the stream, and preserving memory, while at the same time not blocking the request manager thread.

Also removes parameter from AsyncLoader.ProcessResponses that is now spurious.