### PR TITLE
Prevent allocator underflow

### DIFF
--- a/allocator/allocator_test.go
+++ b/allocator/allocator_test.go
@@ -307,6 +307,37 @@ func TestAllocator(t *testing.T) {
 				},
 			},
 		},
+		"release block then peer more than allocated": {
+			total:      2000,
+			maxPerPeer: 1000,
+			steps: []allocStep{
+				{
+					op:              alloc{peers[0], 1000},
+					totals:          map[peer.ID]uint64{peers[0]: 1000},
+					expectedPending: []pendingResult{},
+				},
+				{
+					op:              alloc{peers[1], 500},
+					totals:          map[peer.ID]uint64{peers[0]: 1000, peers[1]: 500},
+					expectedPending: []pendingResult{},
+				},
+				{
+					op:              releaseBlock{peers[0], 500},
+					totals:          map[peer.ID]uint64{peers[0]: 500, peers[1]: 500},
+					expectedPending: []pendingResult{},
+				},
+				{
+					op:              releaseBlock{peers[0], 1000},
+					totals:          map[peer.ID]uint64{peers[0]: 0, peers[1]: 500},
+					expectedPending: []pendingResult{},
+				},
+				{
+					op:              releasePeer{peers[1]},
+					totals:          map[peer.ID]uint64{peers[0]: 0, peers[1]: 0},
+					expectedPending: []pendingResult{},
+				},
+			},
+		},
 	}
 	for testCase, data := range testCases {
 		t.Run(testCase, func(t *testing.T) {


### PR DESCRIPTION
# Goals

Address scenario that could cause an underflow in the allocator (leading to total allocated
being very high)

The scenario is:
- peer 1 allocates block amount x
- peer 2 allocates block amount y >= 1
- peer 1 call to deallocate block amount x+1 (this shouldn't happen somehow it does). We protect against peer 1 allocation going below zero by setting it to 0, but the global total is now :   y-1 (x+y - (x+1))
- peer 2 deallocates entirely. total is now -1 (no check of total allocated >= 0 after peer deallocation). on unsigned int this becomes MaxUint64

# Implementation

- Add test to demonstrate issues
- Add precautionary check on peer deallocations to prevent underflow
- When deallocating blocks that are greater than total peer memory, only subtract total peer memory from global total, since that's what is actually deallocated
- Add logging to all these unusual scenarios to try to understand how often they are happening