### PR TITLE
Fix deadlock on notifications

### DIFF
--- a/notifications/publisher.go
+++ b/notifications/publisher.go
@@ -21,16 +21,17 @@ type cmd struct {
 
 // publisher is a publisher of events for
 type publisher struct {
-	lk      sync.RWMutex
-	closed  chan struct{}
-	cmdChan chan cmd
+	lk     sync.RWMutex
+	closed chan struct{}
+	cmds   []cmd
+	cmdsLk *sync.Cond
 }
 
 // NewPublisher returns a new message event publisher
 func NewPublisher() Publisher {
 	ps := &publisher{
-		cmdChan: make(chan cmd),
-		closed:  make(chan struct{}),
+		cmdsLk: sync.NewCond(&sync.Mutex{}),
+		closed: make(chan struct{}),
 	}
 	return ps
 }
@@ -49,7 +50,7 @@ func (ps *publisher) Publish(topic Topic, event Event) {
 	default:
 	}
 
-	ps.cmdChan <- cmd{op: pub, topics: []Topic{topic}, msg: event}
+	ps.queue(cmd{op: pub, topics: []Topic{topic}, msg: event})
 }
 
 // Shutdown shuts down all events and subscriptions
@@ -62,7 +63,7 @@ func (ps *publisher) Shutdown() {
 	default:
 	}
 	close(ps.closed)
-	ps.cmdChan <- cmd{op: shutdown}
+	ps.queue(cmd{op: shutdown})
 }
 
 func (ps *publisher) Close(id Topic) {
@@ -73,7 +74,7 @@ func (ps *publisher) Close(id Topic) {
 		return
 	default:
 	}
-	ps.cmdChan <- cmd{op: closeTopic, topics: []Topic{id}}
+	ps.queue(cmd{op: closeTopic, topics: []Topic{id}})
 }
 
 func (ps *publisher) Subscribe(topic Topic, sub Subscriber) bool {
@@ -86,7 +87,7 @@ func (ps *publisher) Subscribe(topic Topic, sub Subscriber) bool {
 	default:
 	}
 
-	ps.cmdChan <- cmd{op: subscribe, topics: []Topic{topic}, sub: sub}
+	ps.queue(cmd{op: subscribe, topics: []Topic{topic}, sub: sub})
 	return true
 }
 
@@ -100,7 +101,7 @@ func (ps *publisher) Unsubscribe(sub Subscriber) bool {
 	default:
 	}
 
-	ps.cmdChan <- cmd{op: unsubAll, sub: sub}
+	ps.queue(cmd{op: unsubAll, sub: sub})
 	return true
 }
 
@@ -111,7 +112,8 @@ func (ps *publisher) start() {
 	}
 
 loop:
-	for cmd := range ps.cmdChan {
+	for {
+		cmd := ps.dequeue()
 		if cmd.topics == nil {
 			switch cmd.op {
 			case unsubAll:
@@ -201,4 +203,23 @@ func (reg *subscriberRegistry) remove(topic Topic, sub Subscriber) {
 	}
 
 	sub.OnClose(topic)
+}
+
+func (ps *publisher) queue(cmd cmd) {
+	ps.cmdsLk.L.Lock()
+	ps.cmds = append(ps.cmds, cmd)
+	ps.cmdsLk.L.Unlock()
+	ps.cmdsLk.Signal()
+}
+
+func (ps *publisher) dequeue() cmd {
+	ps.cmdsLk.L.Lock()
+	for len(ps.cmds) == 0 {
+		ps.cmdsLk.Wait()
+	}
+
+	cmd := ps.cmds[0]
+	ps.cmds = ps.cmds[1:]
+	ps.cmdsLk.L.Unlock()
+	return cmd
 }

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -280,6 +280,11 @@ func (rm *ResponseManager) FinishTask(task *peertask.Task, err error) {
 	rm.send(&finishTaskRequest{task, err}, nil)
 }
 
+// CloseWithNetworkError closes a request due to a network error
+func (rm *ResponseManager) CloseWithNetworkError(p peer.ID, requestID graphsync.RequestID) {
+	rm.send(&errorRequestMessage{p, requestID, errNetworkError, make(chan error, 1)}, nil)
+}
+
 func (rm *ResponseManager) send(message responseManagerMessage, done <-chan struct{}) {
 	select {
 	case <-rm.ctx.Done():

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -158,8 +158,7 @@ func (rm *ResponseManager) processRequests(p peer.ID, requests []gsmsg.GraphSync
 		sub := notifications.NewTopicDataSubscriber(&subscriber{
 			p:                     key.p,
 			request:               request,
-			ctx:                   rm.ctx,
-			messages:              rm.messages,
+			requestCloser:         rm,
 			blockSentListeners:    rm.blockSentListeners,
 			completedListeners:    rm.completedListeners,
 			networkErrorListeners: rm.networkErrorListeners,


### PR DESCRIPTION
# Goals

The notification queue is extremely vulnerable to deadlocks if one of the subscribers takes a long time to process a notification. 

# Implementation

This change makes calls to Subscribe and Publish more non-blocking by treating internal commands as an unbuffered queue, rather than a blocking channel. We use a mutex and a sync.Cond to implement, a fairly standard way to implement a non-blocking concurrent queue.

We also cleanup the subscriber for the response manager. (this was a side effect of initially trying to solve the deadlock issue by making the subscriber more non-blocking in it's processing). Ultimately, it may make sense to move these subscribers directly into the message queue and remove the notification system entirely. but in the meantime, it makes sense for subscriber not to have access to private vars in the response manager