### PR TITLE
chore: short-circuit unnecessary message processing

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -486,8 +486,17 @@ func (gsr *graphSyncReceiver) ReceiveMessage(
 	ctx context.Context,
 	sender peer.ID,
 	incoming gsmsg.GraphSyncMessage) {
-	gsr.graphSync().responseManager.ProcessRequests(ctx, sender, incoming.Requests())
-	gsr.graphSync().requestManager.ProcessResponses(sender, incoming.Responses(), incoming.Blocks())
+
+	requests := incoming.Requests()
+	responses := incoming.Responses()
+	blocks := incoming.Blocks()
+
+	if len(requests) > 0 {
+		gsr.graphSync().responseManager.ProcessRequests(ctx, sender, requests)
+	}
+	if len(responses) > 0 || len(blocks) > 0 {
+		gsr.graphSync().requestManager.ProcessResponses(sender, responses, blocks)
+	}
 }
 
 // ReceiveError is part of the network's Receiver interface and handles incoming


### PR DESCRIPTION
@hannahhoward I noticed this when looking at some new traces I'm starting from `ReceiveMessage`. The majority that come in through here don't have any requests, so going into `responseManager.ProcessRequests` gets it put into the message handling loop and eventually hit a `for` loop that iterates over an empty slice and does nothing else. On the other side, `requestManager.ProcessResponses` has the same thing but even more branches where it hits various `for` loops to collect and process things over an empty slice when there's no responses or blocks.

So, minor optimisation, but seems to be worthwhile given how chatty this call seems to be.