### PR TITLE
feat: add basic tracing for responses

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -378,8 +378,6 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 		"request(0)->terminateRequest(0)",
 	}, tracing.TracesToStrings())
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)")
-	require.False(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isUpdate").AsBool())
-	require.False(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isCancel").AsBool())
 	require.Equal(t, int64(0), testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "priority").AsInt64())
 	require.Equal(t, []string{string(td.extensionName)}, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "extensions").AsStringSlice())
 }
@@ -818,9 +816,6 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 	}, tracing.TracesToStrings())
 	// make sure the attributes are what we expect
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)->processUpdate(0)")
-	require.True(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isUpdate").AsBool())
-	require.False(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isCancel").AsBool())
-	require.Equal(t, int64(0), testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "priority").AsInt64())
 	require.Equal(t, []string{string(td.extensionName)}, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "extensions").AsStringSlice())
 	// pause recorded
 	tracing.SingleExceptionEvent(t, "response(0)->executeTask(0)", "github.com/ipfs/go-graphsync/responsemanager/hooks.ErrPaused", hooks.ErrPaused{}.Error(), false)
@@ -904,9 +899,6 @@ func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
 	}, tracing.TracesToStrings())
 	// make sure the attributes are what we expect
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)->processUpdate(0)")
-	require.True(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isUpdate").AsBool())
-	require.False(t, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "isCancel").AsBool())
-	require.Equal(t, int64(0), testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "priority").AsInt64())
 	require.Equal(t, []string{string(td.extensionName)}, testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "extensions").AsStringSlice())
 	// pause recorded
 	tracing.SingleExceptionEvent(t, "response(0)->executeTask(0)", "github.com/ipfs/go-graphsync/responsemanager/hooks.ErrPaused", hooks.ErrPaused{}.Error(), false)

--- a/message/message.go
+++ b/message/message.go
@@ -375,6 +375,15 @@ func (gsr GraphSyncRequest) Extension(name graphsync.ExtensionName) ([]byte, boo
 	return val, true
 }
 
+// ExtensionNames returns the names of the extensions included in this request
+func (gsr GraphSyncRequest) ExtensionNames() []string {
+	var extNames []string
+	for ext := range gsr.extensions {
+		extNames = append(extNames, ext)
+	}
+	return extNames
+}
+
 // IsCancel returns true if this particular request is being cancelled
 func (gsr GraphSyncRequest) IsCancel() bool { return gsr.isCancel }
 
@@ -398,7 +407,15 @@ func (gsr GraphSyncResponse) Extension(name graphsync.ExtensionName) ([]byte, bo
 		return nil, false
 	}
 	return val, true
+}
 
+// ExtensionNames returns the names of the extensions included in this request
+func (gsr GraphSyncResponse) ExtensionNames() []string {
+	var extNames []string
+	for ext := range gsr.extensions {
+		extNames = append(extNames, ext)
+	}
+	return extNames
 }
 
 // ReplaceExtensions merges the extensions given extensions into the request to create a new request,

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	ipld "github.com/ipld/go-ipld-prime"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/ipldutil"
@@ -30,6 +31,7 @@ var log = logging.Logger("graphsync")
 
 type inProgressResponseStatus struct {
 	ctx        context.Context
+	span       trace.Span
 	cancelFn   func()
 	request    gsmsg.GraphSyncRequest
 	loader     ipld.BlockReadOpener
@@ -197,8 +199,8 @@ func (rm *ResponseManager) CancelResponse(p peer.ID, requestID graphsync.Request
 	}
 }
 
-// this is a test utility method to force all messages to get processed
-func (rm *ResponseManager) synchronize() {
+// Synchronize is a utility method that blocks until all current messages are processed
+func (rm *ResponseManager) Synchronize() {
 	sync := make(chan error)
 	rm.send(&synchronizeMessage{sync}, nil)
 	select {

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -200,7 +200,7 @@ func (rm *ResponseManager) CancelResponse(p peer.ID, requestID graphsync.Request
 }
 
 // Synchronize is a utility method that blocks until all current messages are processed
-func (rm *ResponseManager) Synchronize() {
+func (rm *ResponseManager) synchronize() {
 	sync := make(chan error)
 	rm.send(&synchronizeMessage{sync}, nil)
 	select {

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -15,6 +15,10 @@ type processRequestMessage struct {
 	requests []gsmsg.GraphSyncRequest
 }
 
+func (prm *processRequestMessage) handle(rm *ResponseManager) {
+	rm.processRequests(prm.p, prm.requests)
+}
+
 type pauseRequestMessage struct {
 	p         peer.ID
 	requestID graphsync.RequestID
@@ -109,10 +113,6 @@ func (str *startTaskRequest) handle(rm *ResponseManager) {
 	case <-rm.ctx.Done():
 	case str.taskDataChan <- taskData:
 	}
-}
-
-func (prm *processRequestMessage) handle(rm *ResponseManager) {
-	rm.processRequests(prm.p, prm.requests)
 }
 
 type peerStateMessage struct {

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -100,7 +100,7 @@ func TestCancellationQueryInProgress(t *testing.T) {
 		gsmsg.CancelRequest(td.requestID),
 	}
 	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
-	responseManager.Synchronize()
+	responseManager.synchronize()
 	close(waitForCancel)
 
 	testutil.AssertDoesReceive(td.ctx, t, cancelledListenerCalled, "should call cancelled listener")
@@ -149,7 +149,7 @@ func TestEarlyCancellation(t *testing.T) {
 	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
 	responseManager.Startup()
 	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-	responseManager.Synchronize()
+	responseManager.synchronize()
 	td.connManager.AssertProtectedWithTags(t, td.p, td.requests[0].ID().Tag())
 
 	// send a cancellation
@@ -158,7 +158,7 @@ func TestEarlyCancellation(t *testing.T) {
 	}
 	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
 
-	responseManager.Synchronize()
+	responseManager.synchronize()
 
 	td.assertNoResponses()
 	td.connManager.RefuteProtected(t, td.p)
@@ -634,7 +634,7 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.Synchronize()
+				responseManager.synchronize()
 				close(wait)
 				td.assertCompleteRequestWith(graphsync.RequestCompletedFull)
 				td.assertReceiveExtensionResponse()
@@ -704,7 +704,7 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.Synchronize()
+				responseManager.synchronize()
 				close(wait)
 				td.assertCompleteRequestWith(graphsync.RequestFailedUnknown)
 			})

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -100,7 +100,7 @@ func TestCancellationQueryInProgress(t *testing.T) {
 		gsmsg.CancelRequest(td.requestID),
 	}
 	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
-	responseManager.synchronize()
+	responseManager.Synchronize()
 	close(waitForCancel)
 
 	testutil.AssertDoesReceive(td.ctx, t, cancelledListenerCalled, "should call cancelled listener")
@@ -149,7 +149,7 @@ func TestEarlyCancellation(t *testing.T) {
 	td.requestHooks.Register(selectorvalidator.SelectorValidator(100))
 	responseManager.Startup()
 	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-	responseManager.synchronize()
+	responseManager.Synchronize()
 	td.connManager.AssertProtectedWithTags(t, td.p, td.requests[0].ID().Tag())
 
 	// send a cancellation
@@ -158,7 +158,7 @@ func TestEarlyCancellation(t *testing.T) {
 	}
 	responseManager.ProcessRequests(td.ctx, td.p, cancelRequests)
 
-	responseManager.synchronize()
+	responseManager.Synchronize()
 
 	td.assertNoResponses()
 	td.connManager.RefuteProtected(t, td.p)
@@ -634,7 +634,7 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.synchronize()
+				responseManager.Synchronize()
 				close(wait)
 				td.assertCompleteRequestWith(graphsync.RequestCompletedFull)
 				td.assertReceiveExtensionResponse()
@@ -704,7 +704,7 @@ func TestValidationAndExtensions(t *testing.T) {
 				responseManager.ProcessRequests(td.ctx, td.p, td.requests)
 				testutil.AssertDoesReceive(td.ctx, t, sent, "sends blocks")
 				responseManager.ProcessRequests(td.ctx, td.p, td.updateRequests)
-				responseManager.synchronize()
+				responseManager.Synchronize()
 				close(wait)
 				td.assertCompleteRequestWith(graphsync.RequestFailedUnknown)
 			})

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -66,10 +66,6 @@ func (rm *ResponseManager) processUpdate(key responseKey, update gsmsg.GraphSync
 
 	_, span := otel.Tracer("graphsync").Start(trace.ContextWithSpan(rm.ctx, response.span), "processUpdate", trace.WithAttributes(
 		attribute.Int("id", int(update.ID())),
-		attribute.Int("priority", int(update.Priority())),
-		attribute.String("root", update.Root().String()),
-		attribute.Bool("isCancel", update.IsCancel()),
-		attribute.Bool("isUpdate", update.IsUpdate()),
 		attribute.StringSlice("extensions", update.ExtensionNames()),
 	))
 	defer span.End()
@@ -186,8 +182,6 @@ func (rm *ResponseManager) processRequests(p peer.ID, requests []gsmsg.GraphSync
 			attribute.Int("id", int(request.ID())),
 			attribute.Int("priority", int(request.Priority())),
 			attribute.String("root", request.Root().String()),
-			attribute.Bool("isCancel", request.IsCancel()),
-			attribute.Bool("isUpdate", request.IsUpdate()),
 			attribute.StringSlice("extensions", request.ExtensionNames()),
 		))
 		rm.connManager.Protect(p, request.ID().Tag())

--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -77,13 +77,13 @@ func (c Collector) tracesToString(trace string, spans tracetest.SpanStubs, match
 // identified by its trace string as described in TracesToStrings. Note that
 // this string can also be a partial of a complete trace, e.g. just `"foo(0)"`
 // without any children to fetch the parent span.
-func (c Collector) FindSpanByTraceString(trace string) tracetest.SpanStub {
-	var found tracetest.SpanStub
+func (c Collector) FindSpanByTraceString(trace string) *tracetest.SpanStub {
+	var found *tracetest.SpanStub
 	c.tracesToString("", c.FindParentSpans(), trace, func(span tracetest.SpanStub) {
-		if found.Name != "" {
+		if found != nil && found.Name != "" {
 			panic("found more than one span with the same trace string")
 		}
-		found = span
+		found = &span
 	})
 	return found
 }
@@ -121,7 +121,7 @@ func (c Collector) SingleExceptionEvent(t *testing.T, trace string, typeRe strin
 	// has ContextCancelError exception recorded in the right place
 	et := c.FindSpanByTraceString(trace)
 	require.Len(t, et.Events, 1, "expected one event in span %v", trace)
-	ex := EventAsException(t, EventInTraceSpan(t, et, "exception"))
+	ex := EventAsException(t, EventInTraceSpan(t, *et, "exception"))
 	require.Regexp(t, typeRe, ex.Type)
 	require.Regexp(t, messageRe, ex.Message)
 	if errorCode {


### PR DESCRIPTION
This works so far for the `responseManager.ProcessRequests()` path, but it's pretty complicated; with the two main problems (building on from what I mentioned @ https://github.com/ipfs/go-graphsync/pull/290/files#r760950285 about the branching inside `GraphSync#ReceiveMessage()` and wanting to have a base span that lives for the entirety of an incoming message there:

* Even if taking the `responseManager` path in isolation, each "message" can have multiple requests, each of which becomes detached from the others for processing—so making a "message" span live across all of these is going to have to take some tricky tracking, or a special wrapper that can decrement calls to "End" and call a true "End" when it reaches zero.
* The fact that an incoming message can have two paths - one to `responseManager` and one to `requestManager`, with the latter having a fairly complicated journey, doubles the pain of having a parent "message" span having a discrete end.

Perhaps a parent "message" span isn't what we want, and we should just have a parent "request" span for each of the requests that an individual message can trigger? Which is a bit unfortunate because then we can't have a span that lives for the lifetime of a call through the top-level `GraphSync` call, but maybe that's OK?

Currently I have a parent "message" span live until all child "request" spans have been started, so there'll be a parent->child relationship, but the parent won't live much longer after the child is started. I bet different trace viewing tools will deal with that in their own unique way but I reckon it'll still retain the hierarchy.