### PR TITLE
Check IPLD context cancellation error type instead of string comparison

### DIFF
--- a/ipldutil/traverser.go
+++ b/ipldutil/traverser.go
@@ -29,6 +29,12 @@ func (cp ContextCancelError) Error() string {
 	return "context cancelled"
 }
 
+// IsContextCancelErr checks whther the given err is ContextCancelError or has a one wrapped.
+// See: errors.Is.
+func IsContextCancelErr(err error) bool {
+	return errors.Is(err, ContextCancelError{})
+}
+
 // TraversalBuilder defines parameters for an iterative traversal
 type TraversalBuilder struct {
 	Root       ipld.Link

--- a/ipldutil/traverser_test.go
+++ b/ipldutil/traverser_test.go
@@ -3,12 +3,14 @@ package ipldutil
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
 
 	blocks "github.com/ipfs/go-block-format"
-	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime"
+
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	basicnode "github.com/ipld/go-ipld-prime/node/basic"
 	"github.com/ipld/go-ipld-prime/traversal"
@@ -154,5 +156,34 @@ func checkTraverseSequence(ctx context.Context, t *testing.T, traverser Traverse
 		require.NoError(t, err)
 	} else {
 		require.EqualError(t, err, finalErr.Error())
+	}
+}
+
+func Test_IsContextErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "ContextCancelErrorIsMatched",
+			err:  ContextCancelError{},
+			want: true,
+		},
+		{
+			name: "WrappedContextCancelErrorIsMatched",
+			err:  fmt.Errorf("%w", ContextCancelError{}),
+			want: true,
+		},
+		{
+			name: "UnwrappedContextCancelErrorWithMatchingStringIsNotMatched",
+			err:  fmt.Errorf("%s", ContextCancelError{}),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IsContextCancelErr(tt.err)
+			require.Equal(t, tt.want, got, "IsContextCancelErr() = %v, want %v", got, tt.want)
+		})
 	}
 }

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal"
-	peer "github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync"

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -119,7 +119,7 @@ func (rm *ResponseManager) abortRequest(p peer.ID, requestID graphsync.RequestID
 
 	if response.state != running {
 		_ = rm.responseAssembler.Transaction(p, requestID, func(rb responseassembler.ResponseBuilder) error {
-			if isContextErr(err) {
+			if ipldutil.IsContextCancelErr(err) {
 				rm.connManager.Unprotect(p, requestID.Tag())
 				rm.cancelledListeners.NotifyCancelledListeners(p, response.request)
 				rb.ClearRequest()


### PR DESCRIPTION
Now that upstream issue re error wrapping in IPLD is resolved, use
`errors.Is` to check that a given error does indeed represent context
cancellation. Consolidate duplicate implementation into one exported
utility function.

Note that the functionality of the error check is now different, in that
it no longer match any error that contains the expected string. A test
is added to assert this change as expected behaviour.

Add tests to assert the expected functionality. Note that the tests are
duplicate due to duplicate functionality across the codebase.

See: https://github.com/ipld/go-ipld-prime/issues/58