### PR TITLE
Add support for IPLD prime's budgets feature in selectors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/ipfs/go-peertaskqueue v0.2.0
 	github.com/ipfs/go-unixfs v0.2.4
 	github.com/ipld/go-codec-dagpb v1.3.0
-	github.com/ipld/go-ipld-prime v0.12.0
+	github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/libp2p/go-libp2p v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -238,8 +238,8 @@ github.com/ipfs/go-verifcid v0.0.1/go.mod h1:5Hrva5KBeIog4A+UpqlaIU+DEstipcJYQQZ
 github.com/ipld/go-codec-dagpb v1.3.0 h1:czTcaoAuNNyIYWs6Qe01DJ+sEX7B+1Z0LcXjSatMGe8=
 github.com/ipld/go-codec-dagpb v1.3.0/go.mod h1:ga4JTU3abYApDC3pZ00BC2RSvC3qfBb9MSJkMLSwnhA=
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
-github.com/ipld/go-ipld-prime v0.12.0 h1:JapyKWTsJgmhrPI7hfx4V798c/RClr85sXfBZnH1VIw=
-github.com/ipld/go-ipld-prime v0.12.0/go.mod h1:hy8b93WleDMRKumOJnTIrr0MbbFbx9GD6Kzxa53Xppc=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e h1:HPLQ9V/OFHKjfbFio8vQV+EW7lpQPj+iPl93VcwSTYM=
+github.com/ipld/go-ipld-prime v0.12.3-0.20210929125341-05d5528bd84e/go.mod h1:PaeLYq8k6dJLmDUSLrzkEpoGV4PEfe/1OtFN/eALOc8=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=
@@ -539,6 +539,8 @@ github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=
 github.com/multiformats/go-multibase v0.0.3 h1:l/B6bJDQjvQ5G52jw4QGSYeOTZoAwIO77RblWplfIqk=
 github.com/multiformats/go-multibase v0.0.3/go.mod h1:5+1R4eQrT3PkYZ24C3W2Ue2tPwIdYQD509ZjSb5y9Oc=
+github.com/multiformats/go-multicodec v0.3.0 h1:tstDwfIjiHbnIjeM5Lp+pMrSeN+LCMsEwOrkPmWm03A=
+github.com/multiformats/go-multicodec v0.3.0/go.mod h1:qGGaQmioCDh+TeFOnxrbU0DaIPw8yFgAZgFG0V7p1qQ=
 github.com/multiformats/go-multihash v0.0.1/go.mod h1:w/5tugSrLEbWqlcgJabL3oHFKTwfvkofsjW2Qa1ct4U=
 github.com/multiformats/go-multihash v0.0.5/go.mod h1:lt/HCbqlQwlPBz7lv0sQCdtfcMtlJvakRUn/0Ual8po=
 github.com/multiformats/go-multihash v0.0.8/go.mod h1:YSLudS+Pi8NHE7o6tb3D8vrpKa63epEDmG8nTduyAew=

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -140,6 +140,7 @@ func MaxInProgressOutgoingRequests(maxInProgressOutgoingRequests uint64) Option 
 
 // MaxLinksPerOutgoingRequests changes the allowed number of links an outgoing
 // request can traverse before failing
+// A value of 0 = infinity, or no limit
 func MaxLinksPerOutgoingRequests(maxLinksPerOutgoingRequest uint64) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.maxLinksPerOutgoingRequest = maxLinksPerOutgoingRequest
@@ -148,6 +149,7 @@ func MaxLinksPerOutgoingRequests(maxLinksPerOutgoingRequest uint64) Option {
 
 // MaxLinksPerIncomingRequests changes the allowed number of links an incoming
 // request can traverse before failing
+// A value of 0 = infinity, or no limit
 func MaxLinksPerIncomingRequests(maxLinksPerIncomingRequest uint64) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.maxLinksPerIncomingRequest = maxLinksPerIncomingRequest

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -74,6 +74,8 @@ type graphsyncConfigOptions struct {
 	maxInProgressIncomingRequests uint64
 	maxInProgressOutgoingRequests uint64
 	registerDefaultValidator      bool
+	maxLinksPerOutgoingRequest    uint64
+	maxLinksPerIncomingRequest    uint64
 }
 
 // Option defines the functional option type that can be used to configure
@@ -136,6 +138,22 @@ func MaxInProgressOutgoingRequests(maxInProgressOutgoingRequests uint64) Option 
 	}
 }
 
+// MaxLinksPerOutgoingRequests changes the allowed number of links an outgoing
+// request can traverse before failing
+func MaxLinksPerOutgoingRequests(maxLinksPerOutgoingRequest uint64) Option {
+	return func(gs *graphsyncConfigOptions) {
+		gs.maxLinksPerOutgoingRequest = maxLinksPerOutgoingRequest
+	}
+}
+
+// MaxLinksPerIncomingRequests changes the allowed number of links an incoming
+// request can traverse before failing
+func MaxLinksPerIncomingRequests(maxLinksPerIncomingRequest uint64) Option {
+	return func(gs *graphsyncConfigOptions) {
+		gs.maxLinksPerIncomingRequest = maxLinksPerIncomingRequest
+	}
+}
+
 // New creates a new GraphSync Exchange on the given network,
 // and the given link loader+storer.
 func New(parent context.Context, network gsnet.GraphSyncNetwork,
@@ -179,11 +197,11 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 
 	asyncLoader := asyncloader.New(ctx, linkSystem, requestAllocator)
 	requestQueue := taskqueue.NewTaskQueue(ctx)
-	requestManager := requestmanager.New(ctx, asyncLoader, linkSystem, outgoingRequestHooks, incomingResponseHooks, networkErrorListeners, requestQueue, network.ConnectionManager())
+	requestManager := requestmanager.New(ctx, asyncLoader, linkSystem, outgoingRequestHooks, incomingResponseHooks, networkErrorListeners, requestQueue, network.ConnectionManager(), gsConfig.maxLinksPerOutgoingRequest)
 	requestExecutor := executor.NewExecutor(requestManager, incomingBlockHooks, asyncLoader.AsyncLoad)
 	responseAssembler := responseassembler.New(ctx, peerManager)
 	peerTaskQueue := peertaskqueue.New()
-	responseManager := responsemanager.New(ctx, linkSystem, responseAssembler, peerTaskQueue, requestQueuedHooks, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressIncomingRequests, network.ConnectionManager())
+	responseManager := responsemanager.New(ctx, linkSystem, responseAssembler, peerTaskQueue, requestQueuedHooks, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressIncomingRequests, network.ConnectionManager(), gsConfig.maxLinksPerIncomingRequest)
 	graphSync := &GraphSync{
 		network:                     network,
 		linkSystem:                  linkSystem,

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -87,15 +87,16 @@ type AsyncLoader interface {
 // RequestManager tracks outgoing requests and processes incoming reponses
 // to them.
 type RequestManager struct {
-	ctx             context.Context
-	cancel          func()
-	messages        chan requestManagerMessage
-	peerHandler     PeerHandler
-	rc              *responseCollector
-	asyncLoader     AsyncLoader
-	disconnectNotif *pubsub.PubSub
-	linkSystem      ipld.LinkSystem
-	connManager     network.ConnManager
+	ctx                context.Context
+	cancel             func()
+	messages           chan requestManagerMessage
+	peerHandler        PeerHandler
+	rc                 *responseCollector
+	asyncLoader        AsyncLoader
+	disconnectNotif    *pubsub.PubSub
+	linkSystem         ipld.LinkSystem
+	connManager        network.ConnManager
+	maxLinksPerRequest uint64
 
 	// dont touch out side of run loop
 	nextRequestID             graphsync.RequestID
@@ -129,6 +130,7 @@ func New(ctx context.Context,
 	networkErrorListeners *listeners.NetworkErrorListeners,
 	requestQueue taskqueue.TaskQueue,
 	connManager network.ConnManager,
+	maxLinksPerRequest uint64,
 ) *RequestManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &RequestManager{
@@ -145,6 +147,7 @@ func New(ctx context.Context,
 		networkErrorListeners:     networkErrorListeners,
 		requestQueue:              requestQueue,
 		connManager:               connManager,
+		maxLinksPerRequest:        maxLinksPerRequest,
 	}
 }
 

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -88,15 +88,16 @@ type AsyncLoader interface {
 // RequestManager tracks outgoing requests and processes incoming reponses
 // to them.
 type RequestManager struct {
-	ctx                context.Context
-	cancel             func()
-	messages           chan requestManagerMessage
-	peerHandler        PeerHandler
-	rc                 *responseCollector
-	asyncLoader        AsyncLoader
-	disconnectNotif    *pubsub.PubSub
-	linkSystem         ipld.LinkSystem
-	connManager        network.ConnManager
+	ctx             context.Context
+	cancel          func()
+	messages        chan requestManagerMessage
+	peerHandler     PeerHandler
+	rc              *responseCollector
+	asyncLoader     AsyncLoader
+	disconnectNotif *pubsub.PubSub
+	linkSystem      ipld.LinkSystem
+	connManager     network.ConnManager
+	// maximum number of links to traverse per request. A value of zero = infinity, or no limit
 	maxLinksPerRequest uint64
 
 	// dont touch out side of run loop

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -66,6 +66,7 @@ type inProgressRequestStatus struct {
 	inProgressChan   chan graphsync.ResponseProgress
 	inProgressErr    chan error
 	traverser        ipldutil.Traverser
+	traverserCancel  context.CancelFunc
 }
 
 // PeerHandler is an interface that can send requests to peers

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -1019,7 +1019,7 @@ func newTestData(ctx context.Context, t *testing.T) *testData {
 	td.networkErrorListeners = listeners.NewNetworkErrorListeners()
 	td.taskqueue = taskqueue.NewTaskQueue(ctx)
 	lsys := cidlink.DefaultLinkSystem()
-	td.requestManager = New(ctx, td.fal, lsys, td.requestHooks, td.responseHooks, td.networkErrorListeners, td.taskqueue, td.tcm)
+	td.requestManager = New(ctx, td.fal, lsys, td.requestHooks, td.responseHooks, td.networkErrorListeners, td.taskqueue, td.tcm, 0)
 	td.executor = executor.NewExecutor(td.requestManager, td.blockHooks, td.fal.AsyncLoad)
 	td.requestManager.SetDelegate(td.fph)
 	td.requestManager.Startup()

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -109,12 +109,17 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 				LinkBudget: int64(rm.maxLinksPerRequest),
 			}
 		}
+		// the traverser has its own context because we want to fail on block boundaries, in the executor,
+		// and make sure all blocks included up to the termination message
+		// are processed and passed in the response channel
+		ctx, cancel := context.WithCancel(rm.ctx)
+		ipr.traverserCancel = cancel
 		ipr.traverser = ipldutil.TraversalBuilder{
 			Root:     cidlink.Link{Cid: ipr.request.Root()},
 			Selector: ipr.request.Selector(),
 			Visitor: func(tp traversal.Progress, node ipld.Node, tr traversal.VisitReason) error {
 				select {
-				case <-ipr.ctx.Done():
+				case <-ctx.Done():
 				case ipr.inProgressChan <- graphsync.ResponseProgress{
 					Node:      node,
 					Path:      tp.Path,
@@ -126,7 +131,7 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 			Chooser:    ipr.nodeStyleChooser,
 			LinkSystem: rm.linkSystem,
 			Budget:     budget,
-		}.Start(ipr.ctx)
+		}.Start(ctx)
 	}
 
 	ipr.state = running
@@ -165,6 +170,7 @@ func (rm *RequestManager) terminateRequest(requestID graphsync.RequestID, ipr *i
 	ipr.cancelFn()
 	rm.asyncLoader.CleanupRequest(requestID)
 	if ipr.traverser != nil {
+		ipr.traverserCancel()
 		ipr.traverser.Shutdown(rm.ctx)
 	}
 	// make sure context is not closed before closing channels (could cause send

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -102,6 +102,13 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 	var initialRequest bool
 	if ipr.traverser == nil {
 		initialRequest = true
+		var budget *traversal.Budget
+		if rm.maxLinksPerRequest > 0 {
+			budget = &traversal.Budget{
+				NodeBudget: math.MaxInt64,
+				LinkBudget: int64(rm.maxLinksPerRequest),
+			}
+		}
 		ipr.traverser = ipldutil.TraversalBuilder{
 			Root:     cidlink.Link{Cid: ipr.request.Root()},
 			Selector: ipr.request.Selector(),
@@ -118,6 +125,7 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 			},
 			Chooser:    ipr.nodeStyleChooser,
 			LinkSystem: rm.linkSystem,
+			Budget:     budget,
 		}.Start(ipr.ctx)
 	}
 

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -155,7 +155,8 @@ type ResponseManager struct {
 	inProgressResponses   map[responseKey]*inProgressResponseStatus
 	maxInProcessRequests  uint64
 	connManager           network.ConnManager
-	maxLinksPerRequest    uint64
+	// maximum number of links to traverse per request. A value of zero = infinity, or no limit
+	maxLinksPerRequest uint64
 }
 
 // New creates a new response manager for responding to requests

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -155,6 +155,7 @@ type ResponseManager struct {
 	inProgressResponses   map[responseKey]*inProgressResponseStatus
 	maxInProcessRequests  uint64
 	connManager           network.ConnManager
+	maxLinksPerRequest    uint64
 }
 
 // New creates a new response manager for responding to requests
@@ -172,6 +173,7 @@ func New(ctx context.Context,
 	networkErrorListeners NetworkErrorListeners,
 	maxInProcessRequests uint64,
 	connManager network.ConnManager,
+	maxLinksPerRequest uint64,
 ) *ResponseManager {
 	ctx, cancelFn := context.WithCancel(ctx)
 	messages := make(chan responseManagerMessage, 16)
@@ -194,6 +196,7 @@ func New(ctx context.Context,
 		inProgressResponses:   make(map[responseKey]*inProgressResponseStatus),
 		maxInProcessRequests:  maxInProcessRequests,
 		connManager:           connManager,
+		maxLinksPerRequest:    maxLinksPerRequest,
 	}
 	rm.qe = &queryExecutor{
 		blockHooks:         blockHooks,

--- a/responsemanager/querypreparer.go
+++ b/responsemanager/querypreparer.go
@@ -22,9 +22,10 @@ import (
 )
 
 type queryPreparer struct {
-	requestHooks       RequestHooks
-	responseAssembler  ResponseAssembler
-	linkSystem         ipld.LinkSystem
+	requestHooks      RequestHooks
+	responseAssembler ResponseAssembler
+	linkSystem        ipld.LinkSystem
+	// maximum number of links to traverse per request. A value of zero = infinity, or no limit=
 	maxLinksPerRequest uint64
 }
 

--- a/responsemanager/querypreparer.go
+++ b/responsemanager/querypreparer.go
@@ -3,10 +3,12 @@ package responsemanager
 import (
 	"context"
 	"errors"
+	"math"
 
 	"github.com/ipfs/go-cid"
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
+	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ipfs/go-graphsync"
@@ -20,9 +22,10 @@ import (
 )
 
 type queryPreparer struct {
-	requestHooks      RequestHooks
-	responseAssembler ResponseAssembler
-	linkSystem        ipld.LinkSystem
+	requestHooks       RequestHooks
+	responseAssembler  ResponseAssembler
+	linkSystem         ipld.LinkSystem
+	maxLinksPerRequest uint64
 }
 
 func (qe *queryPreparer) prepareQuery(ctx context.Context,
@@ -71,11 +74,19 @@ func (qe *queryPreparer) prepareQuery(ctx context.Context,
 	if linkSystem.StorageReadOpener == nil {
 		linkSystem = qe.linkSystem
 	}
+	var budget *traversal.Budget
+	if qe.maxLinksPerRequest > 0 {
+		budget = &traversal.Budget{
+			NodeBudget: math.MaxInt64,
+			LinkBudget: int64(qe.maxLinksPerRequest),
+		}
+	}
 	traverser := ipldutil.TraversalBuilder{
 		Root:       rootLink,
 		Selector:   request.Selector(),
 		LinkSystem: linkSystem,
 		Chooser:    result.CustomChooser,
+		Budget:     budget,
 	}.Start(ctx)
 
 	return linkSystem.StorageReadOpener, traverser, isPaused, nil

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -1103,13 +1103,13 @@ func newTestData(t *testing.T) testData {
 }
 
 func (td *testData) newResponseManager() *ResponseManager {
-	return New(td.ctx, td.persistence, td.responseAssembler, td.queryQueue, td.requestQueuedHooks, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager)
+	return New(td.ctx, td.persistence, td.responseAssembler, td.queryQueue, td.requestQueuedHooks, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager, 0)
 }
 
 func (td *testData) alternateLoaderResponseManager() *ResponseManager {
 	obs := make(map[ipld.Link][]byte)
 	persistence := testutil.NewTestStore(obs)
-	return New(td.ctx, persistence, td.responseAssembler, td.queryQueue, td.requestQueuedHooks, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager)
+	return New(td.ctx, persistence, td.responseAssembler, td.queryQueue, td.requestQueuedHooks, td.requestHooks, td.blockHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager, 0)
 }
 
 func (td *testData) assertPausedRequest() {

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -196,7 +196,7 @@ func (rm *ResponseManager) taskDataForKey(key responseKey) ResponseTaskData {
 		return ResponseTaskData{Empty: true}
 	}
 	if response.loader == nil || response.traverser == nil {
-		loader, traverser, isPaused, err := (&queryPreparer{rm.requestHooks, rm.responseAssembler, rm.linkSystem}).prepareQuery(response.ctx, key.p, response.request, response.signals, response.subscriber)
+		loader, traverser, isPaused, err := (&queryPreparer{rm.requestHooks, rm.responseAssembler, rm.linkSystem, rm.maxLinksPerRequest}).prepareQuery(response.ctx, key.p, response.request, response.signals, response.subscriber)
 		if err != nil {
 			response.cancelFn()
 			delete(rm.inProgressResponses, key)

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -152,10 +152,13 @@ func ReadNResponses(ctx context.Context, t TestingT, responseChan <-chan graphsy
 	var returnedBlocks []graphsync.ResponseProgress
 	for i := 0; i < count; i++ {
 		select {
-		case blk := <-responseChan:
+		case blk, ok := <-responseChan:
+			if !ok {
+				require.FailNowf(t, "Channel closed early", "expected %d messages, got %d", count, len(returnedBlocks))
+			}
 			returnedBlocks = append(returnedBlocks, blk)
 		case <-ctx.Done():
-			t.Fatal("Unable to read enough responses")
+			require.FailNow(t, "Unable to read enough responses")
 		}
 	}
 	return returnedBlocks


### PR DESCRIPTION
# Goals

Provide absolute limits on links traversed for incoming and outgoing requests

# Implementation

- use budget in Traverser utility (add logic to handle budget for first link load)
- create options for MaxLinksPerOutgoingRequest & MaxLinksPerIncomingRequest
- pass through and create traversak budgets as needed (0 vals = no max links)
- add integration tests & unit tests of traverser behavior