### PR TITLE
Remove assertion with gauranteed flaky behavior

### DIFF
--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -699,7 +699,6 @@ func TestNetworkErrors(t *testing.T) {
 		td.notifyBlockSendsNetworkError(err)
 		td.assertHasNetworkErrors(err)
 		td.assertNoCompletedResponseStatuses()
-		td.assertRequestCleared()
 	})
 	t.Run("network error while paused", func(t *testing.T) {
 		td := newTestData(t)


### PR DESCRIPTION
# Goals

Fix #193 

# Implementation

The root problem is this test is testing something not gauranteed to happen, even when response manager behaves correctly.

Essentially, when a network send error occurs, we want to interrupt execution of a response.. However, it is still possible
the execution of the selector query is already complete, even if there are still blocks waiting to be sent over the network. In this case, there will not be any clearing of the request. That's ok.