### PR TITLE
Do not send first blocks extension

### DIFF
--- a/donotsendfirstblocks/donotsendfirstblocks.go
+++ b/donotsendfirstblocks/donotsendfirstblocks.go
@@ -9,12 +9,7 @@ import (
 // EncodeDoNotSendFirstBlocks returns encoded cbor data for the given number
 // of blocks to skip
 func EncodeDoNotSendFirstBlocks(skipBlockCount int64) ([]byte, error) {
-	nb := basicnode.Prototype.Int.NewBuilder()
-	err := nb.AssignInt(skipBlockCount)
-	if err != nil {
-		return nil, err
-	}
-	nd := nb.Build()
+	nd := basicnode.NewInt(skipBlockCount)
 	return ipldutil.EncodeNode(nd)
 }
 

--- a/donotsendfirstblocks/donotsendfirstblocks.go
+++ b/donotsendfirstblocks/donotsendfirstblocks.go
@@ -1,0 +1,28 @@
+package donotsendfirstblocks
+
+import (
+	basicnode "github.com/ipld/go-ipld-prime/node/basic"
+
+	"github.com/ipfs/go-graphsync/ipldutil"
+)
+
+// EncodeDoNotSendFirstBlocks returns encoded cbor data for the given number
+// of blocks to skip
+func EncodeDoNotSendFirstBlocks(skipBlockCount int64) ([]byte, error) {
+	nb := basicnode.Prototype.Int.NewBuilder()
+	err := nb.AssignInt(skipBlockCount)
+	if err != nil {
+		return nil, err
+	}
+	nd := nb.Build()
+	return ipldutil.EncodeNode(nd)
+}
+
+// DecodeDoNotSendFirstBlocks returns the number of blocks to skip
+func DecodeDoNotSendFirstBlocks(data []byte) (int64, error) {
+	nd, err := ipldutil.DecodeNode(data)
+	if err != nil {
+		return 0, err
+	}
+	return nd.AsInt()
+}

--- a/graphsync.go
+++ b/graphsync.go
@@ -45,6 +45,10 @@ const (
 	// https://github.com/ipld/specs/blob/master/block-layer/graphsync/known_extensions.md
 	ExtensionDoNotSendCIDs = ExtensionName("graphsync/do-not-send-cids")
 
+	// ExtensionsDoNotSendFirstBlocks tells the responding peer not to wait till the given
+	// number of blocks have been traversed before it begins to send blocks over the wire
+	ExtensionsDoNotSendFirstBlocks = ExtensionName("graphsync/do-not-send-first-blocks")
+
 	// ExtensionDeDupByKey tells the responding peer to only deduplicate block sending
 	// for requests that have the same key. The data for the extension is a string key
 	ExtensionDeDupByKey = ExtensionName("graphsync/dedup-by-key")

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -40,6 +40,7 @@ import (
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/cidset"
+	"github.com/ipfs/go-graphsync/donotsendfirstblocks"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	gsnet "github.com/ipfs/go-graphsync/network"
 	"github.com/ipfs/go-graphsync/storeutil"
@@ -329,6 +330,55 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 
 	require.Equal(t, blockChainLength, totalSent)
 	require.Equal(t, blockChainLength-set.Len(), totalSentOnWire)
+}
+
+func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
+	// create network
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	defer cancel()
+	td := newGsTestData(ctx, t)
+
+	// initialize graphsync on first node to make requests
+	requestor := td.GraphSyncHost1()
+
+	// setup receiving peer to just record message coming in
+	blockChainLength := 100
+	blockChain := testutil.SetupBlockChain(ctx, t, td.persistence2, 100, blockChainLength)
+
+	// store blocks locally
+	firstHalf := blockChain.Blocks(0, 50)
+	for _, blk := range firstHalf {
+		td.blockStore1[cidlink.Link{Cid: blk.Cid()}] = blk.RawData()
+	}
+
+	doNotSendFirstBlocksData, err := donotsendfirstblocks.EncodeDoNotSendFirstBlocks(50)
+	require.NoError(t, err)
+	extension := graphsync.ExtensionData{
+		Name: graphsync.ExtensionsDoNotSendFirstBlocks,
+		Data: doNotSendFirstBlocksData,
+	}
+
+	// initialize graphsync on second node to response to requests
+	responder := td.GraphSyncHost2()
+
+	totalSent := 0
+	totalSentOnWire := 0
+	responder.RegisterOutgoingBlockHook(func(p peer.ID, requestData graphsync.RequestData, blockData graphsync.BlockData, hookActions graphsync.OutgoingBlockHookActions) {
+		totalSent++
+		if blockData.BlockSizeOnWire() > 0 {
+			totalSentOnWire++
+		}
+	})
+
+	progressChan, errChan := requestor.Request(ctx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), extension)
+
+	blockChain.VerifyWholeChain(ctx, progressChan)
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
+	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
+
+	require.Equal(t, blockChainLength, totalSent)
+	require.Equal(t, blockChainLength-50, totalSentOnWire)
 }
 
 func TestPauseResume(t *testing.T) {

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -334,8 +334,7 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 
 func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
 	// create network
-	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -126,6 +126,7 @@ type NetworkErrorListeners interface {
 type ResponseAssembler interface {
 	DedupKey(p peer.ID, requestID graphsync.RequestID, key string)
 	IgnoreBlocks(p peer.ID, requestID graphsync.RequestID, links []ipld.Link)
+	SkipFirstBlocks(p peer.ID, requestID graphsync.RequestID, skipCount int64)
 	Transaction(p peer.ID, requestID graphsync.RequestID, transaction responseassembler.Transaction) error
 }
 

--- a/responsemanager/responseassembler/responseBuilder.go
+++ b/responsemanager/responseassembler/responseBuilder.go
@@ -60,9 +60,9 @@ func (rb *responseBuilder) AddNotifee(notifee notifications.Notifee) {
 func (rb *responseBuilder) setupBlockOperation(
 	link ipld.Link, data []byte) blockOperation {
 	hasBlock := data != nil
-	isUnique := rb.linkTracker.RecordLinkTraversal(rb.requestID, link, hasBlock)
+	send := rb.linkTracker.RecordLinkTraversal(rb.requestID, link, hasBlock)
 	return blockOperation{
-		data, hasBlock && isUnique, link, rb.requestID,
+		data, send, link, rb.requestID,
 	}
 }
 

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -86,6 +86,11 @@ func (ra *ResponseAssembler) IgnoreBlocks(p peer.ID, requestID graphsync.Request
 	ra.GetProcess(p).(*peerLinkTracker).IgnoreBlocks(requestID, links)
 }
 
+// SkipFirstBlocks tells the assembler for the given request to not send the first N blocks
+func (ra *ResponseAssembler) SkipFirstBlocks(p peer.ID, requestID graphsync.RequestID, skipFirstBlocks int64) {
+	ra.GetProcess(p).(*peerLinkTracker).SkipFirstBlocks(requestID, skipFirstBlocks)
+}
+
 // Transaction builds a response, and queues it for sending in the next outgoing message
 func (ra *ResponseAssembler) Transaction(p peer.ID, requestID graphsync.RequestID, transaction Transaction) error {
 	rb := &responseBuilder{

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -259,6 +259,84 @@ func TestResponseAssemblerIgnoreBlocks(t *testing.T) {
 
 }
 
+func TestResponseAssemblerSkipFirstBlocks(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	p := testutil.GeneratePeers(1)[0]
+	requestID1 := graphsync.RequestID(rand.Int31())
+	requestID2 := graphsync.RequestID(rand.Int31())
+	blks := testutil.GenerateBlocksOfSize(5, 100)
+	links := make([]ipld.Link, 0, len(blks))
+	for _, block := range blks {
+		links = append(links, cidlink.Link{Cid: block.Cid()})
+	}
+	fph := newFakePeerHandler(ctx, t)
+	responseAssembler := New(ctx, fph)
+
+	responseAssembler.SkipFirstBlocks(p, requestID1, 3)
+
+	var bd1, bd2, bd3, bd4, bd5 graphsync.BlockData
+	err := responseAssembler.Transaction(p, requestID1, func(b ResponseBuilder) error {
+		bd1 = b.SendResponse(links[0], blks[0].RawData())
+		return nil
+	})
+	require.NoError(t, err)
+
+	assertSentNotOnWire(t, bd1, blks[0])
+	fph.RefuteBlocks()
+	fph.AssertResponses(expectedResponses{requestID1: graphsync.PartialResponse})
+
+	err = responseAssembler.Transaction(p, requestID2, func(b ResponseBuilder) error {
+		bd1 = b.SendResponse(links[0], blks[0].RawData())
+		return nil
+	})
+	require.NoError(t, err)
+	fph.AssertResponses(expectedResponses{
+		requestID2: graphsync.PartialResponse,
+	})
+
+	err = responseAssembler.Transaction(p, requestID1, func(b ResponseBuilder) error {
+		bd2 = b.SendResponse(links[1], blks[1].RawData())
+		bd3 = b.SendResponse(links[2], blks[2].RawData())
+		return nil
+	})
+	require.NoError(t, err)
+
+	assertSentNotOnWire(t, bd1, blks[0])
+	assertSentNotOnWire(t, bd2, blks[1])
+	assertSentNotOnWire(t, bd3, blks[2])
+
+	fph.RefuteBlocks()
+	fph.AssertResponses(expectedResponses{
+		requestID1: graphsync.PartialResponse,
+	})
+	err = responseAssembler.Transaction(p, requestID1, func(b ResponseBuilder) error {
+		bd4 = b.SendResponse(links[3], blks[3].RawData())
+		bd5 = b.SendResponse(links[4], blks[4].RawData())
+		b.FinishRequest()
+		return nil
+	})
+	require.NoError(t, err)
+
+	assertSentOnWire(t, bd4, blks[3])
+	assertSentOnWire(t, bd5, blks[4])
+
+	fph.AssertBlocks(blks[3], blks[4])
+	fph.AssertResponses(expectedResponses{requestID1: graphsync.RequestCompletedFull})
+
+	err = responseAssembler.Transaction(p, requestID2, func(b ResponseBuilder) error {
+		b.SendResponse(links[3], blks[3].RawData())
+		b.FinishRequest()
+		return nil
+	})
+	require.NoError(t, err)
+
+	fph.AssertBlocks(blks[3])
+	fph.AssertResponses(expectedResponses{requestID2: graphsync.RequestCompletedFull})
+
+}
+
 func TestResponseAssemblerDupKeys(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)


### PR DESCRIPTION
# Goals

Implement #225

# Implementation

- add the extension name an a utility to encode decode the data (just a number)
- add processing of the extension to the query preparer
- handle behavior for the extension in the response assembler. You can now specify a number of blocks (** non-unique **) on a request to traverse before they start going over the wire.
- add integration test to demonstrate flow