### PR TITLE
Limit simultaneous incoming requests on a per peer basis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/ipfs/go-ipld-format v0.2.0
 	github.com/ipfs/go-log/v2 v2.1.1
 	github.com/ipfs/go-merkledag v0.3.2
-	github.com/ipfs/go-peertaskqueue v0.2.0
+	github.com/ipfs/go-peertaskqueue v0.6.0
 	github.com/ipfs/go-unixfs v0.2.4
 	github.com/ipld/go-codec-dagpb v1.3.0
 	github.com/ipld/go-ipld-prime v0.12.3

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cB
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/btcsuite/btcd v0.0.0-20190213025234-306aecffea32/go.mod h1:DrZx5ec/dmnfpw9KyYoQyYo7d0KEvTkk/5M/vbZjAr8=
 github.com/btcsuite/btcd v0.0.0-20190523000118-16327141da8c/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/btcsuite/btcd v0.0.0-20190605094302-a0d1e3e36d50/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
@@ -227,8 +229,8 @@ github.com/ipfs/go-metrics-interface v0.0.1 h1:j+cpbjYvu4R8zbleSs36gvB7jR+wsL2fG
 github.com/ipfs/go-metrics-interface v0.0.1/go.mod h1:6s6euYU4zowdslK0GKHmqaIZ3j/b/tL7HTWtJ4VPgWY=
 github.com/ipfs/go-peertaskqueue v0.1.0/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
 github.com/ipfs/go-peertaskqueue v0.1.1/go.mod h1:Jmk3IyCcfl1W3jTW3YpghSwSEC6IJ3Vzz/jUmWw8Z0U=
-github.com/ipfs/go-peertaskqueue v0.2.0 h1:2cSr7exUGKYyDeUyQ7P/nHPs9P7Ht/B+ROrpN1EJOjc=
-github.com/ipfs/go-peertaskqueue v0.2.0/go.mod h1:5/eNrBEbtSKWCG+kQK8K8fGNixoYUnr+P7jivavs9lY=
+github.com/ipfs/go-peertaskqueue v0.6.0 h1:BT1/PuNViVomiz1PnnP5+WmKsTNHrxIDvkZrkj4JhOg=
+github.com/ipfs/go-peertaskqueue v0.6.0/go.mod h1:M/akTIE/z1jGNXMU7kFB4TeSEFvj68ow0Rrb04donIU=
 github.com/ipfs/go-unixfs v0.2.4 h1:6NwppOXefWIyysZ4LR/qUBPvXd5//8J3jiMdvpbw6Lo=
 github.com/ipfs/go-unixfs v0.2.4/go.mod h1:SUdisfUjNoSDzzhGVxvCL9QO/nKdwXdr+gbMUdqcbYw=
 github.com/ipfs/go-verifcid v0.0.1 h1:m2HI7zIuR5TFyQ1b79Da5N9dnnCP1vcu2QqawmWlK2E=

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -132,7 +132,7 @@ func MaxInProgressIncomingRequests(maxInProgressIncomingRequests uint64) Option 
 }
 
 // MaxInProgressIncomingRequestsPerPeer changes the maximum number of
-// incoming graphsync requests that are processed in parallel on a peer peer basis.
+// incoming graphsync requests that are processed in parallel on a per-peer basis.
 // The value is not set by default.
 // Useful in an environment for very high bandwidth graphsync responders serving
 // many peers

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -67,15 +67,16 @@ type GraphSync struct {
 }
 
 type graphsyncConfigOptions struct {
-	totalMaxMemoryResponder       uint64
-	maxMemoryPerPeerResponder     uint64
-	totalMaxMemoryRequestor       uint64
-	maxMemoryPerPeerRequestor     uint64
-	maxInProgressIncomingRequests uint64
-	maxInProgressOutgoingRequests uint64
-	registerDefaultValidator      bool
-	maxLinksPerOutgoingRequest    uint64
-	maxLinksPerIncomingRequest    uint64
+	totalMaxMemoryResponder              uint64
+	maxMemoryPerPeerResponder            uint64
+	totalMaxMemoryRequestor              uint64
+	maxMemoryPerPeerRequestor            uint64
+	maxInProgressIncomingRequests        uint64
+	maxInProgressIncomingRequestsPerPeer uint64
+	maxInProgressOutgoingRequests        uint64
+	registerDefaultValidator             bool
+	maxLinksPerOutgoingRequest           uint64
+	maxLinksPerIncomingRequest           uint64
 }
 
 // Option defines the functional option type that can be used to configure
@@ -123,15 +124,29 @@ func MaxMemoryPerPeerRequestor(maxMemoryPerPeer uint64) Option {
 }
 
 // MaxInProgressIncomingRequests changes the maximum number of
-// graphsync requests that are processed in parallel (default 6)
+// incoming graphsync requests that are processed in parallel (default 6)
 func MaxInProgressIncomingRequests(maxInProgressIncomingRequests uint64) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.maxInProgressIncomingRequests = maxInProgressIncomingRequests
 	}
 }
 
+// MaxInProgressIncomingRequestsPerPeer changes the maximum number of
+// incoming graphsync requests that are processed in parallel on a peer peer basis.
+// The value is not set by default.
+// Useful in an environment for very high bandwidth graphsync responders serving
+// many peers
+// Note: if for some reason this is set higher than MaxInProgressIncomingRequests
+// it will simply have no effect.
+// Note: setting a value of zero will have no effect
+func MaxInProgressIncomingRequestsPerPeer(maxInProgressIncomingRequestsPerPeer uint64) Option {
+	return func(gs *graphsyncConfigOptions) {
+		gs.maxInProgressIncomingRequestsPerPeer = maxInProgressIncomingRequestsPerPeer
+	}
+}
+
 // MaxInProgressOutgoingRequests changes the maximum number of
-// graphsync requests that are processed in parallel (default 6)
+// outgoing graphsync requests that are processed in parallel (default 6)
 func MaxInProgressOutgoingRequests(maxInProgressOutgoingRequests uint64) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.maxInProgressOutgoingRequests = maxInProgressOutgoingRequests
@@ -202,7 +217,11 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	requestManager := requestmanager.New(ctx, asyncLoader, linkSystem, outgoingRequestHooks, incomingResponseHooks, networkErrorListeners, requestQueue, network.ConnectionManager(), gsConfig.maxLinksPerOutgoingRequest)
 	requestExecutor := executor.NewExecutor(requestManager, incomingBlockHooks, asyncLoader.AsyncLoad)
 	responseAssembler := responseassembler.New(ctx, peerManager)
-	peerTaskQueue := peertaskqueue.New()
+	var ptqopts []peertaskqueue.Option
+	if gsConfig.maxInProgressIncomingRequestsPerPeer > 0 {
+		ptqopts = append(ptqopts, peertaskqueue.MaxOutstandingWorkPerPeer(int(gsConfig.maxInProgressIncomingRequestsPerPeer)))
+	}
+	peerTaskQueue := peertaskqueue.New(ptqopts...)
 	responseManager := responsemanager.New(ctx, linkSystem, responseAssembler, peerTaskQueue, requestQueuedHooks, incomingRequestHooks, outgoingBlockHooks, requestUpdatedHooks, completedResponseListeners, requestorCancelledListeners, blockSentListeners, networkErrorListeners, gsConfig.maxInProgressIncomingRequests, network.ConnectionManager(), gsConfig.maxLinksPerIncomingRequest)
 	graphSync := &GraphSync{
 		network:                     network,


### PR DESCRIPTION
# Goals

Don't let the request queue fill all the way up with requests with a very slow peer in an Estuary like scenario

# Implementation

I didn't even know this existed in the peer task queue! What this option does is you just won't be able to pop work from a queue until the number active requests drops. Note that paused requests are not part of the active count, so we don't need to worry about that part.