### PR TITLE
Fix tracing span collection

### DIFF
--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -25,7 +25,7 @@ type Collector struct {
 
 // ExportSpans receives the ReadOnlySpans from the batch provider
 func (c *Collector) ExportSpans(ctx context.Context, spans []trace.ReadOnlySpan) error {
-	c.Spans = tracetest.SpanStubsFromReadOnlySpans(spans)
+	c.Spans = append(c.Spans, tracetest.SpanStubsFromReadOnlySpans(spans)...)
 	sort.SliceStable(c.Spans, func(i, j int) bool {
 		return c.Spans[i].StartTime.Before(c.Spans[j].StartTime)
 	})


### PR DESCRIPTION
# Goals

Caught this working with tracing over in go-data-transfer. I'm not sure what causes ExportSpans to get called multiple times -- over a fixed number? some kind of context cancellation? Not sure. Anyway, if it does, we were losing spans.

# Implementation

Append span list rather than overwriting it on export.