### PR TITLE
chore(queryexecutor): fix tests for runtraversal refactor + clean up

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -285,7 +285,6 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		requestorCancelledListeners,
 		responseAssembler,
 		responseWorkSignal,
-		time.NewTicker(queryexecutor.ThawSpeed),
 		network.ConnectionManager(),
 	)
 	graphSync := &GraphSync{

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -216,8 +216,8 @@ func (rm *ResponseManager) synchronize() {
 }
 
 // StartTask starts the given task from the peer task queue
-func (rm *ResponseManager) StartTask(task *peertask.Task, responseTaskDataChan chan<- queryexecutor.ResponseTaskData) {
-	rm.send(&startTaskRequest{task, responseTaskDataChan}, nil)
+func (rm *ResponseManager) StartTask(task *peertask.Task, responseTaskChan chan<- queryexecutor.ResponseTask) {
+	rm.send(&startTaskRequest{task, responseTaskChan}, nil)
 }
 
 // GetUpdates is called to read pending updates for a task and clear them

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -93,7 +93,7 @@ func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 
 type startTaskRequest struct {
 	task         *peertask.Task
-	taskDataChan chan<- queryexecutor.ResponseTaskData
+	taskDataChan chan<- queryexecutor.ResponseTask
 }
 
 func (str *startTaskRequest) handle(rm *ResponseManager) {

--- a/responsemanager/queryexecutor/queryexecutor.go
+++ b/responsemanager/queryexecutor/queryexecutor.go
@@ -133,11 +133,7 @@ func (qe *QueryExecutor) executeQuery(
 			if isPaused {
 				return err
 			}
-			if ipldutil.IsContextCancelErr(err) {
-				rb.ClearRequest()
-				return err
-			}
-			if err == ErrNetworkError {
+			if err == ErrNetworkError || ipldutil.IsContextCancelErr(err) {
 				rb.ClearRequest()
 				return err
 			}

--- a/responsemanager/queryexecutor/queryexecutor.go
+++ b/responsemanager/queryexecutor/queryexecutor.go
@@ -1,13 +1,14 @@
 package queryexecutor
 
 import (
+	"bytes"
 	"context"
-	"errors"
-	"time"
+	"io"
 
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
+	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/libp2p/go-libp2p-core/peer"
 
 	"github.com/ipfs/go-graphsync"
@@ -17,19 +18,24 @@ import (
 	"github.com/ipfs/go-graphsync/notifications"
 	"github.com/ipfs/go-graphsync/responsemanager/hooks"
 	"github.com/ipfs/go-graphsync/responsemanager/responseassembler"
-	"github.com/ipfs/go-graphsync/responsemanager/runtraversal"
 )
 
-const (
-	ThawSpeed = time.Millisecond * 100
-)
+var log = logging.Logger("gs-queryexecutor")
 
-var log = logging.Logger("graphsync")
-var ErrNetworkError = errors.New("network error")
-var ErrCancelledByCommand = errors.New("response cancelled by responder")
+type errorString string
 
-// ResponseTaskData returns all information needed to execute a given response
-type ResponseTaskData struct {
+func (e errorString) Error() string {
+	return string(e)
+}
+
+const ErrNetworkError = errorString("network error")
+const ErrCancelledByCommand = errorString("response cancelled by responder")
+
+// ErrFirstBlockLoad indicates the traversal was unable to load the very first block in the traversal
+const ErrFirstBlockLoad = errorString("Unable to load first block")
+
+// ResponseTask returns all information needed to execute a given response
+type ResponseTask struct {
 	Empty      bool
 	Subscriber *notifications.TopicDataSubscriber
 	Ctx        context.Context
@@ -55,7 +61,6 @@ type QueryExecutor struct {
 	cancelledListeners CancelledListeners
 	responseAssembler  ResponseAssembler
 	workSignal         chan struct{}
-	ticker             *time.Ticker
 	connManager        network.ConnManager
 }
 
@@ -67,7 +72,6 @@ func New(ctx context.Context,
 	cancelledListeners CancelledListeners,
 	responseAssembler ResponseAssembler,
 	workSignal chan struct{},
-	ticker *time.Ticker,
 	connManager network.ConnManager,
 ) *QueryExecutor {
 	qm := &QueryExecutor{
@@ -78,7 +82,6 @@ func New(ctx context.Context,
 		manager:            manager,
 		ctx:                ctx,
 		workSignal:         workSignal,
-		ticker:             ticker,
 		connManager:        connManager,
 	}
 	return qm
@@ -91,93 +94,54 @@ func New(ctx context.Context,
 // suggests we should stop or pause.
 func (qe *QueryExecutor) ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.Task) bool {
 	// StartTask lets us block until this task is at the top of the execution stack
-	taskDataChan := make(chan ResponseTaskData)
-	var taskData ResponseTaskData
-	qe.manager.StartTask(task, taskDataChan)
+	responseTaskChan := make(chan ResponseTask)
+	var rt ResponseTask
+	qe.manager.StartTask(task, responseTaskChan)
 	select {
-	case taskData = <-taskDataChan:
+	case rt = <-responseTaskChan:
 	case <-qe.ctx.Done():
 		return true
 	}
-	if taskData.Empty {
+	if rt.Empty {
 		log.Info("Empty task on peer request stack")
 		return false
 	}
 
-	log.Debugw("beginning response execution", "id", taskData.Request.ID(), "peer", pid.String(), "root_cid", taskData.Request.Root().String())
-	_, err := qe.executeQuery(pid, taskData.Request, taskData.Loader, taskData.Traverser, taskData.Signals, taskData.Subscriber)
-	isCancelled := err != nil && ipldutil.IsContextCancelErr(err) // TODO(rv): this won't match ErrCancelledByCommand, only
+	log.Debugw("beginning response execution", "id", rt.Request.ID(), "peer", pid.String(), "root_cid", rt.Request.Root().String())
+	err := qe.executeQuery(pid, rt)
+	isCancelled := err != nil && ipldutil.IsContextCancelErr(err)
 	if isCancelled {
-		qe.connManager.Unprotect(pid, taskData.Request.ID().Tag())
-		qe.cancelledListeners.NotifyCancelledListeners(pid, taskData.Request)
+		qe.connManager.Unprotect(pid, rt.Request.ID().Tag())
+		qe.cancelledListeners.NotifyCancelledListeners(pid, rt.Request)
 	}
 	qe.manager.FinishTask(task, err)
-	log.Debugw("finishing response execution", "id", taskData.Request.ID(), "peer", pid.String(), "root_cid", taskData.Request.Root().String())
+	log.Debugw("finishing response execution", "id", rt.Request.ID(), "peer", pid.String(), "root_cid", rt.Request.Root().String())
 	return false
 }
 
 func (qe *QueryExecutor) executeQuery(
-	p peer.ID,
-	request gsmsg.GraphSyncRequest,
-	loader ipld.BlockReadOpener,
-	traverser ipldutil.Traverser,
-	signals ResponseSignals,
-	sub *notifications.TopicDataSubscriber) (graphsync.ResponseStatusCode, error) {
+	p peer.ID, rt ResponseTask) error {
 
 	// Execute the traversal operation, continue until we have reason to stop (error, pause, complete)
-	updateChan := make(chan []gsmsg.GraphSyncRequest)
-	err := runtraversal.RunTraversal(loader, traverser, func(link ipld.Link, data []byte) error {
-		// Execute a transaction for this block, including any other queued operations
-		var err error
-		_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
-			// Ensure that any updates that have occurred till now are integrated into the response
-			err = qe.checkForUpdates(p, request, signals, updateChan, rb)
-			// On any error other than a pause, we bail, if it's a pause then we continue processing _this_ block
-			if _, ok := err.(hooks.ErrPaused); !ok && err != nil {
-				return nil
-			}
-			blockData := rb.SendResponse(link, data)
-			rb.AddNotifee(notifications.Notifee{Data: blockData, Subscriber: sub})
-			if blockData.BlockSize() > 0 {
-				result := qe.blockHooks.ProcessBlockHooks(p, request, blockData)
-				for _, extension := range result.Extensions {
-					rb.SendExtensionData(extension)
-				}
-				if _, ok := result.Err.(hooks.ErrPaused); ok {
-					rb.PauseRequest()
-				}
-				if result.Err != nil {
-					// Halts the traversal and returns to the top-level `err`
-					err = result.Err
-				}
-			}
-			return nil
-		})
-		return err
-	})
+	err := qe.runTraversal(p, rt)
 
 	// Close out the response, either temporarily (pause) or permanently (cancel, fail, complete)
-	var code graphsync.ResponseStatusCode
-	_ = qe.responseAssembler.Transaction(p, request.ID(), func(rb responseassembler.ResponseBuilder) error {
+	return qe.responseAssembler.Transaction(p, rt.Request.ID(), func(rb responseassembler.ResponseBuilder) error {
+		var code graphsync.ResponseStatusCode
 		if err != nil {
-			// TODO(rv): in the pause, cancel and network-error cases, the `code` is dropped on the floor,
-			// should we be capturing that or passing it on? Why set it otherwise?
 			_, isPaused := err.(hooks.ErrPaused)
 			if isPaused {
-				code = graphsync.RequestPaused
-				return nil
+				return err
 			}
 			if ipldutil.IsContextCancelErr(err) {
 				rb.ClearRequest()
-				code = graphsync.RequestCancelled
-				return nil
+				return err
 			}
 			if err == ErrNetworkError {
 				rb.ClearRequest()
-				code = graphsync.RequestFailedUnknown
-				return nil
+				return err
 			}
-			if err == runtraversal.ErrFirstBlockLoad {
+			if err == ErrFirstBlockLoad {
 				code = graphsync.RequestFailedContentNotFound
 			} else if err == ErrCancelledByCommand {
 				code = graphsync.RequestCancelled
@@ -188,34 +152,29 @@ func (qe *QueryExecutor) executeQuery(
 		} else {
 			code = rb.FinishRequest()
 		}
-		rb.AddNotifee(notifications.Notifee{Data: code, Subscriber: sub})
-		return nil
+		rb.AddNotifee(notifications.Notifee{Data: code, Subscriber: rt.Subscriber})
+		return err
 	})
-	return code, err
 }
 
 // checkForUpdates is called on each block traversed to ensure no outstanding signals
 // or updates need to be handled during the current transaction
 func (qe *QueryExecutor) checkForUpdates(
-	p peer.ID,
-	request gsmsg.GraphSyncRequest,
-	signals ResponseSignals,
-	updateChan chan []gsmsg.GraphSyncRequest,
-	rb responseassembler.ResponseBuilder) error {
-
+	p peer.ID, taskData ResponseTask, rb responseassembler.ResponseBuilder) error {
 	for {
 		select {
-		case <-signals.PauseSignal:
+		case <-taskData.Signals.PauseSignal:
 			rb.PauseRequest()
 			return hooks.ErrPaused{}
-		case err := <-signals.ErrSignal:
+		case err := <-taskData.Signals.ErrSignal:
 			return err
-		case <-signals.UpdateSignal:
-			qe.manager.GetUpdates(p, request.ID(), updateChan)
+		case <-taskData.Signals.UpdateSignal:
+			updateChan := make(chan []gsmsg.GraphSyncRequest)
+			qe.manager.GetUpdates(p, taskData.Request.ID(), updateChan)
 			select {
 			case updates := <-updateChan:
 				for _, update := range updates {
-					result := qe.updateHooks.ProcessUpdateHooks(p, request, update)
+					result := qe.updateHooks.ProcessUpdateHooks(p, taskData.Request, update)
 					for _, extension := range result.Extensions {
 						// if there is something to send to the client for this update, build it into the
 						// response that will be sent with the current transaction
@@ -233,9 +192,93 @@ func (qe *QueryExecutor) checkForUpdates(
 	}
 }
 
+func (qe *QueryExecutor) runTraversal(p peer.ID, taskData ResponseTask) error {
+	for {
+		traverser := taskData.Traverser
+		isComplete, err := traverser.IsComplete()
+		if isComplete {
+			if err != nil {
+				log.Errorf("traversal completion check failed, nBlocksRead=%d, err=%s", traverser.NBlocksTraversed(), err)
+				if (traverser.NBlocksTraversed() == 0 && err == traversal.SkipMe{}) {
+					return ErrFirstBlockLoad
+				}
+			} else {
+				log.Debugf("traversal completed successfully, nBlocksRead=%d", traverser.NBlocksTraversed())
+			}
+			return err
+		}
+		lnk, data, err := qe.nextBlock(taskData)
+		if err != nil {
+			return err
+		}
+		err = qe.sendResponse(p, taskData, lnk, data)
+		if err != nil {
+			return err
+		}
+	}
+}
+
+func (qe *QueryExecutor) nextBlock(taskData ResponseTask) (ipld.Link, []byte, error) {
+	lnk, lnkCtx := taskData.Traverser.CurrentRequest()
+	log.Debugf("will load link=%s", lnk)
+	result, err := taskData.Loader(lnkCtx, lnk)
+
+	if err != nil {
+		log.Errorf("failed to load link=%s, nBlocksRead=%d, err=%s", lnk, taskData.Traverser.NBlocksTraversed(), err)
+		taskData.Traverser.Error(traversal.SkipMe{})
+		return lnk, nil, nil
+	}
+
+	blockBuffer, ok := result.(*bytes.Buffer)
+	if !ok {
+		blockBuffer = new(bytes.Buffer)
+		_, err = io.Copy(blockBuffer, result)
+		if err != nil {
+			log.Errorf("failed to write to buffer, link=%s, nBlocksRead=%d, err=%s", lnk, taskData.Traverser.NBlocksTraversed(), err)
+			taskData.Traverser.Error(err)
+			return lnk, nil, err
+		}
+	}
+	data := blockBuffer.Bytes()
+	err = taskData.Traverser.Advance(blockBuffer)
+	if err != nil {
+		log.Errorf("failed to advance traversal, link=%s, nBlocksRead=%d, err=%s", lnk, taskData.Traverser.NBlocksTraversed(), err)
+		return lnk, data, err
+	}
+	log.Debugf("successfully loaded link=%s, nBlocksRead=%d", lnk, taskData.Traverser.NBlocksTraversed())
+	return lnk, data, nil
+}
+
+func (qe *QueryExecutor) sendResponse(p peer.ID, taskData ResponseTask, link ipld.Link, data []byte) error {
+	// Execute a transaction for this block, including any other queued operations
+	return qe.responseAssembler.Transaction(p, taskData.Request.ID(), func(rb responseassembler.ResponseBuilder) error {
+		// Ensure that any updates that have occurred till now are integrated into the response
+		err := qe.checkForUpdates(p, taskData, rb)
+		// On any error other than a pause, we bail, if it's a pause then we continue processing _this_ block
+		if _, ok := err.(hooks.ErrPaused); !ok && err != nil {
+			return err
+		}
+		blockData := rb.SendResponse(link, data)
+		rb.AddNotifee(notifications.Notifee{Data: blockData, Subscriber: taskData.Subscriber})
+		if blockData.BlockSize() > 0 {
+			result := qe.blockHooks.ProcessBlockHooks(p, taskData.Request, blockData)
+			for _, extension := range result.Extensions {
+				rb.SendExtensionData(extension)
+			}
+			if _, ok := result.Err.(hooks.ErrPaused); ok {
+				rb.PauseRequest()
+			}
+			if result.Err != nil {
+				return result.Err // halts the traversal and returns to the top-level `err`
+			}
+		}
+		return err
+	})
+}
+
 // Manager providers an interface to the response manager
 type Manager interface {
-	StartTask(task *peertask.Task, responseTaskDataChan chan<- ResponseTaskData)
+	StartTask(task *peertask.Task, responseTaskChan chan<- ResponseTask)
 	GetUpdates(p peer.ID, requestID graphsync.RequestID, updatesChan chan<- []gsmsg.GraphSyncRequest)
 	FinishTask(task *peertask.Task, err error)
 }

--- a/responsemanager/queryexecutor/queryexecutor_test.go
+++ b/responsemanager/queryexecutor/queryexecutor_test.go
@@ -38,7 +38,7 @@ func TestEmptyTask(t *testing.T) {
 	peer := testutil.GeneratePeers(1)[0]
 	task := &peertask.Task{}
 	td.manager.expectedStartTask = task
-	td.manager.toSendResponseTaskData = ResponseTaskData{Empty: true}
+	td.manager.toSendResponseTaskData = ResponseTask{Empty: true}
 
 	qe := New(
 		td.ctx,
@@ -48,7 +48,6 @@ func TestEmptyTask(t *testing.T) {
 		td.cancelledListeners,
 		td.responseAssembler,
 		td.workSignal,
-		time.NewTicker(ThawSpeed),
 		td.connManager,
 	)
 
@@ -113,7 +112,7 @@ func TestOneBlockTask(t *testing.T) {
 	}
 
 	td.manager.expectedStartTask = task
-	td.manager.toSendResponseTaskData = ResponseTaskData{
+	td.manager.toSendResponseTaskData = ResponseTask{
 		Request:    td.requests[0],
 		Loader:     loader,
 		Traverser:  expectedTraverser,
@@ -129,7 +128,6 @@ func TestOneBlockTask(t *testing.T) {
 		td.cancelledListeners,
 		td.responseAssembler,
 		td.workSignal,
-		time.NewTicker(ThawSpeed),
 		td.connManager,
 	)
 
@@ -214,7 +212,7 @@ func TestSmallGraphTask(t *testing.T) {
 		}
 
 		td.manager.expectedStartTask = task
-		td.manager.toSendResponseTaskData = ResponseTaskData{
+		td.manager.toSendResponseTaskData = ResponseTask{
 			Request:    td.requests[0],
 			Loader:     loader,
 			Traverser:  expectedTraverser,
@@ -230,7 +228,6 @@ func TestSmallGraphTask(t *testing.T) {
 			td.cancelledListeners,
 			td.responseAssembler,
 			td.workSignal,
-			time.NewTicker(ThawSpeed),
 			td.connManager,
 		)
 		return td, qe
@@ -622,16 +619,16 @@ func newTestData(t *testing.T) *testData {
 type fauxManager struct {
 	ctx                    context.Context
 	t                      *testing.T
-	toSendResponseTaskData ResponseTaskData
+	toSendResponseTaskData ResponseTask
 	expectedStartTask      *peertask.Task
 }
 
-func (fm *fauxManager) StartTask(task *peertask.Task, responseTaskDataChan chan<- ResponseTaskData) {
+func (fm *fauxManager) StartTask(task *peertask.Task, responseTaskChan chan<- ResponseTask) {
 	require.Same(fm.t, fm.expectedStartTask, task)
 	go func() {
 		select {
 		case <-fm.ctx.Done():
-		case responseTaskDataChan <- fm.toSendResponseTaskData:
+		case responseTaskChan <- fm.toSendResponseTaskData:
 		}
 	}()
 }

--- a/responsemanager/querypreparer.go
+++ b/responsemanager/querypreparer.go
@@ -2,7 +2,6 @@ package responsemanager
 
 import (
 	"context"
-	"errors"
 	"math"
 
 	"github.com/ipfs/go-cid"
@@ -21,6 +20,14 @@ import (
 	"github.com/ipfs/go-graphsync/responsemanager/queryexecutor"
 	"github.com/ipfs/go-graphsync/responsemanager/responseassembler"
 )
+
+type errorString string
+
+func (e errorString) Error() string {
+	return string(e)
+}
+
+const errInvalidRequest = errorString("request not valid")
 
 type queryPreparer struct {
 	requestHooks      RequestHooks
@@ -48,7 +55,7 @@ func (qe *queryPreparer) prepareQuery(ctx context.Context,
 		} else if !result.IsValidated {
 			rb.FinishWithError(graphsync.RequestRejected)
 			rb.AddNotifee(rejectNotifee)
-			return errors.New("request not valid")
+			return errInvalidRequest
 		} else if result.IsPaused {
 			rb.PauseRequest()
 			isPaused = true

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -98,9 +98,7 @@ func (ra *ResponseAssembler) Transaction(p peer.ID, requestID graphsync.RequestI
 		linkTracker: ra.GetProcess(p).(*peerLinkTracker),
 	}
 	err := transaction(rb)
-	if err == nil {
-		ra.execute(p, rb.operations, rb.notifees)
-	}
+	ra.execute(p, rb.operations, rb.notifees)
 	return err
 }
 

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -1106,7 +1106,7 @@ func (td *testData) alternateLoaderResponseManager() *ResponseManager {
 }
 
 func (td *testData) newQueryExecutor(manager queryexecutor.Manager) *queryexecutor.QueryExecutor {
-	return queryexecutor.New(td.ctx, manager, td.blockHooks, td.updateHooks, td.cancelledListeners, td.responseAssembler, td.workSignal, time.NewTicker(queryexecutor.ThawSpeed), td.connManager)
+	return queryexecutor.New(td.ctx, manager, td.blockHooks, td.updateHooks, td.cancelledListeners, td.responseAssembler, td.workSignal, td.connManager)
 }
 
 func (td *testData) assertPausedRequest() {


### PR DESCRIPTION
Builds on #263, mainly to deal with the tests in #244 that were rebased into that branch that are currently broken. But I've also been iteratively improving the state of the tests so they're a bit more readable and organised. Not perfect, but much better than in #244 so far I think.

Still needs a bit more coverage in runtraversal, since the existing runtraversal tests are not ported in the merge.