### PR TITLE
Response message tracing

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -1136,12 +1136,11 @@ func TestConnectFail(t *testing.T) {
 	drain(requestor)
 
 	tracing := collectTracing(t)
-	require.ElementsMatch(t, []string{
-		"request(0)->newRequest(0)",
-		"request(0)->executeTask(0)",
-		"request(0)->terminateRequest(0)",
-		"message(0)->sendMessage(0)",
-	}, tracing.TracesToStrings())
+	traceStrings := tracing.TracesToStrings()
+	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
+	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
+	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
+	require.Contains(t, traceStrings, "message(0)->sendMessage(0)")
 	// has ContextCancelError exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ContextCancelError", ipldutil.ContextCancelError{}.Error(), false)
 }

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -1641,13 +1641,13 @@ func assertAllResponsesReceivedFunction(gs graphsync.GraphExchange) func(context
 	var responseCount int
 	finalResponseStatusChanRequestor := make(chan graphsync.ResponseStatusCode, 1)
 	gs.RegisterIncomingResponseHook(func(p peer.ID, response graphsync.ResponseData, hookActions graphsync.IncomingResponseHookActions) {
+		responseCount = responseCount + 1
 		if response.Status().IsTerminal() {
 			select {
 			case finalResponseStatusChanRequestor <- response.Status():
 			default:
 			}
 		}
-		responseCount = responseCount + 1
 	})
 	return func(ctx context.Context, t *testing.T) int {
 		testutil.AssertDoesReceive(ctx, t, finalResponseStatusChanRequestor, "final response never received")

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -164,9 +164,11 @@ func (mq *MessageQueue) runQueue() {
 					_, metadata, err := mq.extractOutgoingMessage()
 					if err == nil {
 						span := trace.SpanFromContext(metadata.ctx)
-						span.SetStatus(codes.Error, "message queue shutdown")
+						err := fmt.Errorf("message queue shutdown")
+						span.RecordError(err)
+						span.SetStatus(codes.Error, err.Error())
 						span.End()
-						mq.publishError(metadata, fmt.Errorf("message queue shutdown"))
+						mq.publishError(metadata, err)
 						mq.eventPublisher.Close(metadata.topic)
 					} else {
 						break

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -11,6 +11,10 @@ import (
 	"github.com/ipfs/go-graphsync"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/libp2p/go-libp2p-core/peer"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	gsnet "github.com/ipfs/go-graphsync/network"
@@ -112,7 +116,10 @@ func (mq *MessageQueue) buildMessage(size uint64, buildMessageFn func(*Builder))
 	if shouldBeginNewResponse(mq.builders, size) {
 		topic := mq.nextBuilderTopic
 		mq.nextBuilderTopic++
-		mq.builders = append(mq.builders, NewBuilder(topic))
+		ctx, _ := otel.Tracer("graphsync").Start(mq.ctx, "message", trace.WithAttributes(
+			attribute.Int64("topic", int64(topic)),
+		))
+		mq.builders = append(mq.builders, NewBuilder(ctx, topic))
 	}
 	builder := mq.builders[len(mq.builders)-1]
 	buildMessageFn(builder)
@@ -156,6 +163,9 @@ func (mq *MessageQueue) runQueue() {
 				for {
 					_, metadata, err := mq.extractOutgoingMessage()
 					if err == nil {
+						span := trace.SpanFromContext(metadata.ctx)
+						span.SetStatus(codes.Error, "message queue shutdown")
+						span.End()
 						mq.publishError(metadata, fmt.Errorf("message queue shutdown"))
 						mq.eventPublisher.Close(metadata.topic)
 					} else {
@@ -211,12 +221,20 @@ func (mq *MessageQueue) extractOutgoingMessage() (gsmsg.GraphSyncMessage, intern
 
 func (mq *MessageQueue) sendMessage() {
 	message, metadata, err := mq.extractOutgoingMessage()
+
 	if err != nil {
 		if err != errEmptyMessage {
 			log.Errorf("Unable to assemble GraphSync message: %s", err.Error())
 		}
 		return
 	}
+	span := trace.SpanFromContext(metadata.ctx)
+	defer span.End()
+	_, sendSpan := otel.Tracer("graphsync").Start(metadata.ctx, "sendMessage", trace.WithAttributes(
+		attribute.Int64("topic", int64(metadata.topic)),
+		attribute.Int64("size", int64(metadata.msgSize)),
+	))
+	defer sendSpan.End()
 	mq.publishQueued(metadata)
 	defer mq.eventPublisher.Close(metadata.topic)
 
@@ -337,6 +355,7 @@ func openSender(ctx context.Context, network MessageNetwork, p peer.ID, sendTime
 }
 
 type internalMetadata struct {
+	ctx             context.Context
 	public          Metadata
 	topic           Topic
 	msgSize         uint64

--- a/messagequeue/messagequeue_test.go
+++ b/messagequeue/messagequeue_test.go
@@ -183,6 +183,7 @@ func TestProcessingNotification(t *testing.T) {
 
 func TestDedupingMessages(t *testing.T) {
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
 	defer cancel()
 
@@ -251,6 +252,12 @@ func TestDedupingMessages(t *testing.T) {
 			t.Fatal("incorrect request added to message")
 		}
 	}
+
+	tracing := collectTracing(t)
+	require.ElementsMatch(t, []string{
+		"message(0)->sendMessage(0)",
+		"message(1)->sendMessage(0)",
+	}, tracing.TracesToStrings())
 }
 
 func TestSendsVeryLargeBlocksResponses(t *testing.T) {

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -30,7 +30,7 @@ type fakePeer struct {
 }
 
 func (fp *fakePeer) AllocateAndBuildMessage(blkSize uint64, buildMessage func(b *messagequeue.Builder)) {
-	builder := messagequeue.NewBuilder(messagequeue.Topic(0))
+	builder := messagequeue.NewBuilder(context.TODO(), messagequeue.Topic(0))
 	buildMessage(builder)
 	message, err := builder.Build()
 	if err != nil {

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -1015,7 +1015,7 @@ type fakePeerHandler struct {
 
 func (fph *fakePeerHandler) AllocateAndBuildMessage(p peer.ID, blkSize uint64,
 	requestBuilder func(b *messagequeue.Builder)) {
-	builder := messagequeue.NewBuilder(messagequeue.Topic(0))
+	builder := messagequeue.NewBuilder(context.TODO(), messagequeue.Topic(0))
 	requestBuilder(builder)
 	message, err := builder.Build()
 	if err != nil {

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -85,7 +85,7 @@ type NetworkErrorListeners interface {
 
 // ResponseAssembler is an interface that returns sender interfaces for peer responses.
 type ResponseAssembler interface {
-	NewStream(p peer.ID, requestID graphsync.RequestID, subscriber notifications.Subscriber) responseassembler.ResponseStream
+	NewStream(ctx context.Context, p peer.ID, requestID graphsync.RequestID, subscriber notifications.Subscriber) responseassembler.ResponseStream
 }
 
 type responseManagerMessage interface {

--- a/responsemanager/queryexecutor/queryexecutor.go
+++ b/responsemanager/queryexecutor/queryexecutor.go
@@ -249,11 +249,10 @@ func (qe *QueryExecutor) nextBlock(ctx context.Context, taskData ResponseTask) (
 }
 
 func (qe *QueryExecutor) sendResponse(ctx context.Context, p peer.ID, taskData ResponseTask, link ipld.Link, data []byte) error {
-	ctx, span := otel.Tracer("graphsync").Start(ctx, "sendBlock")
-	defer span.End()
-
 	// Execute a transaction for this block, including any other queued operations
 	return taskData.ResponseStream.Transaction(func(rb responseassembler.ResponseBuilder) error {
+		ctx, span := otel.Tracer("graphsync").Start(ctx, "sendBlock", trace.WithLinks(trace.LinkFromContext(rb.Context())))
+		defer span.End()
 		// Ensure that any updates that have occurred till now are integrated into the response
 		err := qe.checkForUpdates(p, taskData, rb)
 		// On any error other than a pause, we bail, if it's a pause then we continue processing _this_ block

--- a/responsemanager/queryexecutor/queryexecutor.go
+++ b/responsemanager/queryexecutor/queryexecutor.go
@@ -83,7 +83,7 @@ func New(ctx context.Context,
 // and uses the ResponseAssembler to build and send a response, while also triggering any of
 // the QueryExecutor's BlockHooks. Traversal continues until complete, or a signal or hook
 // suggests we should stop or pause.
-func (qe *QueryExecutor) ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.Task) bool {
+func (qe *QueryExecutor) ExecuteTask(_ context.Context, pid peer.ID, task *peertask.Task) bool {
 	// StartTask lets us block until this task is at the top of the execution stack
 	responseTaskChan := make(chan ResponseTask)
 	var rt ResponseTask

--- a/responsemanager/queryexecutor/queryexecutor_test.go
+++ b/responsemanager/queryexecutor/queryexecutor_test.go
@@ -437,6 +437,10 @@ func (rb fauxResponseBuilder) PauseRequest() {
 	}
 }
 
+func (rb fauxResponseBuilder) Context() context.Context {
+	return context.TODO()
+}
+
 var _ responseassembler.ResponseBuilder = &fauxResponseBuilder{}
 
 type blockData struct {

--- a/responsemanager/responseassembler/responseBuilder.go
+++ b/responsemanager/responseassembler/responseBuilder.go
@@ -1,6 +1,8 @@
 package responseassembler
 
 import (
+	"context"
+
 	blocks "github.com/ipfs/go-block-format"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipld/go-ipld-prime"
@@ -18,6 +20,7 @@ type responseOperation interface {
 }
 
 type responseBuilder struct {
+	ctx         context.Context
 	requestID   graphsync.RequestID
 	operations  []responseOperation
 	linkTracker *peerLinkTracker
@@ -45,6 +48,10 @@ func (rb *responseBuilder) FinishWithError(status graphsync.ResponseStatusCode) 
 
 func (rb *responseBuilder) PauseRequest() {
 	rb.operations = append(rb.operations, statusOperation{rb.requestID, graphsync.RequestPaused})
+}
+
+func (rb *responseBuilder) Context() context.Context {
+	return rb.ctx
 }
 
 func (rb *responseBuilder) setupBlockOperation(

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -163,7 +163,7 @@ func (rs *responseStream) execute(ctx context.Context, operations []responseOper
 		size += op.size()
 	}
 	rs.messageSenders.AllocateAndBuildMessage(rs.p, size, func(builder *messagequeue.Builder) {
-		_, span = otel.Tracer("graphsync").Start(ctx, "message-build", trace.WithLinks(trace.LinkFromContext(builder.Context())))
+		_, span = otel.Tracer("graphsync").Start(ctx, "buildMessage", trace.WithLinks(trace.LinkFromContext(builder.Context())))
 		defer span.End()
 
 		if rs.isClosed() {

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -41,11 +41,11 @@ func TestResponseAssemblerSendsResponses(t *testing.T) {
 	var bd1, bd2 graphsync.BlockData
 
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	sub2 := testutil.NewTestSubscriber(10)
-	stream2 := responseAssembler.NewStream(p, requestID2, sub2)
+	stream2 := responseAssembler.NewStream(ctx, p, requestID2, sub2)
 	sub3 := testutil.NewTestSubscriber(10)
-	stream3 := responseAssembler.NewStream(p, requestID3, sub3)
+	stream3 := responseAssembler.NewStream(ctx, p, requestID3, sub3)
 
 	// send block 0 for request 1
 	require.NoError(t, stream1.Transaction(func(b ResponseBuilder) error {
@@ -138,7 +138,7 @@ func TestResponseAssemblerCloseStream(t *testing.T) {
 	responseAssembler := New(ctx, fph)
 
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	require.NoError(t, stream1.Transaction(func(b ResponseBuilder) error {
 		b.SendResponse(links[0], blks[0].RawData())
 		return nil
@@ -174,7 +174,7 @@ func TestResponseAssemblerSendsExtensionData(t *testing.T) {
 	responseAssembler := New(ctx, fph)
 
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	require.NoError(t, stream1.Transaction(func(b ResponseBuilder) error {
 		b.SendResponse(links[0], blks[0].RawData())
 		return nil
@@ -220,7 +220,7 @@ func TestResponseAssemblerSendsResponsesInTransaction(t *testing.T) {
 	fph := newFakePeerHandler(ctx, t)
 	responseAssembler := New(ctx, fph)
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	var bd1, bd2, bd3 graphsync.BlockData
 	err := stream1.Transaction(func(b ResponseBuilder) error {
 		bd1 = b.SendResponse(links[0], blks[0].RawData())
@@ -260,9 +260,9 @@ func TestResponseAssemblerIgnoreBlocks(t *testing.T) {
 	fph := newFakePeerHandler(ctx, t)
 	responseAssembler := New(ctx, fph)
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	sub2 := testutil.NewTestSubscriber(10)
-	stream2 := responseAssembler.NewStream(p, requestID2, sub2)
+	stream2 := responseAssembler.NewStream(ctx, p, requestID2, sub2)
 
 	stream1.IgnoreBlocks(links)
 
@@ -336,9 +336,9 @@ func TestResponseAssemblerSkipFirstBlocks(t *testing.T) {
 	responseAssembler := New(ctx, fph)
 
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	sub2 := testutil.NewTestSubscriber(10)
-	stream2 := responseAssembler.NewStream(p, requestID2, sub2)
+	stream2 := responseAssembler.NewStream(ctx, p, requestID2, sub2)
 
 	stream1.SkipFirstBlocks(3)
 
@@ -427,11 +427,11 @@ func TestResponseAssemblerDupKeys(t *testing.T) {
 	fph := newFakePeerHandler(ctx, t)
 	responseAssembler := New(ctx, fph)
 	sub1 := testutil.NewTestSubscriber(10)
-	stream1 := responseAssembler.NewStream(p, requestID1, sub1)
+	stream1 := responseAssembler.NewStream(ctx, p, requestID1, sub1)
 	sub2 := testutil.NewTestSubscriber(10)
-	stream2 := responseAssembler.NewStream(p, requestID2, sub2)
+	stream2 := responseAssembler.NewStream(ctx, p, requestID2, sub2)
 	sub3 := testutil.NewTestSubscriber(10)
-	stream3 := responseAssembler.NewStream(p, requestID3, sub3)
+	stream3 := responseAssembler.NewStream(ctx, p, requestID3, sub3)
 
 	stream1.DedupKey("applesauce")
 	stream3.DedupKey("applesauce")

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -125,12 +125,12 @@ func TestResponseAssemblerSendsResponses(t *testing.T) {
 
 	tracing := collectTracing(t)
 	require.ElementsMatch(t, []string{
-		"transaction(0)->execute(0)->message-build(0)",
-		"transaction(1)->execute(0)->message-build(0)",
-		"transaction(2)->execute(0)->message-build(0)",
-		"transaction(3)->execute(0)->message-build(0)",
-		"transaction(4)->execute(0)->message-build(0)",
-		"transaction(5)->execute(0)->message-build(0)",
+		"transaction(0)->execute(0)->buildMessage(0)",
+		"transaction(1)->execute(0)->buildMessage(0)",
+		"transaction(2)->execute(0)->buildMessage(0)",
+		"transaction(3)->execute(0)->buildMessage(0)",
+		"transaction(4)->execute(0)->buildMessage(0)",
+		"transaction(5)->execute(0)->buildMessage(0)",
 	}, tracing.TracesToStrings())
 }
 

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -23,6 +23,7 @@ import (
 
 func TestResponseAssemblerSendsResponses(t *testing.T) {
 	ctx := context.Background()
+	ctx, collectTracing := testutil.SetupTracing(ctx)
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 	p := testutil.GeneratePeers(1)[0]
@@ -121,6 +122,16 @@ func TestResponseAssemblerSendsResponses(t *testing.T) {
 	fph.AssertResponses(expectedResponses{requestID3: graphsync.PartialResponse})
 	fph.AssertSubscriber(requestID3, sub3)
 	fph.AssertResponseStream(requestID3, stream3)
+
+	tracing := collectTracing(t)
+	require.ElementsMatch(t, []string{
+		"transaction(0)->execute(0)->message-build(0)",
+		"transaction(1)->execute(0)->message-build(0)",
+		"transaction(2)->execute(0)->message-build(0)",
+		"transaction(3)->execute(0)->message-build(0)",
+		"transaction(4)->execute(0)->message-build(0)",
+		"transaction(5)->execute(0)->message-build(0)",
+	}, tracing.TracesToStrings())
 }
 
 func TestResponseAssemblerCloseStream(t *testing.T) {

--- a/responsemanager/responseassembler/responseassembler_test.go
+++ b/responsemanager/responseassembler/responseassembler_test.go
@@ -619,7 +619,7 @@ func (fph *fakePeerHandler) RefuteResponses() {
 }
 
 func (fph *fakePeerHandler) AllocateAndBuildMessage(p peer.ID, blkSize uint64, buildMessageFn func(*messagequeue.Builder)) {
-	builder := messagequeue.NewBuilder(messagequeue.Topic(0))
+	builder := messagequeue.NewBuilder(context.TODO(), messagequeue.Topic(0))
 	buildMessageFn(builder)
 
 	msg, err := builder.Build()

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -1008,6 +1008,10 @@ func (frb *fakeResponseBuilder) PauseRequest() {
 	frb.fra.pauseRequest(frb.requestID)
 }
 
+func (frb *fakeResponseBuilder) Context() context.Context {
+	return context.TODO()
+}
+
 type testData struct {
 	ctx                       context.Context
 	t                         *testing.T

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -87,9 +87,10 @@ func TestIncomingQuery(t *testing.T) {
 	td.connManager.RefuteProtected(t, td.p)
 
 	tracing := td.collectTracing(t)
-	require.ElementsMatch(t, []string{
-		"TestIncomingQuery(0)->response(0)->executeTask(0)",
-	}, tracing.TracesToStrings())
+	require.ElementsMatch(t, append(
+		testutil.RepeatTraceStrings("TestIncomingQuery(0)->response(0)->executeTask(0)->processBlock({})->loadBlock(0)", td.blockChainLength),
+		testutil.RepeatTraceStrings("TestIncomingQuery(0)->response(0)->executeTask(0)->processBlock({})->sendBlock(0)->processBlockHooks(0)", td.blockChainLength)..., // half of the full chain
+	), tracing.TracesToStrings())
 }
 
 func TestCancellationQueryInProgress(t *testing.T) {

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -858,7 +858,7 @@ type fakeResponseAssembler struct {
 	missingBlock           bool
 }
 
-func (fra *fakeResponseAssembler) NewStream(p peer.ID, requestID graphsync.RequestID, subscriber notifications.Subscriber) responseassembler.ResponseStream {
+func (fra *fakeResponseAssembler) NewStream(ctx context.Context, p peer.ID, requestID graphsync.RequestID, subscriber notifications.Subscriber) responseassembler.ResponseStream {
 	fra.notifeePublisher.AddSubscriber(subscriber)
 	return &fakeResponseStream{fra, requestID}
 }

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -213,7 +213,7 @@ func (rm *ResponseManager) processRequests(p peer.ID, requests []gsmsg.GraphSync
 				},
 				state:          graphsync.Queued,
 				startTime:      time.Now(),
-				responseStream: rm.responseAssembler.NewStream(key.p, key.requestID, sub),
+				responseStream: rm.responseAssembler.NewStream(ctx, key.p, key.requestID, sub),
 			}
 		// TODO: Use a better work estimation metric.
 


### PR DESCRIPTION
# Goals

Trace the path of each out going response

# Implementation

There are three layers of traces here:
1. Tracking each message sent through the message queue
   1. Produces: message -> sendMessage traces (where `message` encompasses the entire lifecycle of the message while `sendMessage` only covers the process of sending it over the wire)
2. Tracking each transaction in the ResponseAssembler
   1. Produces: response -> transaction -> execute-> message-build (where transaction encompasses the the whole transaction, execute encompasses the whole call to AllocateAndBuildMessage time including waiting for memory to be allocated, and message-build includes only the time building the messageQueue message)
   2. Links: message-build -> message span of the message the data ends up in
3. Tracking each block traversed in the QueryExecutor
   1. Produces: response -> executeTask -> processBlock
      1. -> loadBlock
      2. -> sendBlock -> processBlockHooks
   2. Links: sendBlock -> transaction