### PR TITLE
Fix flaky tests

### DIFF
--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -224,7 +224,12 @@ func (rm *ResponseManager) GetUpdates(p peer.ID, requestID graphsync.RequestID, 
 
 // FinishTask marks a task from the task queue as done
 func (rm *ResponseManager) FinishTask(task *peertask.Task, err error) {
-	rm.send(&finishTaskRequest{task, err}, nil)
+	done := make(chan struct{}, 1)
+	rm.send(&finishTaskRequest{task, err, done}, nil)
+	select {
+	case <-rm.ctx.Done():
+	case <-done:
+	}
 }
 
 // CloseWithNetworkError closes a request due to a network error

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -85,10 +85,15 @@ func (rur *responseUpdateRequest) handle(rm *ResponseManager) {
 type finishTaskRequest struct {
 	task *peertask.Task
 	err  error
+	done chan struct{}
 }
 
 func (ftr *finishTaskRequest) handle(rm *ResponseManager) {
 	rm.finishTask(ftr.task, ftr.err)
+	select {
+	case <-rm.ctx.Done():
+	case ftr.done <- struct{}{}:
+	}
 }
 
 type startTaskRequest struct {

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -291,7 +291,6 @@ func TestValidationAndExtensions(t *testing.T) {
 		// request fails with base loader reading from block store that's missing data
 		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 		td.assertCompleteRequestWith(graphsync.RequestFailedContentNotFound)
-		td.taskqueue.WaitForNoActiveTasks()
 
 		err := td.peristenceOptions.Register("chainstore", td.persistence)
 		require.NoError(t, err)
@@ -632,8 +631,6 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				td.verifyNResponses(blockCount)
 				td.assertPausedRequest()
-
-				td.taskqueue.WaitForNoActiveTasks()
 
 				// send update
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
@@ -1114,6 +1111,7 @@ func (td *testData) newQueryExecutor(manager queryexecutor.Manager) *queryexecut
 func (td *testData) assertPausedRequest() {
 	var pausedRequest pausedRequest
 	testutil.AssertReceive(td.ctx, td.t, td.pausedRequests, &pausedRequest, "should pause request")
+	td.taskqueue.WaitForNoActiveTasks()
 }
 
 func (td *testData) getAllBlocks() []blocks.Block {
@@ -1150,6 +1148,7 @@ func (td *testData) assertCompleteRequestWith(expectedCode graphsync.ResponseSta
 	var status graphsync.ResponseStatusCode
 	testutil.AssertReceive(td.ctx, td.t, td.completedResponseStatuses, &status, "should receive status")
 	require.Equal(td.t, expectedCode, status)
+	td.taskqueue.WaitForNoActiveTasks()
 }
 
 func (td *testData) assertOnlyCompleteProcessingWith(expectedCode graphsync.ResponseStatusCode) {

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -291,6 +291,7 @@ func TestValidationAndExtensions(t *testing.T) {
 		// request fails with base loader reading from block store that's missing data
 		responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 		td.assertCompleteRequestWith(graphsync.RequestFailedContentNotFound)
+		td.taskqueue.WaitForNoActiveTasks()
 
 		err := td.peristenceOptions.Register("chainstore", td.persistence)
 		require.NoError(t, err)
@@ -631,6 +632,8 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				td.verifyNResponses(blockCount)
 				td.assertPausedRequest()
+
+				td.taskqueue.WaitForNoActiveTasks()
 
 				// send update
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)


### PR DESCRIPTION
@rvagg I believe your WaitForNoActiveTasks was just one small concurrency fix away from being the solution. The issue here is that FinishTask is currently an asynchronous call -- it simply sends the finish message to the response manager and moves on. That means the worker queue can finish draining before the response manager thread actually processes the finish message.

The easy solution, or at least the proof of concept solution, is simply to make the FinishTask method synchronous - it doesn't return till the message is processed (this is done by using a return channel).