### PR TITLE
Remove accidental legacy field, fix metrics

### DIFF
--- a/taskqueue/taskqueue.go
+++ b/taskqueue/taskqueue.go
@@ -42,12 +42,12 @@ type WorkerTaskQueue struct {
 }
 
 // NewTaskQueue initializes a new queue
-func NewTaskQueue(ctx context.Context) *WorkerTaskQueue {
+func NewTaskQueue(ctx context.Context, ptqopts ...peertaskqueue.Option) *WorkerTaskQueue {
 	ctx, cancelFn := context.WithCancel(ctx)
 	return &WorkerTaskQueue{
 		ctx:           ctx,
 		cancelFn:      cancelFn,
-		PeerTaskQueue: peertaskqueue.New(),
+		PeerTaskQueue: peertaskqueue.New(ptqopts...),
 		workSignal:    make(chan struct{}, 1),
 		noTaskCond:    sync.NewCond(&sync.Mutex{}),
 		ticker:        time.NewTicker(thawSpeed),


### PR DESCRIPTION
# Goals

Well, I guess this is the price you pay for not having testing on stats! we broke the request queue stats when we did the request queue refactor

# Implementation

- Remove peer task queue legacy struct member
- Use responseQueue for stats instead
- Also noticed we broke peer peer limits for the responder here.