### PR TITLE
fix(responsemanager): remove unused maxInProcessRequests parameter

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -251,7 +251,6 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		requestorCancelledListeners,
 		blockSentListeners,
 		networkErrorListeners,
-		gsConfig.maxInProgressIncomingRequests,
 		network.ConnectionManager(),
 		gsConfig.maxLinksPerIncomingRequest,
 		responseQueue)

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -111,7 +111,6 @@ type ResponseManager struct {
 	networkErrorListeners NetworkErrorListeners
 	messages              chan responseManagerMessage
 	inProgressResponses   map[responseKey]*inProgressResponseStatus
-	maxInProcessRequests  uint64
 	connManager           network.ConnManager
 	// maximum number of links to traverse per request. A value of zero = infinity, or no limit
 	maxLinksPerRequest uint64
@@ -129,7 +128,6 @@ func New(ctx context.Context,
 	cancelledListeners CancelledListeners,
 	blockSentListeners BlockSentListeners,
 	networkErrorListeners NetworkErrorListeners,
-	maxInProcessRequests uint64,
 	connManager network.ConnManager,
 	maxLinksPerRequest uint64,
 	responseQueue taskqueue.TaskQueue,
@@ -150,7 +148,6 @@ func New(ctx context.Context,
 		networkErrorListeners: networkErrorListeners,
 		messages:              messages,
 		inProgressResponses:   make(map[responseKey]*inProgressResponseStatus),
-		maxInProcessRequests:  maxInProcessRequests,
 		connManager:           connManager,
 		maxLinksPerRequest:    maxLinksPerRequest,
 		responseQueue:         responseQueue,

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -1137,7 +1137,7 @@ func newTestData(t *testing.T) testData {
 }
 
 func (td *testData) newResponseManager() *ResponseManager {
-	rm := New(td.ctx, td.persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager, 0, td.taskqueue)
+	rm := New(td.ctx, td.persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, td.connManager, 0, td.taskqueue)
 	queryExecutor := td.newQueryExecutor(rm)
 	td.taskqueue.Startup(6, queryExecutor)
 	return rm
@@ -1145,14 +1145,14 @@ func (td *testData) newResponseManager() *ResponseManager {
 
 func (td *testData) nullTaskQueueResponseManager() *ResponseManager {
 	ntq := nullTaskQueue{tasksQueued: make(map[peer.ID][]peertask.Topic)}
-	rm := New(td.ctx, td.persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager, 0, ntq)
+	rm := New(td.ctx, td.persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, td.connManager, 0, ntq)
 	return rm
 }
 
 func (td *testData) alternateLoaderResponseManager() *ResponseManager {
 	obs := make(map[ipld.Link][]byte)
 	persistence := testutil.NewTestStore(obs)
-	rm := New(td.ctx, persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, 6, td.connManager, 0, td.taskqueue)
+	rm := New(td.ctx, persistence, td.responseAssembler, td.requestQueuedHooks, td.requestHooks, td.updateHooks, td.completedListeners, td.cancelledListeners, td.blockSentListeners, td.networkErrorListeners, td.connManager, 0, td.taskqueue)
 	queryExecutor := td.newQueryExecutor(rm)
 	td.taskqueue.Startup(6, queryExecutor)
 	return rm


### PR DESCRIPTION
this is now handled by the taskqueue which is outside of the
responsemanager so is not used here.