### PR TITLE
Configure message parameters

### DIFF
--- a/benchmarks/testnet/virtual.go
+++ b/benchmarks/testnet/virtual.go
@@ -200,7 +200,7 @@ func (mp *messagePasser) Reset() error {
 	return nil
 }
 
-func (nc *networkClient) NewMessageSender(ctx context.Context, p peer.ID) (gsnet.MessageSender, error) {
+func (nc *networkClient) NewMessageSender(ctx context.Context, p peer.ID, _ gsnet.MessageSenderOpts) (gsnet.MessageSender, error) {
 	return &messagePasser{
 		net:    nc,
 		target: p,

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -193,6 +193,8 @@ func MessageSendRetries(messageSendRetries int) Option {
 // trying again (up to max retries).
 // Lower to increase the speed at which an unresponsive peer is
 // detected.
+//
+// If not set, a default of 10 minutes is used.
 func SendMessageTimeout(sendMessageTimeout time.Duration) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.sendMessageTimeout = sendMessageTimeout

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -2,6 +2,7 @@ package graphsync
 
 import (
 	"context"
+	"time"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue"
@@ -33,6 +34,8 @@ const maxRecursionDepth = 100
 const defaultTotalMaxMemory = uint64(256 << 20)
 const defaultMaxMemoryPerPeer = uint64(16 << 20)
 const defaultMaxInProgressRequests = uint64(6)
+const defaultMessageSendRetries = 10
+const defaultSendMessageTimeout = 10 * time.Minute
 
 // GraphSync is an instance of a GraphSync exchange that implements
 // the graphsync protocol.
@@ -77,6 +80,8 @@ type graphsyncConfigOptions struct {
 	registerDefaultValidator             bool
 	maxLinksPerOutgoingRequest           uint64
 	maxLinksPerIncomingRequest           uint64
+	messageSendRetries                   int
+	sendMessageTimeout                   time.Duration
 }
 
 // Option defines the functional option type that can be used to configure
@@ -171,6 +176,27 @@ func MaxLinksPerIncomingRequests(maxLinksPerIncomingRequest uint64) Option {
 	}
 }
 
+// MessageSendRetries sets the number of times graphsync will send
+// attempt to send a message before giving up.
+// Lower to increase the speed at which an unresponsive peer is
+// detected.
+func MessageSendRetries(messageSendRetries int) Option {
+	return func(gs *graphsyncConfigOptions) {
+		gs.messageSendRetries = messageSendRetries
+	}
+}
+
+// SendMessageTimeout sets the amount of time graphsync will wait
+// for a message to go across the wire before giving up and
+// trying again (up to max retries).
+// Lower to increase the speed at which an unresponsive peer is
+// detected.
+func SendMessageTimeout(sendMessageTimeout time.Duration) Option {
+	return func(gs *graphsyncConfigOptions) {
+		gs.sendMessageTimeout = sendMessageTimeout
+	}
+}
+
 // New creates a new GraphSync Exchange on the given network,
 // and the given link loader+storer.
 func New(parent context.Context, network gsnet.GraphSyncNetwork,
@@ -185,6 +211,8 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		maxInProgressIncomingRequests: defaultMaxInProgressRequests,
 		maxInProgressOutgoingRequests: defaultMaxInProgressRequests,
 		registerDefaultValidator:      true,
+		messageSendRetries:            defaultMessageSendRetries,
+		sendMessageTimeout:            defaultSendMessageTimeout,
 	}
 	for _, option := range options {
 		option(gsConfig)
@@ -207,7 +235,7 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 	}
 	responseAllocator := allocator.NewAllocator(gsConfig.totalMaxMemoryResponder, gsConfig.maxMemoryPerPeerResponder)
 	createMessageQueue := func(ctx context.Context, p peer.ID) peermanager.PeerQueue {
-		return messagequeue.New(ctx, p, network, responseAllocator)
+		return messagequeue.New(ctx, p, network, responseAllocator, gsConfig.messageSendRetries, gsConfig.sendMessageTimeout)
 	}
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 	requestAllocator := allocator.NewAllocator(gsConfig.totalMaxMemoryRequestor, gsConfig.maxMemoryPerPeerRequestor)

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -180,6 +180,8 @@ func MaxLinksPerIncomingRequests(maxLinksPerIncomingRequest uint64) Option {
 // attempt to send a message before giving up.
 // Lower to increase the speed at which an unresponsive peer is
 // detected.
+//
+// If not set, a default of 10 is used.
 func MessageSendRetries(messageSendRetries int) Option {
 	return func(gs *graphsyncConfigOptions) {
 		gs.messageSendRetries = messageSendRetries

--- a/network/interface.go
+++ b/network/interface.go
@@ -2,6 +2,7 @@ package network
 
 import (
 	"context"
+	"time"
 
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/protocol"
@@ -30,9 +31,14 @@ type GraphSyncNetwork interface {
 	// ConnectTo establishes a connection to the given peer
 	ConnectTo(context.Context, peer.ID) error
 
-	NewMessageSender(context.Context, peer.ID) (MessageSender, error)
+	NewMessageSender(context.Context, peer.ID, MessageSenderOpts) (MessageSender, error)
 
 	ConnectionManager() ConnManager
+}
+
+// MessageSenderOpts sets parameters for a message sender
+type MessageSenderOpts struct {
+	SendTimeout time.Duration
 }
 
 // ConnManager provides the methods needed to protect and unprotect connections


### PR DESCRIPTION
# Goals

Currently, for each network message, graphsync attempts to send it for 10 minutes, then if it fails, retries 10 times. So for a network message to truly fail, it takes 100 minutes. This seems like an extremely long time.

# Implementation

- Copy over some network layer configuration code from go-bitswap
- Allow configuring these values. For the time being, I'm not changing the defaults -- it seems like it would be better to experiment in the estuary context and then see if there are clear correct winners for what we should do here.