### PR TITLE
Use `context.CancelFunc` instead of `func()`

### DIFF
--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -114,7 +114,7 @@ type traverser struct {
 	blocksCount    int
 	parentCtx      context.Context
 	ctx            context.Context
-	cancel         func()
+	cancel         context.CancelFunc
 	root           ipld.Link
 	selector       ipld.Node
 	visitor        traversal.AdvVisitFn

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -89,7 +89,7 @@ type AsyncLoader interface {
 // to them.
 type RequestManager struct {
 	ctx             context.Context
-	cancel          func()
+	cancel          context.CancelFunc
 	messages        chan requestManagerMessage
 	peerHandler     PeerHandler
 	rc              *responseCollector

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -991,7 +991,7 @@ func (frb *fakeResponseBuilder) AddNotifee(notifee notifications.Notifee) {
 type testData struct {
 	ctx                       context.Context
 	t                         *testing.T
-	cancel                    func()
+	cancel                    context.CancelFunc
 	blockStore                map[ipld.Link][]byte
 	persistence               ipld.LinkSystem
 	blockChainLength          int


### PR DESCRIPTION
Where context cancellation function is referenced in struct types use
existing `context.CancelFunc` to represent.

Fixes #223