### PR TITLE
feat(responsemanager): trace full messages via links to responses

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -206,9 +206,10 @@ func TestRejectRequestsByDefault(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 		"processResponses(0)->loaderProcess(0)->cacheProcess(0)",
-		"response(0)->transaction(0)->execute(0)->buildMessage(0)",
-		"requestMessage(0)->sendMessage(0)",
-		"requestMessage(1)->sendMessage(0)",
+		"processRequests(0)->transaction(0)->execute(0)->buildMessage(0)",
+		"message(0)->sendMessage(0)",
+		"message(1)->sendMessage(0)",
+		"response(0)",
 	}, tracing.TracesToStrings())
 	// has ContextCancelError exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ContextCancelError", ipldutil.ContextCancelError{}.Error(), false)
@@ -557,11 +558,11 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 		"request(0)->terminateRequest(0)",
 	},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+1)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+1)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 50)...), // half of the full chain
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", blockChainLength)...),
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
 	), tracing.TracesToStrings())
 }
 
@@ -631,11 +632,11 @@ func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
 		"request(0)->terminateRequest(0)",
 	},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+1)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+1)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 50)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", blockChainLength)...),
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
 	), tracing.TracesToStrings())
 }
 
@@ -883,20 +884,20 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 
 	tracing := collectTracing(t)
 	require.ElementsMatch(t, append(append(append(append(append(append(append(append([]string{
-		"response(0)->executeTask(0)",
 		"response(0)->processUpdate(0)",
 		"request(0)->newRequest(0)",
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
+		"processRequests(1)",
 	},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+2)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+2)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", 50)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", 50)...), // half of the full chain
 		testutil.RepeatTraceStrings("response(0)->executeTask(1)->processBlock({})->loadBlock(0)", 50)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(1)->processBlock({})->sendBlock(0)->processBlockHooks(0)", 50)...), // half of the full chain
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+3)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+3)...,
 	), tracing.TracesToStrings())
 	// make sure the attributes are what we expect
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)->processUpdate(0)")
@@ -904,13 +905,13 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 	// pause recorded
 	tracing.SingleExceptionEvent(t, "response(0)->executeTask(0)", "github.com/ipfs/go-graphsync/responsemanager/hooks.ErrPaused", hooks.ErrPaused{}.Error(), false)
 
-	message0Span := tracing.FindSpanByTraceString("requestMessage(0)")
-	message1Span := tracing.FindSpanByTraceString("requestMessage(1)")
+	message0Span := tracing.FindSpanByTraceString("processRequests(0)")
+	message1Span := tracing.FindSpanByTraceString("processRequests(1)")
 	responseSpan := tracing.FindSpanByTraceString("response(0)")
-	// response(0) originates in requestMessage(0)
+	// response(0) originates in processRequests(0)
 	require.Len(t, responseSpan.Links, 1)
 	require.Equal(t, responseSpan.Links[0].SpanContext.SpanID(), message0Span.SpanContext.SpanID())
-	// response(0)->processUpdate(0) occurs thanks to requestMessage(1)
+	// response(0)->processUpdate(0) occurs thanks to processRequests(1)
 	require.Len(t, processUpdateSpan.Links, 1)
 	require.Equal(t, processUpdateSpan.Links[0].SpanContext.SpanID(), message1Span.SpanContext.SpanID())
 }
@@ -991,15 +992,16 @@ func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
 		"request(0)->newRequest(0)",
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
+		"processRequests(1)",
 	},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+2)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+2)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", 50)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", 50)...), // half of the full chain
 		testutil.RepeatTraceStrings("response(0)->executeTask(1)->processBlock({})->loadBlock(0)", 50)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(1)->processBlock({})->sendBlock(0)->processBlockHooks(0)", 50)...), // half of the full chain
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+3)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+3)...,
 	), tracing.TracesToStrings())
 	// make sure the attributes are what we expect
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)->processUpdate(0)")
@@ -1085,11 +1087,12 @@ func TestNetworkDisconnect(t *testing.T) {
 	tracing := collectTracing(t)
 
 	traceStrings := tracing.TracesToStrings()
-	require.Contains(t, traceStrings, "requestMessage(0)")
-	require.Contains(t, traceStrings, "response(0)->executeTask(0)")
-	require.Contains(t, traceStrings, "response(0)->abortRequest(0)")
+	require.Contains(t, traceStrings, "processRequests(0)->transaction(0)->execute(0)->buildMessage(0)")
 	require.Contains(t, traceStrings, "response(0)->executeTask(0)->processBlock(0)->loadBlock(0)")
 	require.Contains(t, traceStrings, "response(0)->executeTask(0)->processBlock(0)->sendBlock(0)->processBlockHooks(0)")
+	require.Contains(t, traceStrings, "response(0)->abortRequest(0)")
+	require.Contains(t, traceStrings, "response(0)->executeTask(1)->processBlock(0)->loadBlock(0)")
+	require.Contains(t, traceStrings, "response(0)->executeTask(1)->processBlock(0)->sendBlock(0)->processBlockHooks(0)")
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
@@ -1377,11 +1380,11 @@ func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
 		"request(0)->terminateRequest(0)",
 	},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+1)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+1)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", blockChainLength)...),
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
 	), tracing.TracesToStrings())
 }
 
@@ -1612,17 +1615,16 @@ func TestGraphsyncBlockListeners(t *testing.T) {
 	tracing := collectTracing(t)
 	require.ElementsMatch(t, append(append(append(append(append(append(
 		[]string{
-			"response(0)->executeTask(0)",
 			"request(0)->newRequest(0)",
 			"request(0)->executeTask(0)",
 			"request(0)->terminateRequest(0)",
 		},
 		processResponsesTraces(t, tracing, responseCount)...),
-		testutil.RepeatTraceStrings("requestMessage({})->sendMessage(0)", responseCount+1)...),
+		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+1)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", blockChainLength)...),
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", blockChainLength)...),
-		testutil.RepeatTraceStrings("response(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
+		testutil.RepeatTraceStrings("processRequests(0)->transaction({})->execute(0)->buildMessage(0)", blockChainLength+2)...,
 	), tracing.TracesToStrings())
 }
 

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -154,7 +154,7 @@ func New(ctx context.Context,
 
 // ProcessRequests processes incoming requests for the given peer
 func (rm *ResponseManager) ProcessRequests(ctx context.Context, p peer.ID, requests []gsmsg.GraphSyncRequest) {
-	rm.send(&processRequestMessage{p, requests}, ctx.Done())
+	rm.send(&processRequestsMessage{p, requests}, ctx.Done())
 }
 
 // UnpauseResponse unpauses a response that was previously paused

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -10,12 +10,12 @@ import (
 	"github.com/ipfs/go-graphsync/responsemanager/queryexecutor"
 )
 
-type processRequestMessage struct {
+type processRequestsMessage struct {
 	p        peer.ID
 	requests []gsmsg.GraphSyncRequest
 }
 
-func (prm *processRequestMessage) handle(rm *ResponseManager) {
+func (prm *processRequestsMessage) handle(rm *ResponseManager) {
 	rm.processRequests(prm.p, prm.requests)
 }
 

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -41,7 +41,7 @@ type errorRequestMessage struct {
 }
 
 func (erm *errorRequestMessage) handle(rm *ResponseManager) {
-	err := rm.abortRequest(erm.p, erm.requestID, erm.err)
+	err := rm.abortRequest(rm.ctx, erm.p, erm.requestID, erm.err)
 	select {
 	case <-rm.ctx.Done():
 	case erm.response <- err:

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -136,15 +136,10 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	td.assertRequestCleared()
 
 	tracing := td.collectTracing(t)
-	require.ElementsMatch(t, []string{
-		"processRequests(0)",
-		"response(0)->executeTask(0)->processBlock(0)->loadBlock(0)",
-		"response(0)->executeTask(0)->processBlock(0)->sendBlock(0)->processBlockHooks(0)",
-		"response(0)->executeTask(0)->processBlock(1)->loadBlock(0)",
-		"response(0)->executeTask(0)->processBlock(1)->sendBlock(0)",
-		"response(0)->abortRequest(0)",
-		"processRequests(1)",
-	}, tracing.TracesToStrings())
+	traceStrings := tracing.TracesToStrings()
+	require.Contains(t, traceStrings, "processRequests(0)")
+	require.Contains(t, traceStrings, "response(0)->abortRequest(0)")
+	require.Contains(t, traceStrings, "processRequests(1)")
 	message0Span := tracing.FindSpanByTraceString("processRequests(0)")
 	message1Span := tracing.FindSpanByTraceString("processRequests(1)")
 	responseSpan := tracing.FindSpanByTraceString("response(0)")

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -91,6 +91,10 @@ func TestIncomingQuery(t *testing.T) {
 		testutil.RepeatTraceStrings("TestIncomingQuery(0)->response(0)->executeTask(0)->processBlock({})->loadBlock(0)", td.blockChainLength),
 		testutil.RepeatTraceStrings("TestIncomingQuery(0)->response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", td.blockChainLength)..., // half of the full chain
 	), tracing.TracesToStrings())
+	messageSpan := tracing.FindSpanByTraceString("requestMessage(0)")
+	responseSpan := tracing.FindSpanByTraceString("TestIncomingQuery(0)->response(0)")
+	require.Len(t, responseSpan.Links, 1)
+	require.Equal(t, responseSpan.Links[0].SpanContext.SpanID(), messageSpan.SpanContext.SpanID())
 }
 
 func TestCancellationQueryInProgress(t *testing.T) {
@@ -129,6 +133,24 @@ func TestCancellationQueryInProgress(t *testing.T) {
 	td.connManager.RefuteProtected(t, td.p)
 
 	td.assertRequestCleared()
+
+	tracing := td.collectTracing(t)
+	require.ElementsMatch(t, []string{
+		"requestMessage(0)",
+		"response(0)->executeTask(0)",
+		"response(0)->abortRequest(0)",
+		"requestMessage(1)",
+	}, tracing.TracesToStrings())
+	message0Span := tracing.FindSpanByTraceString("requestMessage(0)")
+	message1Span := tracing.FindSpanByTraceString("requestMessage(1)")
+	responseSpan := tracing.FindSpanByTraceString("response(0)")
+	abortRequestSpan := tracing.FindSpanByTraceString("response(0)->abortRequest(0)")
+	// response(0) originates in requestMessage(0)
+	require.Len(t, responseSpan.Links, 1)
+	require.Equal(t, responseSpan.Links[0].SpanContext.SpanID(), message0Span.SpanContext.SpanID())
+	// response(0)->abortRequest(0) occurs thanks to requestMessage(1)
+	require.Len(t, abortRequestSpan.Links, 1)
+	require.Equal(t, abortRequestSpan.Links[0].SpanContext.SpanID(), message1Span.SpanContext.SpanID())
 }
 
 func TestCancellationViaCommand(t *testing.T) {

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -176,7 +176,7 @@ func (rm *ResponseManager) abortRequest(ctx context.Context, p peer.ID, requestI
 func (rm *ResponseManager) processRequests(p peer.ID, requests []gsmsg.GraphSyncRequest) {
 	ctx, messageSpan := otel.Tracer("graphsync").Start(
 		rm.ctx,
-		"requestMessage",
+		"processRequests",
 		trace.WithAttributes(attribute.String("peerID", p.Pretty())),
 	)
 	defer messageSpan.End()


### PR DESCRIPTION
Fixes: https://github.com/ipfs/go-graphsync/issues/318

Probably the most interesting part of this is seeing two separate messages do different things to a single response. In `TestPauseResumeViaUpdate` we see the first message linked to the start of a response and the second message get linked to the `processUpdate` span of the same response. Then in `TestCancellationQueryInProgress` we see the same thing but for an `abortRequest` triggered by the second message.

One possible change could be that we use this new `message` span as the parent to a `response` if no other parent gets inserted via the reuqestqueued context-modifying hook. So all `response` spans would have a `message` parent unless that hook is wired up by a consumer, as we do in `TestIncomingQuery` and I believe we'll be doing in datatransfer or further upstream. But I think this might miss the point of keeping `response`s as separate things that are independent of the individual messages. The `message` span isn't going to live longer than the synchronous call here but I don't think it would matter to a consuming API if they stacked up, but it does suggest that we're looking at these things in different ways so we should probably keep them separate .. ?