### PR TITLE
feat(requestmanager): add tracing for response messages & block processing

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -110,7 +110,7 @@ func TestMakeRequestToNetwork(t *testing.T) {
 func TestSendResponseToIncomingRequest(t *testing.T) {
 	// create network
 	ctx := context.Background()
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 	r := &receiver{
@@ -178,7 +178,7 @@ func TestRejectRequestsByDefault(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -218,7 +218,7 @@ func TestGraphsyncRoundTripRequestBudgetRequestor(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -269,7 +269,7 @@ func TestGraphsyncRoundTripRequestBudgetResponder(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -316,7 +316,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -427,7 +427,7 @@ func TestGraphsyncRoundTripPartial(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -492,7 +492,7 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -637,7 +637,7 @@ func TestPauseResume(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -727,7 +727,7 @@ func TestPauseResumeRequest(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -808,7 +808,7 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -894,7 +894,7 @@ func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -984,7 +984,7 @@ func TestNetworkDisconnect(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -1075,7 +1075,7 @@ func TestConnectFail(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -1123,7 +1123,7 @@ func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -1215,7 +1215,7 @@ func TestGraphsyncRoundTripMultipleAlternatePersistence(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -1494,7 +1494,7 @@ func TestGraphsyncBlockListeners(t *testing.T) {
 	// create network
 	ctx := context.Background()
 	ctx, collectTracing := testutil.SetupTracing(ctx)
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -51,10 +51,10 @@ import (
 )
 
 func TestMakeRequestToNetwork(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -174,10 +174,10 @@ func TestSendResponseToIncomingRequest(t *testing.T) {
 }
 
 func TestRejectRequestsByDefault(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -214,10 +214,10 @@ func TestRejectRequestsByDefault(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripRequestBudgetRequestor(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -265,10 +265,10 @@ func TestGraphsyncRoundTripRequestBudgetRequestor(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripRequestBudgetResponder(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -312,10 +312,10 @@ func TestGraphsyncRoundTripRequestBudgetResponder(t *testing.T) {
 }
 
 func TestGraphsyncRoundTrip(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -423,10 +423,10 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripPartial(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -488,10 +488,10 @@ func TestGraphsyncRoundTripPartial(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -560,10 +560,10 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	ctx, collectTracing := testutil.SetupTracing(context.Background())
+	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 
@@ -633,10 +633,10 @@ func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
 }
 
 func TestPauseResume(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -723,10 +723,10 @@ func TestPauseResume(t *testing.T) {
 }
 
 func TestPauseResumeRequest(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -804,10 +804,10 @@ func TestPauseResumeRequest(t *testing.T) {
 }
 
 func TestPauseResumeViaUpdate(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -890,10 +890,10 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 }
 
 func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -981,10 +981,9 @@ func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
 }
 
 func TestNetworkDisconnect(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
-
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -1072,10 +1071,10 @@ func TestNetworkDisconnect(t *testing.T) {
 }
 
 func TestConnectFail(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -1120,10 +1119,10 @@ func TestConnectFail(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -1212,10 +1211,10 @@ func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
 }
 
 func TestGraphsyncRoundTripMultipleAlternatePersistence(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -1305,13 +1304,13 @@ func TestGraphsyncRoundTripMultipleAlternatePersistence(t *testing.T) {
 // backlog of blocks and then sending them in one giant network packet that can't
 // be decoded on the client side
 func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	if testing.Short() {
 		t.Skip()
 	}
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
@@ -1368,12 +1367,12 @@ func TestUnixFSFetch(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}
-	collectTracing := testutil.SetupTracing()
 
 	const unixfsChunkSize uint64 = 1 << 10
 	const unixfsLinksPerLevel = 1024
 
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 20*time.Second)
 	defer cancel()
 
@@ -1491,10 +1490,10 @@ func TestUnixFSFetch(t *testing.T) {
 }
 
 func TestGraphsyncBlockListeners(t *testing.T) {
-	collectTracing := testutil.SetupTracing()
 
 	// create network
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -397,7 +397,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	// each verifyBlock span should link to a cacheProcess span that stored it
 
 	cacheProcessSpans := tracing.FindSpans("cacheProcess")
-	cacheProcessLinks := make(map[string]int)
+	cacheProcessLinks := make(map[string]int64)
 	verifyBlockSpans := tracing.FindSpans("verifyBlock")
 
 	for _, verifyBlockSpan := range verifyBlockSpans {
@@ -417,7 +417,7 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	// each cacheProcess span should be linked to one verifyBlock span per block it stored
 
 	for _, cacheProcessSpan := range cacheProcessSpans {
-		blockCount := len(testutil.AttributeValueInTraceSpan(t, cacheProcessSpan, "blocks").AsStringSlice())
+		blockCount := testutil.AttributeValueInTraceSpan(t, cacheProcessSpan, "blockCount").AsInt64()
 		require.Equal(t, cacheProcessLinks[cacheProcessSpan.SpanContext.SpanID().String()], blockCount, "cacheProcess span should be linked to one verifyBlock span per block it processed")
 	}
 }

--- a/requestmanager/asyncloader/asyncloader_test.go
+++ b/requestmanager/asyncloader/asyncloader_test.go
@@ -48,7 +48,7 @@ func TestAsyncLoadInitialLoadSucceedsResponsePresent(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.ProcessResponse(context.Background(), responses, blocks)
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 
 		assertSuccessResponse(ctx, t, resultChan)
@@ -72,7 +72,7 @@ func TestAsyncLoadInitialLoadFails(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(responses, nil)
+		asyncLoader.ProcessResponse(context.Background(), responses, nil)
 
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 		assertFailResponse(ctx, t, resultChan)
@@ -116,7 +116,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenSucceeds(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.ProcessResponse(context.Background(), responses, blocks)
 		assertSuccessResponse(ctx, t, resultChan)
 		st.AssertLocalLoads(t, 1)
 		st.AssertBlockStored(t, block)
@@ -144,7 +144,7 @@ func TestAsyncLoadInitialLoadIndeterminateThenFails(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(responses, nil)
+		asyncLoader.ProcessResponse(context.Background(), responses, nil)
 		assertFailResponse(ctx, t, resultChan)
 		st.AssertLocalLoads(t, 1)
 	})
@@ -182,7 +182,7 @@ func TestAsyncLoadTwiceLoadsLocallySecondTime(t *testing.T) {
 			},
 		}
 		p := testutil.GeneratePeers(1)[0]
-		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.ProcessResponse(context.Background(), responses, blocks)
 		resultChan := asyncLoader.AsyncLoad(p, requestID, link, ipld.LinkContext{})
 
 		assertSuccessResponse(ctx, t, resultChan)
@@ -282,7 +282,7 @@ func TestRequestSplittingSameBlockTwoStores(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.ProcessResponse(context.Background(), responses, blocks)
 
 		assertSuccessResponse(ctx, t, resultChan1)
 		assertSuccessResponse(ctx, t, resultChan2)
@@ -317,7 +317,7 @@ func TestRequestSplittingSameBlockOnlyOneResponse(t *testing.T) {
 				},
 			},
 		}
-		asyncLoader.ProcessResponse(responses, blocks)
+		asyncLoader.ProcessResponse(context.Background(), responses, blocks)
 		asyncLoader.CompleteResponsesFor(requestID1)
 
 		assertFailResponse(ctx, t, resultChan1)

--- a/requestmanager/asyncloader/responsecache/responsecache.go
+++ b/requestmanager/asyncloader/responsecache/responsecache.go
@@ -76,12 +76,8 @@ func (rc *ResponseCache) ProcessResponse(
 	responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
 
-	cids := make([]string, 0, len(blks))
-	for _, blk := range blks {
-		cids = append(cids, blk.Cid().String())
-	}
 	ctx, span := otel.Tracer("graphsync").Start(ctx, "cacheProcess", trace.WithAttributes(
-		attribute.StringSlice("blocks", cids),
+		attribute.Int("blockCount", len(blks)),
 	))
 	traceLink := trace.LinkFromContext(ctx)
 	defer span.End()

--- a/requestmanager/asyncloader/responsecache/responsecache_test.go
+++ b/requestmanager/asyncloader/responsecache/responsecache_test.go
@@ -1,6 +1,7 @@
 package responsecache
 
 import (
+	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	ipld "github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ipfs/go-graphsync"
 	"github.com/ipfs/go-graphsync/metadata"
@@ -19,7 +21,7 @@ type fakeUnverifiedBlockStore struct {
 	inMemoryBlocks map[ipld.Link][]byte
 }
 
-func (ubs *fakeUnverifiedBlockStore) AddUnverifiedBlock(lnk ipld.Link, data []byte) {
+func (ubs *fakeUnverifiedBlockStore) AddUnverifiedBlock(_ trace.Link, lnk ipld.Link, data []byte) {
 	ubs.inMemoryBlocks[lnk] = data
 }
 
@@ -100,7 +102,7 @@ func TestResponseCacheManagingLinks(t *testing.T) {
 	}
 	responseCache := New(fubs)
 
-	responseCache.ProcessResponse(responses, blks)
+	responseCache.ProcessResponse(context.Background(), responses, blks)
 
 	require.Len(t, fubs.blocks(), len(blks)-1, "should prune block with no references")
 	testutil.RefuteContainsBlock(t, fubs.blocks(), blks[2])

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore.go
@@ -1,10 +1,14 @@
 package unverifiedblockstore
 
 import (
+	"context"
 	"fmt"
 
 	logging "github.com/ipfs/go-log/v2"
 	ipld "github.com/ipld/go-ipld-prime"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
 var log = logging.Logger("gs-unverifiedbs")
@@ -16,24 +20,29 @@ type settableWriter interface {
 // UnverifiedBlockStore holds an in memory cache of receied blocks from the network
 // that have not been verified to be part of a traversal
 type UnverifiedBlockStore struct {
-	inMemoryBlocks map[ipld.Link][]byte
+	inMemoryBlocks map[ipld.Link]tracedBlock
 	storer         ipld.BlockWriteOpener
 	dataSize       uint64
+}
+
+type tracedBlock struct {
+	block     []byte
+	traceLink trace.Link
 }
 
 // New initializes a new unverified store with the given storer function for writing
 // to permaneant storage if the block is verified
 func New(storer ipld.BlockWriteOpener) *UnverifiedBlockStore {
 	return &UnverifiedBlockStore{
-		inMemoryBlocks: make(map[ipld.Link][]byte),
+		inMemoryBlocks: make(map[ipld.Link]tracedBlock),
 		storer:         storer,
 	}
 }
 
 // AddUnverifiedBlock adds a new unverified block to the in memory cache as it
 // comes in as part of a traversal.
-func (ubs *UnverifiedBlockStore) AddUnverifiedBlock(lnk ipld.Link, data []byte) {
-	ubs.inMemoryBlocks[lnk] = data
+func (ubs *UnverifiedBlockStore) AddUnverifiedBlock(traceLink trace.Link, lnk ipld.Link, data []byte) {
+	ubs.inMemoryBlocks[lnk] = tracedBlock{data, traceLink}
 	ubs.dataSize = ubs.dataSize + uint64(len(data))
 	log.Debugw("added in-memory block", "total_queued_bytes", ubs.dataSize)
 }
@@ -42,9 +51,9 @@ func (ubs *UnverifiedBlockStore) AddUnverifiedBlock(lnk ipld.Link, data []byte) 
 // if the passed in function returns true for the given link
 func (ubs *UnverifiedBlockStore) PruneBlocks(shouldPrune func(ipld.Link, uint64) bool) {
 	for link, data := range ubs.inMemoryBlocks {
-		if shouldPrune(link, uint64(len(data))) {
+		if shouldPrune(link, uint64(len(data.block))) {
 			delete(ubs.inMemoryBlocks, link)
-			ubs.dataSize = ubs.dataSize - uint64(len(data))
+			ubs.dataSize = ubs.dataSize - uint64(len(data.block))
 		}
 	}
 	log.Debugw("finished pruning in-memory blocks", "total_queued_bytes", ubs.dataSize)
@@ -53,7 +62,7 @@ func (ubs *UnverifiedBlockStore) PruneBlocks(shouldPrune func(ipld.Link, uint64)
 // PruneBlock deletes an individual block from the store
 func (ubs *UnverifiedBlockStore) PruneBlock(link ipld.Link) {
 	delete(ubs.inMemoryBlocks, link)
-	ubs.dataSize = ubs.dataSize - uint64(len(ubs.inMemoryBlocks[link]))
+	ubs.dataSize = ubs.dataSize - uint64(len(ubs.inMemoryBlocks[link].block))
 	log.Debugw("pruned in-memory block", "total_queued_bytes", ubs.dataSize)
 }
 
@@ -64,8 +73,20 @@ func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link, linkContext ipld.Lin
 	if !ok {
 		return nil, fmt.Errorf("block not found")
 	}
+
+	ctx := linkContext.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	_, span := otel.Tracer("graphsync").Start(
+		ctx,
+		"verifyBlock",
+		trace.WithLinks(data.traceLink),
+		trace.WithAttributes(attribute.String("cid", lnk.String())))
+	defer span.End()
+
 	delete(ubs.inMemoryBlocks, lnk)
-	ubs.dataSize = ubs.dataSize - uint64(len(data))
+	ubs.dataSize = ubs.dataSize - uint64(len(data.block))
 	log.Debugw("verified block", "total_queued_bytes", ubs.dataSize)
 
 	buffer, committer, err := ubs.storer(linkContext)
@@ -73,9 +94,9 @@ func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link, linkContext ipld.Lin
 		return nil, err
 	}
 	if settable, ok := buffer.(settableWriter); ok {
-		err = settable.SetBytes(data)
+		err = settable.SetBytes(data.block)
 	} else {
-		_, err = buffer.Write(data)
+		_, err = buffer.Write(data.block)
 	}
 	if err != nil {
 		return nil, err
@@ -84,5 +105,5 @@ func (ubs *UnverifiedBlockStore) VerifyBlock(lnk ipld.Link, linkContext ipld.Lin
 	if err != nil {
 		return nil, err
 	}
-	return data, nil
+	return data.block, nil
 }

--- a/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
+++ b/requestmanager/asyncloader/unverifiedblockstore/unverifiedblockstore_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ipld/go-ipld-prime"
 	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ipfs/go-graphsync/testutil"
 )
@@ -25,7 +26,7 @@ func TestVerifyBlockPresent(t *testing.T) {
 	require.Nil(t, data)
 	require.Error(t, err, "block should not be verifiable till it's added as an unverifiable block")
 
-	unverifiedBlockStore.AddUnverifiedBlock(cidlink.Link{Cid: block.Cid()}, block.RawData())
+	unverifiedBlockStore.AddUnverifiedBlock(trace.Link{}, cidlink.Link{Cid: block.Cid()}, block.RawData())
 	reader, err = lsys.StorageReadOpener(ipld.LinkContext{}, cidlink.Link{Cid: block.Cid()})
 	require.Nil(t, reader)
 	require.Error(t, err, "block should not be loadable till it's verified")

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -74,7 +74,7 @@ type PeerHandler interface {
 // results as new responses are processed
 type AsyncLoader interface {
 	StartRequest(graphsync.RequestID, string) error
-	ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
+	ProcessResponse(ctx context.Context, responses map[graphsync.RequestID]metadata.Metadata,
 		blks []blocks.Block)
 	AsyncLoad(p peer.ID, requestID graphsync.RequestID, link ipld.Link, linkContext ipld.LinkContext) <-chan types.AsyncLoadResult
 	CompleteResponsesFor(requestID graphsync.RequestID)

--- a/requestmanager/testloader/asyncloader.go
+++ b/requestmanager/testloader/asyncloader.go
@@ -61,7 +61,7 @@ func (fal *FakeAsyncLoader) StartRequest(requestID graphsync.RequestID, name str
 }
 
 // ProcessResponse just records values passed to verify expectations later
-func (fal *FakeAsyncLoader) ProcessResponse(responses map[graphsync.RequestID]metadata.Metadata,
+func (fal *FakeAsyncLoader) ProcessResponse(_ context.Context, responses map[graphsync.RequestID]metadata.Metadata,
 	blks []blocks.Block) {
 	fal.responses <- responses
 	fal.blks <- blks

--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -139,19 +139,19 @@ func (c Collector) SingleExceptionEvent(t *testing.T, trace string, typeRe strin
 // a Collector. The returned helper function should be called at the point in
 // a test where the spans are ready to be analyzed. Any spans not properly
 // completed at that point won't be represented in the Collector.
-func SetupTracing() func(t *testing.T) *Collector {
+func SetupTracing(ctx context.Context) (context.Context, func(t *testing.T) *Collector) {
 	collector := &Collector{}
 	tp := trace.NewTracerProvider(trace.WithBatcher(collector))
 	otel.SetTracerProvider(tp)
-
+	ctx, cancel := context.WithCancel(ctx)
 	collect := func(t *testing.T) *Collector {
 		t.Helper()
-
+		cancel()
 		require.NoError(t, tp.Shutdown(context.Background()))
 		return collector
 	}
 
-	return collect
+	return ctx, collect
 }
 
 // AttributeValueInTraceSpan is a test helper that asserts that at a span

--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -202,4 +203,12 @@ func EventAsException(t *testing.T, evt trace.Event) ExceptionEvent {
 	require.NotEmpty(t, typ, "expected non-empty exception.type attribute for %v", evt.Name)
 	require.NotEmpty(t, msg, "expected non-empty exception.message attribute for %v", evt.Name)
 	return ExceptionEvent{Type: typ, Message: msg}
+}
+
+func RepeatTraceStrings(tmpl string, count int) []string {
+	res := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		res = append(res, strings.Replace(tmpl, "{}", fmt.Sprintf("%d", i), 1))
+	}
+	return res
 }

--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -25,6 +26,9 @@ type Collector struct {
 // ExportSpans receives the ReadOnlySpans from the batch provider
 func (c *Collector) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
 	c.Spans = tracetest.SpanStubsFromReadOnlySpans(spans)
+	sort.SliceStable(c.Spans, func(i, j int) bool {
+		return c.Spans[i].StartTime.Before(c.Spans[j].StartTime)
+	})
 	return nil
 }
 


### PR DESCRIPTION
Trace synchronous responseMessage->loaderProcess->cacheProcess block storage and link those to asynchronous request->verifyBlock traces for the same blocks.

Closes: https://github.com/ipfs/go-graphsync/issues/317