### PR TITLE
make go test with coverpkg=./...

### DIFF
--- a/benchmarks/benchmark.go
+++ b/benchmarks/benchmark.go
@@ -1,0 +1,1 @@
+package graphsync


### PR DESCRIPTION
I've run the go test command locally and it looks like benchmarks is the only test-only package here. To workaround https://github.com/golang/go/commit/c59b17e5a2244f7a99c440a07a1c174344da0ad8 we can add empty `benchmark.go` there which fixes the unified CI setup.