### PR TITLE
fix: bail properly when budget exceeded

### DIFF
--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -191,6 +191,7 @@ func (t *traverser) start() {
 			t.budget.LinkBudget--
 			if t.budget.LinkBudget <= 0 {
 				t.writeDone(&traversal.ErrBudgetExceeded{BudgetKind: "link", Link: t.root})
+				return
 			}
 		}
 		nd, err := t.linkSystem.Load(ipld.LinkContext{Ctx: t.ctx}, t.root, ns)

--- a/ipldutil/traverser_test.go
+++ b/ipldutil/traverser_test.go
@@ -92,7 +92,7 @@ func TestTraverser(t *testing.T) {
 		testutil.AssertDoesReceive(ctx, t, done, "should have completed verification but did not")
 	})
 
-	t.Run("errors correctly, with budget", func(t *testing.T) {
+	t.Run("errors correctly, data with budget", func(t *testing.T) {
 		store := make(map[ipld.Link][]byte)
 		persistence := testutil.NewTestStore(store)
 		blockChain := testutil.SetupBlockChain(ctx, t, persistence, 100, 10)
@@ -117,7 +117,7 @@ func TestTraverser(t *testing.T) {
 		checkTraverseSequence(ctx, t, traverser, blockChain.Blocks(0, 6), &traversal.ErrBudgetExceeded{BudgetKind: "link", Path: path, Link: blockChain.LinkTipIndex(6)})
 	})
 
-	t.Run("errors correctly, no budget", func(t *testing.T) {
+	t.Run("errors correctly, with zero budget", func(t *testing.T) {
 		store := make(map[ipld.Link][]byte)
 		persistence := testutil.NewTestStore(store)
 		blockChain := testutil.SetupBlockChain(ctx, t, persistence, 100, 10)


### PR DESCRIPTION
This is only for the budget=0 case, since the >- budget case is handled
inside the go-ipld-prime traverser. Unlikely to see this in real-world usage.