### PR TITLE
Give missing blocks a named error

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -3,6 +3,7 @@ package graphsync
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/ipfs/go-cid"
 	"github.com/ipld/go-ipld-prime"
@@ -92,6 +93,17 @@ type RequestNotFoundErr struct{}
 
 func (e RequestNotFoundErr) Error() string {
 	return "request not found"
+}
+
+// RemoteMissingBlockErr indicates that the remote peer was missing a block
+// in the selector requested. It is a non-terminal error in the error stream
+// for a request and does NOT cause a request to fail completely
+type RemoteMissingBlockErr struct {
+	Link ipld.Link
+}
+
+func (e RemoteMissingBlockErr) Error() string {
+	return fmt.Sprintf("remote peer is missing block: %s", e.Link.String())
 }
 
 var (

--- a/requestmanager/asyncloader/responsecache/responsecache.go
+++ b/requestmanager/asyncloader/responsecache/responsecache.go
@@ -1,7 +1,6 @@
 package responsecache
 
 import (
-	"fmt"
 	"sync"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -59,7 +58,7 @@ func (rc *ResponseCache) AttemptLoad(requestID graphsync.RequestID, link ipld.Li
 	rc.responseCacheLk.Lock()
 	defer rc.responseCacheLk.Unlock()
 	if rc.linkTracker.IsKnownMissingLink(requestID, link) {
-		return nil, fmt.Errorf("remote peer is missing block: %s", link.String())
+		return nil, graphsync.RemoteMissingBlockErr{Link: link}
 	}
 	data, _ := rc.unverifiedBlockStore.VerifyBlock(link, linkContext)
 	return data, nil


### PR DESCRIPTION
# Goals

Support for https://github.com/filecoin-project/lotus/issues/7227 by making missing blocks identifiable as an error

# Implementation

- Define an error type for missing blocks
- Use it