### PR TITLE
feat(requestmanager): add OutgoingRequeustProcessingListener

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -281,6 +281,10 @@ type OnReceiverNetworkErrorListener func(p peer.ID, err error)
 // OnResponseCompletedListener provides a way to listen for when responder has finished serving a response
 type OnResponseCompletedListener func(p peer.ID, request RequestData, status ResponseStatusCode)
 
+// OnOutgoingRequestProcessingListener is called when a request actually begins processing (reaches
+// the top of the outgoing request queue)
+type OnOutgoingRequestProcessingListener func(p peer.ID, request RequestData)
+
 // OnRequestorCancelledListener provides a way to listen for responses the requestor canncels
 type OnRequestorCancelledListener func(p peer.ID, request RequestData)
 
@@ -359,6 +363,10 @@ type GraphExchange interface {
 
 	// RegisterRequestUpdatedHook adds a hook that runs every time an update to a request is received
 	RegisterRequestUpdatedHook(hook OnRequestUpdatedHook) UnregisterHookFunc
+
+	// RegisterOutgoingRequestProcessingListener adds a listener that gets called when a request actually begins processing (reaches
+	// the top of the outgoing request queue)
+	RegisterOutgoingRequestProcessingListener(listener OnOutgoingRequestProcessingListener) UnregisterHookFunc
 
 	// RegisterCompletedResponseListener adds a listener on the responder for completed responses
 	RegisterCompletedResponseListener(listener OnResponseCompletedListener) UnregisterHookFunc

--- a/graphsync.go
+++ b/graphsync.go
@@ -283,7 +283,7 @@ type OnResponseCompletedListener func(p peer.ID, request RequestData, status Res
 
 // OnOutgoingRequestProcessingListener is called when a request actually begins processing (reaches
 // the top of the outgoing request queue)
-type OnOutgoingRequestProcessingListener func(p peer.ID, request RequestData)
+type OnOutgoingRequestProcessingListener func(p peer.ID, request RequestData, inProgressRequestCount int)
 
 // OnRequestorCancelledListener provides a way to listen for responses the requestor canncels
 type OnRequestorCancelledListener func(p peer.ID, request RequestData)

--- a/listeners/listeners.go
+++ b/listeners/listeners.go
@@ -78,14 +78,15 @@ type OutgoingRequestProcessingListeners struct {
 }
 
 type internalOutgoingRequestProcessingEvent struct {
-	p       peer.ID
-	request graphsync.RequestData
+	p                      peer.ID
+	request                graphsync.RequestData
+	inProgressRequestCount int
 }
 
 func outgoingRequestProcessingDispatcher(event pubsub.Event, subscriberFn pubsub.SubscriberFn) error {
 	ie := event.(internalOutgoingRequestProcessingEvent)
 	listener := subscriberFn.(graphsync.OnOutgoingRequestProcessingListener)
-	listener(ie.p, ie.request)
+	listener(ie.p, ie.request, ie.inProgressRequestCount)
 	return nil
 }
 
@@ -100,8 +101,8 @@ func (bsl *OutgoingRequestProcessingListeners) Register(listener graphsync.OnOut
 }
 
 // NotifyOutgoingRequestProcessingListeners notifies all listeners that a requestor cancelled a response
-func (bsl *OutgoingRequestProcessingListeners) NotifyOutgoingRequestProcessingListeners(p peer.ID, request graphsync.RequestData) {
-	_ = bsl.pubSub.Publish(internalOutgoingRequestProcessingEvent{p, request})
+func (bsl *OutgoingRequestProcessingListeners) NotifyOutgoingRequestProcessingListeners(p peer.ID, request graphsync.RequestData, inProgressRequestCount int) {
+	_ = bsl.pubSub.Publish(internalOutgoingRequestProcessingEvent{p, request, inProgressRequestCount})
 }
 
 // BlockSentListeners is a set of listeners for when requestors cancel

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -101,12 +101,13 @@ type RequestManager struct {
 	maxLinksPerRequest uint64
 
 	// dont touch out side of run loop
-	nextRequestID             graphsync.RequestID
-	inProgressRequestStatuses map[graphsync.RequestID]*inProgressRequestStatus
-	requestHooks              RequestHooks
-	responseHooks             ResponseHooks
-	networkErrorListeners     *listeners.NetworkErrorListeners
-	requestQueue              taskqueue.TaskQueue
+	nextRequestID                      graphsync.RequestID
+	inProgressRequestStatuses          map[graphsync.RequestID]*inProgressRequestStatus
+	requestHooks                       RequestHooks
+	responseHooks                      ResponseHooks
+	networkErrorListeners              *listeners.NetworkErrorListeners
+	outgoingRequestProcessingListeners *listeners.OutgoingRequestProcessingListeners
+	requestQueue                       taskqueue.TaskQueue
 }
 
 type requestManagerMessage interface {
@@ -130,26 +131,28 @@ func New(ctx context.Context,
 	requestHooks RequestHooks,
 	responseHooks ResponseHooks,
 	networkErrorListeners *listeners.NetworkErrorListeners,
+	outgoingRequestProcessingListeners *listeners.OutgoingRequestProcessingListeners,
 	requestQueue taskqueue.TaskQueue,
 	connManager network.ConnManager,
 	maxLinksPerRequest uint64,
 ) *RequestManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &RequestManager{
-		ctx:                       ctx,
-		cancel:                    cancel,
-		asyncLoader:               asyncLoader,
-		disconnectNotif:           pubsub.New(disconnectDispatcher),
-		linkSystem:                linkSystem,
-		rc:                        newResponseCollector(ctx),
-		messages:                  make(chan requestManagerMessage, 16),
-		inProgressRequestStatuses: make(map[graphsync.RequestID]*inProgressRequestStatus),
-		requestHooks:              requestHooks,
-		responseHooks:             responseHooks,
-		networkErrorListeners:     networkErrorListeners,
-		requestQueue:              requestQueue,
-		connManager:               connManager,
-		maxLinksPerRequest:        maxLinksPerRequest,
+		ctx:                                ctx,
+		cancel:                             cancel,
+		asyncLoader:                        asyncLoader,
+		disconnectNotif:                    pubsub.New(disconnectDispatcher),
+		linkSystem:                         linkSystem,
+		rc:                                 newResponseCollector(ctx),
+		messages:                           make(chan requestManagerMessage, 16),
+		inProgressRequestStatuses:          make(map[graphsync.RequestID]*inProgressRequestStatus),
+		requestHooks:                       requestHooks,
+		responseHooks:                      responseHooks,
+		networkErrorListeners:              networkErrorListeners,
+		outgoingRequestProcessingListeners: outgoingRequestProcessingListeners,
+		requestQueue:                       requestQueue,
+		connManager:                        connManager,
+		maxLinksPerRequest:                 maxLinksPerRequest,
 	}
 }
 

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -773,12 +773,6 @@ func TestOutgoingRequestListeners(t *testing.T) {
 
 	returnedResponseChan1, returnedErrorChan1 := td.requestManager.NewRequest(requestCtx, peers[0], td.blockChain.TipLink, td.blockChain.Selector(), td.extension1)
 
-	select {
-	case <-outgoingRequests:
-		t.Fatal("should not fire outgoing requests listener immediately")
-	default:
-	}
-
 	requestRecords := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)
 
 	// Should have fired by now

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -133,6 +133,8 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 			LinkSystem: rm.linkSystem,
 			Budget:     budget,
 		}.Start(ctx)
+
+		rm.outgoingRequestProcessingListeners.NotifyOutgoingRequestProcessingListeners(ipr.p, ipr.request)
 	}
 
 	ipr.state = running

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -134,7 +134,8 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 			Budget:     budget,
 		}.Start(ctx)
 
-		rm.outgoingRequestProcessingListeners.NotifyOutgoingRequestProcessingListeners(ipr.p, ipr.request)
+		inProgressCount := len(rm.inProgressRequestStatuses)
+		rm.outgoingRequestProcessingListeners.NotifyOutgoingRequestProcessingListeners(ipr.p, ipr.request, inProgressCount)
 	}
 
 	ipr.state = running


### PR DESCRIPTION
Outgoing requests are now asynchronous, so a new OutgoingRequeustProcessingListener can inform a caller when the request is actually made.

Closes: https://github.com/ipfs/go-graphsync/issues/231

I'm actually not sure what the use-case is here, why might an application want to get this close to the request @hannahhoward?