### PR TITLE
Add request limits

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -42,7 +42,7 @@ type GraphSync struct {
 	requestManager              *requestmanager.RequestManager
 	responseManager             *responsemanager.ResponseManager
 	asyncLoader                 *asyncloader.AsyncLoader
-	requestQueue                *taskqueue.TaskQueue
+	requestQueue                taskqueue.TaskQueue
 	requestExecutor             *executor.Executor
 	responseAssembler           *responseassembler.ResponseAssembler
 	peerTaskQueue               *peertaskqueue.PeerTaskQueue

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -416,7 +416,7 @@ func TestPauseResumeRequest(t *testing.T) {
 
 	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
 
-	blockChain.VerifyResponseRange(ctx, progressChan, 0, stopPoint-1)
+	blockChain.VerifyResponseRange(ctx, progressChan, 0, stopPoint)
 	timer := time.NewTimer(100 * time.Millisecond)
 	testutil.AssertDoesReceiveFirst(t, timer.C, "should pause request", progressChan)
 
@@ -424,7 +424,7 @@ func TestPauseResumeRequest(t *testing.T) {
 	err := requestor.UnpauseRequest(requestID, td.extensionUpdate)
 	require.NoError(t, err)
 
-	blockChain.VerifyRemainder(ctx, progressChan, stopPoint-1)
+	blockChain.VerifyRemainder(ctx, progressChan, stopPoint)
 	testutil.VerifyEmptyErrors(ctx, t, errChan)
 	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
 }

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -93,7 +93,7 @@ type RequestManager struct {
 	requestHooks              RequestHooks
 	responseHooks             ResponseHooks
 	networkErrorListeners     *listeners.NetworkErrorListeners
-	requestQueue              *taskqueue.TaskQueue
+	requestQueue              taskqueue.TaskQueue
 }
 
 type requestManagerMessage interface {
@@ -117,7 +117,7 @@ func New(ctx context.Context,
 	requestHooks RequestHooks,
 	responseHooks ResponseHooks,
 	networkErrorListeners *listeners.NetworkErrorListeners,
-	requestQueue *taskqueue.TaskQueue,
+	requestQueue taskqueue.TaskQueue,
 ) *RequestManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &RequestManager{

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -41,6 +41,14 @@ const (
 	defaultPriority = graphsync.Priority(0)
 )
 
+type state uint64
+
+const (
+	queued state = iota
+	running
+	paused
+)
+
 type inProgressRequestStatus struct {
 	ctx              context.Context
 	startTime        time.Time
@@ -48,7 +56,7 @@ type inProgressRequestStatus struct {
 	p                peer.ID
 	terminalError    error
 	pauseMessages    chan struct{}
-	paused           bool
+	state            state
 	lastResponse     atomic.Value
 	onTerminated     []chan<- error
 	request          gsmsg.GraphSyncRequest

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -73,7 +73,9 @@ func (e *Executor) ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.
 	log.Debugw("beginning request execution", "id", requestTask.Request.ID(), "peer", pid.String(), "root_cid", requestTask.Request.Root().String())
 	err := e.traverse(requestTask)
 	if err != nil {
-		e.manager.SendRequest(requestTask.P, gsmsg.CancelRequest(requestTask.Request.ID()))
+		if !isContextErr(err) {
+			e.manager.SendRequest(requestTask.P, gsmsg.CancelRequest(requestTask.Request.ID()))
+		}
 		if !isContextErr(err) && !isPausedErr(err) {
 			select {
 			case <-requestTask.Ctx.Done():

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal"
@@ -18,183 +19,170 @@ import (
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
+	logging "github.com/ipfs/go-log/v2"
 )
+
+var log = logging.Logger("gs_request_executor")
+
+// Manager are the Executor uses to interact with the request manager
+type Manager interface {
+	SendRequest(peer.ID, gsmsg.GraphSyncRequest)
+	GetRequestTask(peer.ID, *peertask.Task, chan RequestTask)
+	ReleaseRequestTask(peer.ID, *peertask.Task, error)
+}
+
+// BlockHooks run for each block loaded
+type BlockHooks interface {
+	ProcessBlockHooks(p peer.ID, response graphsync.ResponseData, block graphsync.BlockData) hooks.UpdateResult
+}
 
 // AsyncLoadFn is a function which given a request id and an ipld.Link, returns
 // a channel which will eventually return data for the link or an err
 type AsyncLoadFn func(peer.ID, graphsync.RequestID, ipld.Link, ipld.LinkContext) <-chan types.AsyncLoadResult
 
-// ExecutionEnv are request parameters that last between requests
-type ExecutionEnv struct {
-	Ctx              context.Context
-	SendRequest      func(peer.ID, gsmsg.GraphSyncRequest)
-	RunBlockHooks    func(p peer.ID, response graphsync.ResponseData, blk graphsync.BlockData) error
-	TerminateRequest func(graphsync.RequestID)
-	WaitForMessages  func(ctx context.Context, resumeMessages chan graphsync.ExtensionData) ([]graphsync.ExtensionData, error)
-	Loader           AsyncLoadFn
-	LinkSystem       ipld.LinkSystem
+type Executor struct {
+	manager    Manager
+	blockHooks BlockHooks
+	loader     AsyncLoadFn
 }
 
-// RequestExecution are parameters for a single request execution
-type RequestExecution struct {
-	Ctx                  context.Context
-	P                    peer.ID
-	TerminalError        chan error
-	Request              gsmsg.GraphSyncRequest
-	LastResponse         *atomic.Value
-	DoNotSendCids        *cid.Set
-	NodePrototypeChooser traversal.LinkTargetNodePrototypeChooser
-	ResumeMessages       chan []graphsync.ExtensionData
-	PauseMessages        chan struct{}
-}
-
-// Start begins execution of a request in a go routine
-func (ee ExecutionEnv) Start(re RequestExecution) (chan graphsync.ResponseProgress, chan error) {
-	executor := &requestExecutor{
-		inProgressChan:   make(chan graphsync.ResponseProgress),
-		inProgressErr:    make(chan error),
-		ctx:              re.Ctx,
-		p:                re.P,
-		terminalError:    re.TerminalError,
-		request:          re.Request,
-		lastResponse:     re.LastResponse,
-		doNotSendCids:    re.DoNotSendCids,
-		nodeStyleChooser: re.NodePrototypeChooser,
-		resumeMessages:   re.ResumeMessages,
-		pauseMessages:    re.PauseMessages,
-		env:              ee,
+func NewExecutor(
+	manager Manager,
+	blockHooks BlockHooks,
+	loader AsyncLoadFn) *Executor {
+	return &Executor{
+		manager:    manager,
+		blockHooks: blockHooks,
+		loader:     loader,
 	}
-	executor.sendRequest(executor.request)
-	go executor.run()
-	return executor.inProgressChan, executor.inProgressErr
 }
 
-type requestExecutor struct {
-	inProgressChan    chan graphsync.ResponseProgress
-	inProgressErr     chan error
-	ctx               context.Context
-	p                 peer.ID
-	terminalError     chan error
-	request           gsmsg.GraphSyncRequest
-	lastResponse      *atomic.Value
-	nodeStyleChooser  traversal.LinkTargetNodePrototypeChooser
-	resumeMessages    chan []graphsync.ExtensionData
-	pauseMessages     chan struct{}
-	doNotSendCids     *cid.Set
-	env               ExecutionEnv
-	restartNeeded     bool
-	pendingExtensions []graphsync.ExtensionData
-}
-
-func (re *requestExecutor) visitor(tp traversal.Progress, node ipld.Node, tr traversal.VisitReason) error {
+func (e *Executor) ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.Task) bool {
+	requestTaskChan := make(chan RequestTask)
+	var requestTask RequestTask
+	e.manager.GetRequestTask(pid, task, requestTaskChan)
 	select {
-	case <-re.ctx.Done():
-	case re.inProgressChan <- graphsync.ResponseProgress{
-		Node:      node,
-		Path:      tp.Path,
-		LastBlock: tp.LastBlock,
-	}:
+	case requestTask = <-requestTaskChan:
+	case <-ctx.Done():
+		return true
 	}
-	return nil
+	if requestTask.Empty {
+		log.Info("Empty task on peer request stack")
+		return false
+	}
+	log.Debugw("beginning request execution", "id", requestTask.Request.ID(), "peer", pid.String(), "root_cid", requestTask.Request.Root().String())
+	err := e.traverse(requestTask)
+	if err != nil {
+		e.manager.SendRequest(requestTask.P, gsmsg.CancelRequest(requestTask.Request.ID()))
+		if !isContextErr(err) && !isPausedErr(err) {
+			select {
+			case <-requestTask.Ctx.Done():
+			case requestTask.InProgressErr <- err:
+			}
+		}
+	}
+	e.manager.ReleaseRequestTask(pid, task, err)
+	log.Debugw("finishing response execution", "id", requestTask.Request.ID(), "peer", pid.String(), "root_cid", requestTask.Request.Root().String())
+	return false
 }
 
-func (re *requestExecutor) traverse() error {
-	traverser := ipldutil.TraversalBuilder{
-		Root:       cidlink.Link{Cid: re.request.Root()},
-		Selector:   re.request.Selector(),
-		Visitor:    re.visitor,
-		Chooser:    re.nodeStyleChooser,
-		LinkSystem: re.env.LinkSystem,
-	}.Start(re.ctx)
-	defer traverser.Shutdown(context.Background())
+// RequestTask are parameters for a single request execution
+type RequestTask struct {
+	Ctx            context.Context
+	Request        gsmsg.GraphSyncRequest
+	LastResponse   *atomic.Value
+	DoNotSendCids  *cid.Set
+	PauseMessages  <-chan struct{}
+	Traverser      ipldutil.Traverser
+	P              peer.ID
+	InProgressErr  chan error
+	Empty          bool
+	InitialRequest bool
+}
+
+func (e *Executor) traverse(rt RequestTask) error {
+	onlyOnce := &onlyOnce{e, rt, false}
+	// for initial request, start remote right away
+	if rt.InitialRequest {
+		if err := onlyOnce.startRemoteRequest(); err != nil {
+			return err
+		}
+	}
 	for {
-		isComplete, err := traverser.IsComplete()
+		// check if traversal is complete
+		isComplete, err := rt.Traverser.IsComplete()
 		if isComplete {
 			return err
 		}
-		lnk, linkContext := traverser.CurrentRequest()
-		resultChan := re.env.Loader(re.p, re.request.ID(), lnk, linkContext)
+		// get current link request
+		lnk, linkContext := rt.Traverser.CurrentRequest()
+		// attempt to load
+		log.Debugf("will load link=%s", lnk)
+		resultChan := e.loader(rt.P, rt.Request.ID(), lnk, linkContext)
 		var result types.AsyncLoadResult
+		// check for immediate result
 		select {
 		case result = <-resultChan:
 		default:
-			err := re.sendRestartAsNeeded()
-			if err != nil {
+			// if no immediate result
+			// initiate remote request if not already sent (we want to fill out the doNotSendCids on a resume)
+			if err := onlyOnce.startRemoteRequest(); err != nil {
 				return err
 			}
+			// wait for block result
 			select {
-			case <-re.ctx.Done():
+			case <-rt.Ctx.Done():
 				return ipldutil.ContextCancelError{}
 			case result = <-resultChan:
 			}
 		}
-		err = re.processResult(traverser, lnk, result)
-		if _, ok := err.(hooks.ErrPaused); ok {
-			err = re.waitForResume()
-			if err != nil {
-				return err
-			}
-			err = traverser.Advance(bytes.NewBuffer(result.Data))
-			if err != nil {
-				return err
-			}
-		} else if err != nil {
+		log.Debugf("successfully loaded link=%s, nBlocksRead=%d", lnk, rt.Traverser.NBlocksTraversed())
+		// advance the traversal based on results
+		err = e.advanceTraversal(rt, result)
+		if err != nil {
+			return err
+		}
+
+		// check for interrupts and run block hooks
+		err = e.processResult(rt, lnk, result)
+		if err != nil {
 			return err
 		}
 	}
 }
 
-func (re *requestExecutor) run() {
-	err := re.traverse()
-	if err != nil {
-		if !isContextErr(err) {
-			select {
-			case <-re.ctx.Done():
-			case re.inProgressErr <- err:
-			}
-		}
+func (e *Executor) processBlockHooks(p peer.ID, response graphsync.ResponseData, block graphsync.BlockData) error {
+	result := e.blockHooks.ProcessBlockHooks(p, response, block)
+	if len(result.Extensions) > 0 {
+		updateRequest := gsmsg.UpdateRequest(response.RequestID(), result.Extensions...)
+		e.manager.SendRequest(p, updateRequest)
 	}
-	select {
-	case terminalError := <-re.terminalError:
+	return result.Err
+}
+
+func (e *Executor) onNewBlock(rt RequestTask, block graphsync.BlockData) error {
+	rt.DoNotSendCids.Add(block.Link().(cidlink.Link).Cid)
+	response := rt.LastResponse.Load().(gsmsg.GraphSyncResponse)
+	return e.processBlockHooks(rt.P, response, block)
+}
+
+func (e *Executor) advanceTraversal(rt RequestTask, result types.AsyncLoadResult) error {
+	if result.Err != nil {
 		select {
-		case re.inProgressErr <- terminalError:
-		case <-re.env.Ctx.Done():
+		case <-rt.Ctx.Done():
+			return ipldutil.ContextCancelError{}
+		case rt.InProgressErr <- result.Err:
+			rt.Traverser.Error(traversal.SkipMe{})
+			return nil
 		}
-	default:
 	}
-	re.terminateRequest()
-	close(re.inProgressChan)
-	close(re.inProgressErr)
+	return rt.Traverser.Advance(bytes.NewBuffer(result.Data))
 }
 
-func (re *requestExecutor) sendRequest(request gsmsg.GraphSyncRequest) {
-	re.env.SendRequest(re.p, request)
-}
-
-func (re *requestExecutor) terminateRequest() {
-	re.env.TerminateRequest(re.request.ID())
-}
-
-func (re *requestExecutor) runBlockHooks(blk graphsync.BlockData) error {
-	response := re.lastResponse.Load().(gsmsg.GraphSyncResponse)
-	return re.env.RunBlockHooks(re.p, response, blk)
-}
-
-func (re *requestExecutor) waitForResume() error {
+func (e *Executor) processResult(rt RequestTask, link ipld.Link, result types.AsyncLoadResult) error {
+	err := e.onNewBlock(rt, &blockData{link, result.Local, uint64(len(result.Data))})
 	select {
-	case <-re.ctx.Done():
-		return ipldutil.ContextCancelError{}
-	case re.pendingExtensions = <-re.resumeMessages:
-		re.restartNeeded = true
-		return nil
-	}
-}
-
-func (re *requestExecutor) onNewBlockWithPause(block graphsync.BlockData) error {
-	err := re.onNewBlock(block)
-	select {
-	case <-re.pauseMessages:
-		re.sendRequest(gsmsg.CancelRequest(re.request.ID()))
+	case <-rt.PauseMessages:
 		if err == nil {
 			err = hooks.ErrPaused{}
 		}
@@ -203,52 +191,42 @@ func (re *requestExecutor) onNewBlockWithPause(block graphsync.BlockData) error 
 	return err
 }
 
-func (re *requestExecutor) onNewBlock(block graphsync.BlockData) error {
-	re.doNotSendCids.Add(block.Link().(cidlink.Link).Cid)
-	return re.runBlockHooks(block)
-}
-
-func (re *requestExecutor) processResult(traverser ipldutil.Traverser, link ipld.Link, result types.AsyncLoadResult) error {
-	if result.Err != nil {
-		select {
-		case <-re.ctx.Done():
-			return ipldutil.ContextCancelError{}
-		case re.inProgressErr <- result.Err:
-			traverser.Error(traversal.SkipMe{})
-			return nil
+func (e *Executor) startRemoteRequest(rt RequestTask) error {
+	request := rt.Request
+	if rt.DoNotSendCids.Len() > 0 {
+		cidsData, err := cidset.EncodeCidSet(rt.DoNotSendCids)
+		if err != nil {
+			return err
 		}
+		request = rt.Request.ReplaceExtensions([]graphsync.ExtensionData{{Name: graphsync.ExtensionDoNotSendCIDs, Data: cidsData}})
 	}
-	err := re.onNewBlockWithPause(&blockData{link, result.Local, uint64(len(result.Data))})
-	if err != nil {
-		return err
-	}
-	err = traverser.Advance(bytes.NewBuffer(result.Data))
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func (re *requestExecutor) sendRestartAsNeeded() error {
-	if !re.restartNeeded {
-		return nil
-	}
-	extensions := re.pendingExtensions
-	re.pendingExtensions = nil
-	re.restartNeeded = false
-	cidsData, err := cidset.EncodeCidSet(re.doNotSendCids)
-	if err != nil {
-		return err
-	}
-	extensions = append(extensions, graphsync.ExtensionData{Name: graphsync.ExtensionDoNotSendCIDs, Data: cidsData})
-	re.request = re.request.ReplaceExtensions(extensions)
-	re.sendRequest(re.request)
+	log.Debugw("starting remote request", "id", rt.Request.ID(), "peer", rt.P.String(), "root_cid", rt.Request.Root().String())
+	e.manager.SendRequest(rt.P, request)
 	return nil
 }
 
 func isContextErr(err error) bool {
 	// TODO: Match with errors.Is when https://github.com/ipld/go-ipld-prime/issues/58 is resolved
 	return strings.Contains(err.Error(), ipldutil.ContextCancelError{}.Error())
+}
+
+func isPausedErr(err error) bool {
+	_, isPaused := err.(hooks.ErrPaused)
+	return isPaused
+}
+
+type onlyOnce struct {
+	e           *Executor
+	rt          RequestTask
+	requestSent bool
+}
+
+func (so *onlyOnce) startRemoteRequest() error {
+	if so.requestSent {
+		return nil
+	}
+	so.requestSent = true
+	return so.e.startRemoteRequest(so.rt)
 }
 
 type blockData struct {

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -172,6 +172,12 @@ func (e *Executor) onNewBlock(rt RequestTask, block graphsync.BlockData) error {
 
 func (e *Executor) advanceTraversal(rt RequestTask, result types.AsyncLoadResult) error {
 	if result.Err != nil {
+		// before processing result check for context cancel to avoid sending an additional error
+		select {
+		case <-rt.Ctx.Done():
+			return ipldutil.ContextCancelError{}
+		default:
+		}
 		select {
 		case <-rt.Ctx.Done():
 			return ipldutil.ContextCancelError{}

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -9,9 +9,10 @@ import (
 	"time"
 
 	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-peertaskqueue/peertask"
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
-	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+	"github.com/ipld/go-ipld-prime/traversal"
 	peer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
@@ -38,219 +39,137 @@ func TestRequestExecutionBlockChain(t *testing.T) {
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
 				tbc.VerifyWholeChainSync(responses)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 0, ree.currentWaitForResumeResult)
 				require.Equal(t, []requestSent{{ree.p, ree.request}}, ree.requestsSent)
 				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.NoError(t, ree.terminalError)
 			},
 		},
 		"error at block hook": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = errors.New("something went wrong")
+				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.UpdateResult{Err: errors.New("something went wrong")}
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyResponseRangeSync(responses, 0, 5)
+				tbc.VerifyResponseRangeSync(responses, 0, 6)
 				require.Len(t, receivedErrors, 1)
 				require.Regexp(t, "something went wrong", receivedErrors[0].Error())
-				require.Equal(t, 0, ree.currentWaitForResumeResult)
-				require.Equal(t, []requestSent{{ree.p, ree.request}}, ree.requestsSent)
+				require.Len(t, ree.requestsSent, 2)
+				require.Equal(t, ree.request, ree.requestsSent[0].request)
+				require.True(t, ree.requestsSent[1].request.IsCancel())
 				require.Len(t, ree.blookHooksCalled, 6)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.EqualError(t, ree.terminalError, "something went wrong")
 			},
 		},
 		"context cancelled": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = ipldutil.ContextCancelError{}
+				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.UpdateResult{Err: ipldutil.ContextCancelError{}}
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyResponseRangeSync(responses, 0, 5)
+				tbc.VerifyResponseRangeSync(responses, 0, 6)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 0, ree.currentWaitForResumeResult)
-				require.Equal(t, []requestSent{{ree.p, ree.request}}, ree.requestsSent)
+				require.Len(t, ree.requestsSent, 2)
+				require.Equal(t, ree.request, ree.requestsSent[0].request)
+				require.True(t, ree.requestsSent[1].request.IsCancel())
 				require.Len(t, ree.blookHooksCalled, 6)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.EqualError(t, ree.terminalError, ipldutil.ContextCancelError{}.Error())
 			},
 		},
 		"simple pause": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.ErrPaused{}
-				ree.waitForResumeResults = append(ree.waitForResumeResults, nil)
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 10}}
+				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.UpdateResult{Err: hooks.ErrPaused{}}
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyWholeChainSync(responses)
+				tbc.VerifyResponseRangeSync(responses, 0, 6)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 1, ree.currentWaitForResumeResult)
+				require.Len(t, ree.requestsSent, 2)
 				require.Equal(t, ree.request, ree.requestsSent[0].request)
-				doNotSendCidsExt, has := ree.requestsSent[1].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 6, cidSet.Len())
-				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
-			},
-		},
-		"multiple pause": {
-			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.ErrPaused{}
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(7)}] = hooks.ErrPaused{}
-				ree.waitForResumeResults = append(ree.waitForResumeResults, nil, nil)
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 8}, {8, 10}}
-			},
-			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyWholeChainSync(responses)
-				require.Empty(t, receivedErrors)
-				require.Equal(t, 2, ree.currentWaitForResumeResult)
-				require.Equal(t, ree.request, ree.requestsSent[0].request)
-				doNotSendCidsExt, has := ree.requestsSent[1].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 6, cidSet.Len())
-				doNotSendCidsExt, has = ree.requestsSent[2].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err = cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 8, cidSet.Len())
-				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
-			},
-		},
-		"multiple pause with extensions": {
-			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.ErrPaused{}
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(7)}] = hooks.ErrPaused{}
-				ree.waitForResumeResults = append(ree.waitForResumeResults, []graphsync.ExtensionData{
-					{
-						Name: graphsync.ExtensionName("applesauce"),
-						Data: []byte("cheese 1"),
-					},
-				}, []graphsync.ExtensionData{
-					{
-						Name: graphsync.ExtensionName("applesauce"),
-						Data: []byte("cheese 2"),
-					},
-				})
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 8}, {8, 10}}
-			},
-			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyWholeChainSync(responses)
-				require.Empty(t, receivedErrors)
-				require.Equal(t, 2, ree.currentWaitForResumeResult)
-				require.Equal(t, ree.request, ree.requestsSent[0].request)
-				testExtData, has := ree.requestsSent[1].request.Extension(graphsync.ExtensionName("applesauce"))
-				require.True(t, has)
-				require.Equal(t, "cheese 1", string(testExtData))
-				doNotSendCidsExt, has := ree.requestsSent[1].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 6, cidSet.Len())
-				testExtData, has = ree.requestsSent[2].request.Extension(graphsync.ExtensionName("applesauce"))
-				require.True(t, has)
-				require.Equal(t, "cheese 2", string(testExtData))
-				doNotSendCidsExt, has = ree.requestsSent[2].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err = cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 8, cidSet.Len())
-				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.True(t, ree.requestsSent[1].request.IsCancel())
+				require.Len(t, ree.blookHooksCalled, 6)
+				require.EqualError(t, ree.terminalError, hooks.ErrPaused{}.Error())
 			},
 		},
 		"preexisting do not send cids": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
 				ree.doNotSendCids.Add(tbc.GenisisLink.(cidlink.Link).Cid)
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.ErrPaused{}
-				ree.waitForResumeResults = append(ree.waitForResumeResults, nil)
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 10}}
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
 				tbc.VerifyWholeChainSync(responses)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 1, ree.currentWaitForResumeResult)
-				require.Equal(t, ree.request, ree.requestsSent[0].request)
-				doNotSendCidsExt, has := ree.requestsSent[1].request.Extension(graphsync.ExtensionDoNotSendCIDs)
+				require.Equal(t, ree.request.ID(), ree.requestsSent[0].request.ID())
+				require.Equal(t, ree.request.Root(), ree.requestsSent[0].request.Root())
+				require.Equal(t, ree.request.Selector(), ree.requestsSent[0].request.Selector())
+				doNotSendCidsExt, has := ree.requestsSent[0].request.Extension(graphsync.ExtensionDoNotSendCIDs)
 				require.True(t, has)
 				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
 				require.NoError(t, err)
-				require.Equal(t, 7, cidSet.Len())
+				require.Equal(t, 1, cidSet.Len())
 				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
-			},
-		},
-		"pause but request is cancelled": {
-			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.ErrPaused{}
-			},
-			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyResponseRangeSync(responses, 0, 5)
-				require.Empty(t, receivedErrors)
-				require.Equal(t, 0, ree.currentWaitForResumeResult)
-				require.Equal(t, []requestSent{{ree.p, ree.request}}, ree.requestsSent)
-				require.Len(t, ree.blookHooksCalled, 6)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.NoError(t, ree.terminalError)
 			},
 		},
 		"pause externally": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.externalPauses = append(ree.externalPauses, pauseKey{requestID, tbc.LinkTipIndex(5)})
-				ree.waitForResumeResults = append(ree.waitForResumeResults, nil)
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 10}}
+				ree.externalPause = pauseKey{requestID, tbc.LinkTipIndex(5)}
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
-				tbc.VerifyWholeChainSync(responses)
+				tbc.VerifyResponseRangeSync(responses, 0, 6)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 1, ree.currentPauseResult)
-				require.Equal(t, 1, ree.currentWaitForResumeResult)
 				require.Equal(t, ree.request, ree.requestsSent[0].request)
 				require.True(t, ree.requestsSent[1].request.IsCancel())
-				doNotSendCidsExt, has := ree.requestsSent[2].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 6, cidSet.Len())
-				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.Len(t, ree.blookHooksCalled, 6)
+				require.EqualError(t, ree.terminalError, hooks.ErrPaused{}.Error())
 			},
 		},
-		"pause externally multiple": {
+		"resume request": {
 			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
-				ree.externalPauses = append(ree.externalPauses, pauseKey{requestID, tbc.LinkTipIndex(5)}, pauseKey{requestID, tbc.LinkTipIndex(7)})
-				ree.waitForResumeResults = append(ree.waitForResumeResults, nil, nil)
-				ree.loaderRanges = [][2]int{{0, 6}, {6, 8}, {8, 10}}
+				ree.initialRequest = false
+				ree.loadLocallyUntil = 6
 			},
 			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
 				tbc.VerifyWholeChainSync(responses)
 				require.Empty(t, receivedErrors)
-				require.Equal(t, 2, ree.currentPauseResult)
-				require.Equal(t, 2, ree.currentWaitForResumeResult)
-				require.Equal(t, ree.request, ree.requestsSent[0].request)
-				require.True(t, ree.requestsSent[1].request.IsCancel())
-				doNotSendCidsExt, has := ree.requestsSent[2].request.Extension(graphsync.ExtensionDoNotSendCIDs)
+				require.Equal(t, ree.request.ID(), ree.requestsSent[0].request.ID())
+				require.Equal(t, ree.request.Root(), ree.requestsSent[0].request.Root())
+				require.Equal(t, ree.request.Selector(), ree.requestsSent[0].request.Selector())
+				doNotSendCidsExt, has := ree.requestsSent[0].request.Extension(graphsync.ExtensionDoNotSendCIDs)
 				require.True(t, has)
 				cidSet, err := cidset.DecodeCidSet(doNotSendCidsExt)
 				require.NoError(t, err)
 				require.Equal(t, 6, cidSet.Len())
-				require.True(t, ree.requestsSent[3].request.IsCancel())
-				doNotSendCidsExt, has = ree.requestsSent[4].request.Extension(graphsync.ExtensionDoNotSendCIDs)
-				require.True(t, has)
-				cidSet, err = cidset.DecodeCidSet(doNotSendCidsExt)
-				require.NoError(t, err)
-				require.Equal(t, 8, cidSet.Len())
 				require.Len(t, ree.blookHooksCalled, 10)
-				require.Equal(t, ree.request.ID(), ree.terminateRequested)
-				require.True(t, ree.nodeStyleChooserCalled)
+				require.NoError(t, ree.terminalError)
+			},
+		},
+		"error at block hook has precedence over pause": {
+			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
+				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.UpdateResult{Err: errors.New("something went wrong")}
+				ree.externalPause = pauseKey{requestID, tbc.LinkTipIndex(5)}
+			},
+			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
+				tbc.VerifyResponseRangeSync(responses, 0, 6)
+				require.Len(t, receivedErrors, 1)
+				require.Regexp(t, "something went wrong", receivedErrors[0].Error())
+				require.Len(t, ree.requestsSent, 2)
+				require.Equal(t, ree.request, ree.requestsSent[0].request)
+				require.True(t, ree.requestsSent[1].request.IsCancel())
+				require.Len(t, ree.blookHooksCalled, 6)
+				require.EqualError(t, ree.terminalError, "something went wrong")
+			},
+		},
+		"sending updates": {
+			configureRequestExecution: func(p peer.ID, requestID graphsync.RequestID, tbc *testutil.TestBlockChain, ree *requestExecutionEnv) {
+				ree.blockHookResults[blockHookKey{p, requestID, tbc.LinkTipIndex(5)}] = hooks.UpdateResult{Extensions: []graphsync.ExtensionData{{Name: "something", Data: []byte("applesauce")}}}
+			},
+			verifyResults: func(t *testing.T, tbc *testutil.TestBlockChain, ree *requestExecutionEnv, responses []graphsync.ResponseProgress, receivedErrors []error) {
+				tbc.VerifyWholeChainSync(responses)
+				require.Empty(t, receivedErrors)
+				require.Len(t, ree.requestsSent, 2)
+				require.Equal(t, ree.request, ree.requestsSent[0].request)
+				require.True(t, ree.requestsSent[1].request.IsUpdate())
+				data, has := ree.requestsSent[1].request.Extension("something")
+				require.True(t, has)
+				require.Equal(t, string(data), "applesauce")
+				require.Len(t, ree.blookHooksCalled, 10)
+				require.NoError(t, ree.terminalError)
 			},
 		},
 	}
@@ -271,50 +190,57 @@ func TestRequestExecutionBlockChain(t *testing.T) {
 				}
 			}
 			requestCtx, requestCancel := context.WithCancel(ctx)
+			defer requestCancel()
+			var responsesReceived []graphsync.ResponseProgress
 			ree := &requestExecutionEnv{
 				ctx:              requestCtx,
-				cancelFn:         requestCancel,
 				p:                p,
-				resumeMessages:   make(chan []graphsync.ExtensionData, 1),
 				pauseMessages:    make(chan struct{}, 1),
-				blockHookResults: make(map[blockHookKey]error),
+				blockHookResults: make(map[blockHookKey]hooks.UpdateResult),
 				doNotSendCids:    cid.NewSet(),
 				request:          gsmsg.NewRequest(requestID, tbc.TipLink.(cidlink.Link).Cid, tbc.Selector(), graphsync.Priority(rand.Int31())),
 				fal:              fal,
 				tbc:              tbc,
 				configureLoader:  configureLoader,
+				initialRequest:   true,
+				inProgressErr:    make(chan error, 1),
+				traverser: ipldutil.TraversalBuilder{
+					Root:     tbc.TipLink,
+					Selector: tbc.Selector(),
+					Visitor: func(tp traversal.Progress, node ipld.Node, tr traversal.VisitReason) error {
+						responsesReceived = append(responsesReceived, graphsync.ResponseProgress{
+							Node:      node,
+							Path:      tp.Path,
+							LastBlock: tp.LastBlock,
+						})
+						return nil
+					},
+				}.Start(requestCtx),
 			}
 			fal.OnAsyncLoad(ree.checkPause)
 			if data.configureRequestExecution != nil {
 				data.configureRequestExecution(p, requestID, tbc, ree)
 			}
-			if len(ree.loaderRanges) == 0 {
-				ree.loaderRanges = [][2]int{{0, 10}}
-			}
-			inProgress, inProgressErr := ree.requestExecution()
-			var responsesReceived []graphsync.ResponseProgress
+			ree.configureLoader(p, requestID, tbc, fal, [2]int{0, ree.loadLocallyUntil})
 			var errorsReceived []error
-			var inProgressDone, inProgressErrDone bool
-			for !inProgressDone || !inProgressErrDone {
-				select {
-				case response, ok := <-inProgress:
-					if !ok {
-						inProgress = nil
-						inProgressDone = true
-					} else {
-						responsesReceived = append(responsesReceived, response)
+			errCollectionErr := make(chan error, 1)
+			go func() {
+				for {
+					select {
+					case err, ok := <-ree.inProgressErr:
+						if !ok {
+							errCollectionErr <- nil
+						} else {
+							errorsReceived = append(errorsReceived, err)
+						}
+					case <-ctx.Done():
+						errCollectionErr <- ctx.Err()
 					}
-				case err, ok := <-inProgressErr:
-					if !ok {
-						inProgressErr = nil
-						inProgressErrDone = true
-					} else {
-						errorsReceived = append(errorsReceived, err)
-					}
-				case <-ctx.Done():
-					t.Fatal("did not complete request")
 				}
-			}
+			}()
+			executor.NewExecutor(ree, ree, fal.AsyncLoad).ExecuteTask(ctx, ree.p, &peertask.Task{})
+			require.NoError(t, <-errCollectionErr)
+			ree.traverser.Shutdown(ctx)
 			data.verifyResults(t, tbc, ree, responsesReceived, errorsReceived)
 		})
 	}
@@ -338,25 +264,24 @@ type pauseKey struct {
 
 type requestExecutionEnv struct {
 	// params
-	ctx                  context.Context
-	cancelFn             func()
-	request              gsmsg.GraphSyncRequest
-	p                    peer.ID
-	blockHookResults     map[blockHookKey]error
-	doNotSendCids        *cid.Set
-	waitForResumeResults [][]graphsync.ExtensionData
-	resumeMessages       chan []graphsync.ExtensionData
-	pauseMessages        chan struct{}
-	externalPauses       []pauseKey
-	loaderRanges         [][2]int
+	ctx              context.Context
+	cancelFn         func()
+	request          gsmsg.GraphSyncRequest
+	p                peer.ID
+	blockHookResults map[blockHookKey]hooks.UpdateResult
+	doNotSendCids    *cid.Set
+	pauseMessages    chan struct{}
+	externalPause    pauseKey
+	loadLocallyUntil int
+	traverser        ipldutil.Traverser
+	inProgressErr    chan error
+	initialRequest   bool
+	empty            bool
 
 	// results
-	currentPauseResult         int
-	currentWaitForResumeResult int
-	requestsSent               []requestSent
-	blookHooksCalled           []blockHookKey
-	terminateRequested         graphsync.RequestID
-	nodeStyleChooserCalled     bool
+	requestsSent     []requestSent
+	blookHooksCalled []blockHookKey
+	terminalError    error
 
 	// deps
 	configureLoader configureLoaderFn
@@ -364,79 +289,51 @@ type requestExecutionEnv struct {
 	fal             *testloader.FakeAsyncLoader
 }
 
-func (ree *requestExecutionEnv) terminateRequest(requestID graphsync.RequestID) {
-	ree.terminateRequested = requestID
+func (ree *requestExecutionEnv) ReleaseRequestTask(_ peer.ID, _ *peertask.Task, err error) {
+	ree.terminalError = err
+	close(ree.inProgressErr)
 }
 
-func (ree *requestExecutionEnv) waitForResume() ([]graphsync.ExtensionData, error) {
-	if len(ree.waitForResumeResults) <= ree.currentWaitForResumeResult {
-		return nil, ipldutil.ContextCancelError{}
+func (ree *requestExecutionEnv) GetRequestTask(_ peer.ID, _ *peertask.Task, requestExecutionChan chan executor.RequestTask) {
+	var lastResponse atomic.Value
+	lastResponse.Store(gsmsg.NewResponse(ree.request.ID(), graphsync.RequestAcknowledged))
+
+	requestExecution := executor.RequestTask{
+		Ctx:            ree.ctx,
+		Request:        ree.request,
+		LastResponse:   &lastResponse,
+		DoNotSendCids:  ree.doNotSendCids,
+		PauseMessages:  ree.pauseMessages,
+		Traverser:      ree.traverser,
+		P:              ree.p,
+		InProgressErr:  ree.inProgressErr,
+		Empty:          ree.empty,
+		InitialRequest: ree.initialRequest,
 	}
-	extensions := ree.waitForResumeResults[ree.currentWaitForResumeResult]
-	ree.currentWaitForResumeResult++
-	return extensions, nil
+	go func() {
+		select {
+		case <-ree.ctx.Done():
+		case requestExecutionChan <- requestExecution:
+		}
+	}()
 }
 
-func (ree *requestExecutionEnv) sendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
+func (ree *requestExecutionEnv) SendRequest(p peer.ID, request gsmsg.GraphSyncRequest) {
 	ree.requestsSent = append(ree.requestsSent, requestSent{p, request})
-	if ree.currentWaitForResumeResult < len(ree.loaderRanges) && !request.IsCancel() {
-		ree.configureLoader(ree.p, ree.request.ID(), ree.tbc, ree.fal, ree.loaderRanges[ree.currentWaitForResumeResult])
+	if !request.IsCancel() && !request.IsUpdate() {
+		ree.configureLoader(ree.p, ree.request.ID(), ree.tbc, ree.fal, [2]int{ree.loadLocallyUntil, len(ree.tbc.AllBlocks())})
 	}
 }
 
-func (ree *requestExecutionEnv) nodeStyleChooser(ipld.Link, ipld.LinkContext) (ipld.NodePrototype, error) {
-	ree.nodeStyleChooserCalled = true
-	return basicnode.Prototype.Any, nil
+func (ree *requestExecutionEnv) ProcessBlockHooks(p peer.ID, response graphsync.ResponseData, blk graphsync.BlockData) hooks.UpdateResult {
+	bhk := blockHookKey{p, response.RequestID(), blk.Link()}
+	ree.blookHooksCalled = append(ree.blookHooksCalled, bhk)
+	return ree.blockHookResults[bhk]
 }
 
 func (ree *requestExecutionEnv) checkPause(requestID graphsync.RequestID, link ipld.Link, result <-chan types.AsyncLoadResult) {
-	if ree.currentPauseResult >= len(ree.externalPauses) {
-		return
-	}
-	currentPause := ree.externalPauses[ree.currentPauseResult]
-	if currentPause.link == link && currentPause.requestID == requestID {
-		ree.currentPauseResult++
+	if ree.externalPause.link == link && ree.externalPause.requestID == requestID {
+		ree.externalPause = pauseKey{}
 		ree.pauseMessages <- struct{}{}
-		extensions, err := ree.waitForResume()
-		if err != nil {
-			ree.cancelFn()
-		} else {
-			ree.resumeMessages <- extensions
-		}
 	}
-}
-
-func (ree *requestExecutionEnv) runBlockHooks(p peer.ID, response graphsync.ResponseData, blk graphsync.BlockData) error {
-	bhk := blockHookKey{p, response.RequestID(), blk.Link()}
-	ree.blookHooksCalled = append(ree.blookHooksCalled, bhk)
-	err := ree.blockHookResults[bhk]
-	if _, ok := err.(hooks.ErrPaused); ok {
-		extensions, err := ree.waitForResume()
-		if err != nil {
-			ree.cancelFn()
-		} else {
-			ree.resumeMessages <- extensions
-		}
-	}
-	return err
-}
-
-func (ree *requestExecutionEnv) requestExecution() (chan graphsync.ResponseProgress, chan error) {
-	var lastResponse atomic.Value
-	lastResponse.Store(gsmsg.NewResponse(ree.request.ID(), graphsync.RequestAcknowledged))
-	return executor.ExecutionEnv{
-		SendRequest:      ree.sendRequest,
-		RunBlockHooks:    ree.runBlockHooks,
-		TerminateRequest: ree.terminateRequest,
-		Loader:           ree.fal.AsyncLoad,
-	}.Start(executor.RequestExecution{
-		Ctx:                  ree.ctx,
-		P:                    ree.p,
-		LastResponse:         &lastResponse,
-		Request:              ree.request,
-		DoNotSendCids:        ree.doNotSendCids,
-		NodePrototypeChooser: ree.nodeStyleChooser,
-		ResumeMessages:       ree.resumeMessages,
-		PauseMessages:        ree.pauseMessages,
-	})
 }

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -62,7 +62,7 @@ func readNNetworkRequests(ctx context.Context,
 		testutil.AssertReceive(ctx, t, requestRecordChan, &rr, fmt.Sprintf("did not receive request %d", i))
 		requestRecords = append(requestRecords, rr)
 	}
-	// because or the simultaneous request queues it's possible for the requests to go to the network layer out of order
+	// because of the simultaneous request queues it's possible for the requests to go to the network layer out of order
 	// if the requests are queued at a near identical time
 	sort.Slice(requestRecords, func(i, j int) bool {
 		return requestRecords[i].gsr.ID() < requestRecords[j].gsr.ID()

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -20,9 +21,11 @@ import (
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/metadata"
 	"github.com/ipfs/go-graphsync/notifications"
+	"github.com/ipfs/go-graphsync/requestmanager/executor"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
 	"github.com/ipfs/go-graphsync/requestmanager/testloader"
 	"github.com/ipfs/go-graphsync/requestmanager/types"
+	"github.com/ipfs/go-graphsync/taskqueue"
 	"github.com/ipfs/go-graphsync/testutil"
 )
 
@@ -59,6 +62,11 @@ func readNNetworkRequests(ctx context.Context,
 		testutil.AssertReceive(ctx, t, requestRecordChan, &rr, fmt.Sprintf("did not receive request %d", i))
 		requestRecords = append(requestRecords, rr)
 	}
+	// because or the simultaneous request queues it's possible for the requests to go to the network layer out of order
+	// if the requests are queued at a near identical time
+	sort.Slice(requestRecords, func(i, j int) bool {
+		return requestRecords[i].gsr.ID() < requestRecords[j].gsr.ID()
+	})
 	return requestRecords
 }
 
@@ -105,7 +113,9 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 	require.Equal(t, defaultPriority, requestRecords[0].gsr.Priority())
 	require.Equal(t, defaultPriority, requestRecords[1].gsr.Priority())
 
+	require.Equal(t, td.blockChain.TipLink.String(), requestRecords[0].gsr.Root().String())
 	require.Equal(t, td.blockChain.Selector(), requestRecords[0].gsr.Selector(), "did not encode selector properly")
+	require.Equal(t, blockChain2.TipLink.String(), requestRecords[1].gsr.Root().String())
 	require.Equal(t, blockChain2.Selector(), requestRecords[1].gsr.Selector(), "did not encode selector properly")
 
 	firstBlocks := append(td.blockChain.AllBlocks(), blockChain2.Blocks(0, 3)...)
@@ -165,7 +175,7 @@ func TestNormalSimultaneousFetch(t *testing.T) {
 func TestCancelRequestInProgress(t *testing.T) {
 	ctx := context.Background()
 	td := newTestData(ctx, t)
-	requestCtx, cancel := context.WithTimeout(ctx, time.Second)
+	requestCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	requestCtx1, cancel1 := context.WithCancel(requestCtx)
 	requestCtx2, cancel2 := context.WithCancel(requestCtx)
@@ -832,7 +842,7 @@ func TestPauseResume(t *testing.T) {
 	require.EqualError(t, err, "request is not paused")
 	close(holdForResumeAttempt)
 	// verify responses sent read ONLY for blocks BEFORE the pause
-	td.blockChain.VerifyResponseRange(ctx, returnedResponseChan, 0, pauseAt-1)
+	td.blockChain.VerifyResponseRange(ctx, returnedResponseChan, 0, pauseAt)
 	// wait for the pause to occur
 	<-holdForPause
 
@@ -868,7 +878,7 @@ func TestPauseResume(t *testing.T) {
 	td.fal.SuccessResponseOn(peers[0], rr.gsr.ID(), td.blockChain.AllBlocks())
 
 	// verify the correct results are returned, picking up after where there request was paused
-	td.blockChain.VerifyRemainder(ctx, returnedResponseChan, pauseAt-1)
+	td.blockChain.VerifyRemainder(ctx, returnedResponseChan, pauseAt)
 	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan)
 }
 func TestPauseResumeExternal(t *testing.T) {
@@ -912,7 +922,7 @@ func TestPauseResumeExternal(t *testing.T) {
 	td.requestManager.ProcessResponses(peers[0], responses, td.blockChain.AllBlocks())
 	td.fal.SuccessResponseOn(peers[0], rr.gsr.ID(), td.blockChain.AllBlocks())
 	// verify responses sent read ONLY for blocks BEFORE the pause
-	td.blockChain.VerifyResponseRange(ctx, returnedResponseChan, 0, pauseAt-1)
+	td.blockChain.VerifyResponseRange(ctx, returnedResponseChan, 0, pauseAt)
 	// wait for the pause to occur
 	<-holdForPause
 
@@ -948,7 +958,7 @@ func TestPauseResumeExternal(t *testing.T) {
 	td.fal.SuccessResponseOn(peers[0], rr.gsr.ID(), td.blockChain.AllBlocks())
 
 	// verify the correct results are returned, picking up after where there request was paused
-	td.blockChain.VerifyRemainder(ctx, returnedResponseChan, pauseAt-1)
+	td.blockChain.VerifyRemainder(ctx, returnedResponseChan, pauseAt)
 	testutil.VerifyEmptyErrors(ctx, t, returnedErrorChan)
 }
 
@@ -970,6 +980,8 @@ type testData struct {
 	extensionData2        []byte
 	extension2            graphsync.ExtensionData
 	networkErrorListeners *listeners.NetworkErrorListeners
+	taskqueue             *taskqueue.TaskQueue
+	executor              *executor.Executor
 }
 
 func newTestData(ctx context.Context, t *testing.T) *testData {
@@ -981,9 +993,13 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td.responseHooks = hooks.NewResponseHooks()
 	td.blockHooks = hooks.NewBlockHooks()
 	td.networkErrorListeners = listeners.NewNetworkErrorListeners()
-	td.requestManager = New(ctx, td.fal, cidlink.DefaultLinkSystem(), td.requestHooks, td.responseHooks, td.blockHooks, td.networkErrorListeners)
+	td.taskqueue = taskqueue.NewTaskQueue(ctx)
+	lsys := cidlink.DefaultLinkSystem()
+	td.requestManager = New(ctx, td.fal, lsys, td.requestHooks, td.responseHooks, td.networkErrorListeners, td.taskqueue)
+	td.executor = executor.NewExecutor(td.requestManager, td.blockHooks, td.fal.AsyncLoad)
 	td.requestManager.SetDelegate(td.fph)
 	td.requestManager.Startup()
+	td.taskqueue.Startup(6, td.executor)
 	td.blockStore = make(map[ipld.Link][]byte)
 	td.persistence = testutil.NewTestStore(td.blockStore)
 	td.blockChain = testutil.SetupBlockChain(ctx, t, td.persistence, 100, 5)

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -980,7 +980,7 @@ type testData struct {
 	extensionData2        []byte
 	extension2            graphsync.ExtensionData
 	networkErrorListeners *listeners.NetworkErrorListeners
-	taskqueue             *taskqueue.TaskQueue
+	taskqueue             *taskqueue.WorkerTaskQueue
 	executor              *executor.Executor
 }
 

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -157,6 +157,13 @@ func (rm *RequestManager) terminateRequest(requestID graphsync.RequestID, ipr *i
 	if ipr.traverser != nil {
 		ipr.traverser.Shutdown(rm.ctx)
 	}
+	// make sure context is not closed before closing channels (could cause send
+	// on close channel otherwise)
+	select {
+	case <-rm.ctx.Done():
+		return
+	default:
+	}
 	close(ipr.inProgressChan)
 	close(ipr.inProgressErr)
 	for _, onTerminated := range ipr.onTerminated {

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -198,6 +198,7 @@ func (rm *RequestManager) cancelRequest(requestID graphsync.RequestID, onTermina
 	if onTerminated != nil {
 		inProgressRequestStatus.onTerminated = append(inProgressRequestStatus.onTerminated, onTerminated)
 	}
+	rm.SendRequest(inProgressRequestStatus.p, gsmsg.CancelRequest(requestID))
 	rm.cancelOnError(requestID, inProgressRequestStatus, terminalError)
 }
 
@@ -263,6 +264,7 @@ func (rm *RequestManager) processExtensionsForResponse(p peer.ID, response gsmsg
 		if !ok {
 			return false
 		}
+		rm.SendRequest(requestStatus.p, gsmsg.CancelRequest(response.RequestID()))
 		rm.cancelOnError(response.RequestID(), requestStatus, result.Err)
 		return false
 	}
@@ -333,7 +335,7 @@ func (rm *RequestManager) pause(id graphsync.RequestID) error {
 	if !ok {
 		return graphsync.RequestNotFoundErr{}
 	}
-	if inProgressRequestStatus.state != running {
+	if inProgressRequestStatus.state == paused {
 		return errors.New("request is already paused")
 	}
 	select {

--- a/taskqueue/taskqueue.go
+++ b/taskqueue/taskqueue.go
@@ -1,0 +1,89 @@
+package taskqueue
+
+import (
+	"context"
+	"time"
+
+	"github.com/ipfs/go-peertaskqueue"
+	"github.com/ipfs/go-peertaskqueue/peertask"
+	peer "github.com/libp2p/go-libp2p-core/peer"
+)
+
+const thawSpeed = time.Millisecond * 100
+
+// Executor runs a single task on the queue
+type Executor interface {
+	ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.Task) bool
+}
+
+// TaskQueue is a wrapper around peertaskqueue.PeerTaskQueue that manages running workers
+// that pop tasks and execute them
+type TaskQueue struct {
+	ctx           context.Context
+	cancelFn      func()
+	peerTaskQueue *peertaskqueue.PeerTaskQueue
+	workSignal    chan struct{}
+	ticker        *time.Ticker
+}
+
+// NewTaskQueue initializes a new queue
+func NewTaskQueue(ctx context.Context) *TaskQueue {
+	ctx, cancelFn := context.WithCancel(ctx)
+	return &TaskQueue{
+		ctx:           ctx,
+		cancelFn:      cancelFn,
+		peerTaskQueue: peertaskqueue.New(),
+		workSignal:    make(chan struct{}, 1),
+		ticker:        time.NewTicker(thawSpeed),
+	}
+}
+
+// PushTask pushes a new task on to the queue
+func (tq *TaskQueue) PushTask(p peer.ID, task peertask.Task) {
+	tq.peerTaskQueue.PushTasks(p, task)
+	select {
+	case tq.workSignal <- struct{}{}:
+	default:
+	}
+}
+
+// TaskDone marks a task as completed so further tasks can be executed
+func (tq *TaskQueue) TaskDone(p peer.ID, task *peertask.Task) {
+	tq.peerTaskQueue.TasksDone(p, task)
+}
+
+// Startup runs the given number of task workers with the given executor
+func (tq *TaskQueue) Startup(workerCount uint64, executor Executor) {
+	for i := uint64(0); i < workerCount; i++ {
+		go tq.worker(executor)
+	}
+}
+
+// Shutdown shuts down all running workers
+func (tq *TaskQueue) Shutdown() {
+	tq.cancelFn()
+}
+
+func (tq *TaskQueue) worker(executor Executor) {
+	targetWork := 1
+	for {
+		pid, tasks, _ := tq.peerTaskQueue.PopTasks(targetWork)
+		for len(tasks) == 0 {
+			select {
+			case <-tq.ctx.Done():
+				return
+			case <-tq.workSignal:
+				pid, tasks, _ = tq.peerTaskQueue.PopTasks(targetWork)
+			case <-tq.ticker.C:
+				tq.peerTaskQueue.ThawRound()
+				pid, tasks, _ = tq.peerTaskQueue.PopTasks(targetWork)
+			}
+		}
+		for _, task := range tasks {
+			terminate := executor.ExecuteTask(tq.ctx, pid, task)
+			if terminate {
+				return
+			}
+		}
+	}
+}

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -125,7 +125,7 @@ func CollectResponses(ctx context.Context, t TestingT, responseChan <-chan graph
 			}
 			collectedBlocks = append(collectedBlocks, blk)
 		case <-ctx.Done():
-			t.Fatal("response channel never closed")
+			require.FailNow(t, "response channel never closed")
 		}
 	}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -167,8 +167,8 @@ func VerifySingleTerminalError(ctx context.Context, t TestingT, errChan <-chan e
 	var err error
 	AssertReceive(ctx, t, errChan, &err, "should receive an error")
 	select {
-	case _, ok := <-errChan:
-		require.False(t, ok, "shouldn't have sent second error but did")
+	case secondErr, ok := <-errChan:
+		require.Falsef(t, ok, "shouldn't have sent second error but sent: %s, %s", err, secondErr)
 	case <-ctx.Done():
 		t.Fatal("errors not closed")
 	}


### PR DESCRIPTION
# Goals

implement #215 

# Implementation

This is not a super simple PR as adding request limits required some sizable lifting to the request manager operations.

Here are the substantive changes:
- Use a PeerTaskQueue to handle rate limiting and request distribution
- I find myself writing the worker function to consume a PeerTaskQueue over and over... so I wrote an abstraction to do it. And actually, this is useful cause we can make it an interface and implement other versions -- like an execute immediately, or maybe one that scales with demand, or handles multiple types of tasks, or distributes different requests to different queues... who knows!
- Refactor the executor to simply execute a single request till it pauses or finishes. I've removed the "resume" code from the executor which makes it much simpler -- now when you resume you just put the request back in the queue and pick up where you left off
- This means a bit more work is done in the request manager setting up the request and holding data about it.
- At the same time, this simplifies who has control at any given time. Essentially, if a request is in the running state, that means the the executor is in control, and if you example the code carefully, the RequeustManager doesn't modify anything about the request other than to relay pause messages to the executor, and to cancel the request context to cause the request to terminate. There is during this time no modifications directly to the inProgressRequestStatus. Once the request exits a running state, it either becomes paused or is removed cause it's finished.
- This means we have fairly universal behavior for parts of the code that need to abort the request -- if  the request is running, they only cancel the context and let the executor finish before cleanup. If the request is not running, they perform full cleanup.
- I unified the request cleanup process cause it was kind of all over the map :)
- one thing that may be slightly confusing is the "terminalError" property (though it's less bad than it used to be). Essentially, this is used to attach one additional error to the error stream at the end of the request.
- also obviously add startup options to configure the number of in progress requests

# For discussion

There are several obvious "next steps"/refactors that are NOT included in this PR to reduce the already complicated changeset.
- The ResponseManager should be refactored to use the TaskQueue. I just haven't done this to reduce the change set
- The OutgoingRequestHook is called at the point the request is QUEUED, rather than the moment it actually starts. Similar to the ResponseManager, we may need to add an event for "the request is started"

There is one very small breaking change to graphsyncs little known and extremely underused pause request feature -- see https://github.com/ipfs/go-graphsync/issues/160 for the suggestion this shouldn't even exist. Previously, if you paused a request, it would pause on the next block load, but it would NOT return the IPLD responses for the last block. Now it does return IPLD responses. This is better behavior anyway, and I'm pretty sure no one is using this feature.

While not breaking, requests not executing immediately is a potential source of unexpected behavior and this PR, once merged to master, should be thouroughly vetted in go-data-transfer and lotus prior to merge into higher level products
