### PR TITLE
chore(requestmanager): rename processResponses internals for consistency

### DIFF
--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -205,7 +205,7 @@ func TestRejectRequestsByDefault(t *testing.T) {
 		"request(0)->newRequest(0)",
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
-		"responseMessage(0)->loaderProcess(0)->cacheProcess(0)",
+		"processResponses(0)->loaderProcess(0)->cacheProcess(0)",
 	}, tracing.TracesToStrings())
 	// has ContextCancelError exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ContextCancelError", ipldutil.ContextCancelError{}.Error(), false)
@@ -254,8 +254,8 @@ func TestGraphsyncRoundTripRequestBudgetRequestor(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	// has ErrBudgetExceeded exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ErrBudgetExceeded", "traversal budget exceeded", true)
@@ -303,8 +303,8 @@ func TestGraphsyncRoundTripRequestBudgetResponder(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	// has ContextCancelError exception recorded in the right place
 	// the requester gets a cancel, the responder gets a ErrBudgetExceeded
@@ -387,8 +387,8 @@ func TestGraphsyncRoundTrip(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	processUpdateSpan := tracing.FindSpanByTraceString("response(0)")
 	require.Equal(t, int64(0), testutil.AttributeValueInTraceSpan(t, *processUpdateSpan, "priority").AsInt64())
@@ -483,8 +483,8 @@ func TestGraphsyncRoundTripPartial(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 }
 
 func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
@@ -554,7 +554,7 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 50)..., // half of the full chain
 	), tracing.TracesToStrings())
 }
@@ -627,7 +627,7 @@ func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 50)..., // half of the full chain
 	), tracing.TracesToStrings())
 }
@@ -715,8 +715,8 @@ func TestPauseResume(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	// pause recorded
 	tracing.SingleExceptionEvent(t, "response(0)->executeTask(0)", "github.com/ipfs/go-graphsync/responsemanager/hooks.ErrPaused", hooks.ErrPaused{}.Error(), false)
@@ -796,8 +796,8 @@ func TestPauseResumeRequest(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(1)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	// has ErrPaused exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ErrPaused", hooks.ErrPaused{}.Error(), false)
@@ -879,7 +879,7 @@ func TestPauseResumeViaUpdate(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...,
 	), tracing.TracesToStrings())
 	// make sure the attributes are what we expect
@@ -970,7 +970,7 @@ func TestPauseResumeViaUpdateOnBlockHook(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...,
 	), tracing.TracesToStrings())
 	// make sure the attributes are what we expect
@@ -1063,8 +1063,8 @@ func TestNetworkDisconnect(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 
 	// has ContextCancelError exception recorded in the right place
 	tracing.SingleExceptionEvent(t, "request(0)->executeTask(0)", "ContextCancelError", ipldutil.ContextCancelError{}.Error(), false)
@@ -1203,8 +1203,8 @@ func TestGraphsyncRoundTripAlternatePersistenceAndNodes(t *testing.T) {
 	require.Contains(t, traceStrings, "request(1)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(1)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(1)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(1)->verifyBlock(0)")                            // should have one of these per block (TODO: why request(1) and not (0)?)
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(1)->verifyBlock(0)")                             // should have one of these per block (TODO: why request(1) and not (0)?)
 
 	// TODO(rvagg): this is randomly either a SkipMe or a ipldutil.ContextCancelError; confirm this is sane
 	// tracing.SingleExceptionEvent(t, "request(0)->newRequest(0)","request(0)->executeTask(0)", "SkipMe", traversal.SkipMe{}.Error(), true)
@@ -1291,8 +1291,8 @@ func TestGraphsyncRoundTripMultipleAlternatePersistence(t *testing.T) {
 	require.Contains(t, traceStrings, "request(1)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(1)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(1)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 }
 
 // TestRoundTripLargeBlocksSlowNetwork test verifies graphsync continues to work
@@ -1349,7 +1349,7 @@ func TestRoundTripLargeBlocksSlowNetwork(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", blockChainLength)...,
 	), tracing.TracesToStrings())
 }
@@ -1485,8 +1485,8 @@ func TestUnixFSFetch(t *testing.T) {
 	require.Contains(t, traceStrings, "request(0)->newRequest(0)")
 	require.Contains(t, traceStrings, "request(0)->executeTask(0)")
 	require.Contains(t, traceStrings, "request(0)->terminateRequest(0)")
-	require.Contains(t, traceStrings, "responseMessage(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
-	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                            // should have one of these per block
+	require.Contains(t, traceStrings, "processResponses(0)->loaderProcess(0)->cacheProcess(0)") // should have one of these per response
+	require.Contains(t, traceStrings, "request(0)->verifyBlock(0)")                             // should have one of these per block
 }
 
 func TestGraphsyncBlockListeners(t *testing.T) {
@@ -1585,7 +1585,7 @@ func TestGraphsyncBlockListeners(t *testing.T) {
 			"request(0)->executeTask(0)",
 			"request(0)->terminateRequest(0)",
 		},
-		responseMessageTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 100)...,
 	), tracing.TracesToStrings())
 }
@@ -1724,12 +1724,12 @@ func (r *receiver) Connected(p peer.ID) {
 func (r *receiver) Disconnected(p peer.ID) {
 }
 
-func responseMessageTraces(t *testing.T, tracing *testutil.Collector, responseCount int) []string {
-	traces := testutil.RepeatTraceStrings("responseMessage({})->loaderProcess(0)->cacheProcess(0)", responseCount-1)
-	finalStub := tracing.FindSpanByTraceString(fmt.Sprintf("responseMessage(%d)->loaderProcess(0)", responseCount-1))
+func processResponsesTraces(t *testing.T, tracing *testutil.Collector, responseCount int) []string {
+	traces := testutil.RepeatTraceStrings("processResponses({})->loaderProcess(0)->cacheProcess(0)", responseCount-1)
+	finalStub := tracing.FindSpanByTraceString(fmt.Sprintf("processResponses(%d)->loaderProcess(0)", responseCount-1))
 	require.NotNil(t, finalStub)
 	if len(testutil.AttributeValueInTraceSpan(t, *finalStub, "requestIDs").AsInt64Slice()) == 0 {
-		return append(traces, fmt.Sprintf("responseMessage(%d)->loaderProcess(0)", responseCount-1))
+		return append(traces, fmt.Sprintf("processResponses(%d)->loaderProcess(0)", responseCount-1))
 	}
-	return append(traces, fmt.Sprintf("responseMessage(%d)->loaderProcess(0)->cacheProcess(0)", responseCount-1))
+	return append(traces, fmt.Sprintf("processResponses(%d)->loaderProcess(0)->cacheProcess(0)", responseCount-1))
 }

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -556,7 +556,7 @@ func TestGraphsyncRoundTripIgnoreCids(t *testing.T) {
 		"request(0)->executeTask(0)",
 		"request(0)->terminateRequest(0)",
 	},
-    processResponsesTraces(t, tracing, responseCount)...),
+		processResponsesTraces(t, tracing, responseCount)...),
 		testutil.RepeatTraceStrings("message({})->sendMessage(0)", responseCount+1)...),
 		testutil.RepeatTraceStrings("request(0)->verifyBlock({})", 50)...), // half of the full chain
 		testutil.RepeatTraceStrings("response(0)->executeTask(0)->processBlock({})->loadBlock(0)", blockChainLength)...),

--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -290,7 +290,7 @@ func (rm *RequestManager) CancelRequest(ctx context.Context, requestID graphsync
 // and updates the in progress requests based on those responses.
 func (rm *RequestManager) ProcessResponses(p peer.ID, responses []gsmsg.GraphSyncResponse,
 	blks []blocks.Block) {
-	rm.send(&processResponseMessage{p, responses, blks}, nil)
+	rm.send(&processResponsesMessage{p, responses, blks}, nil)
 }
 
 // UnpauseRequest unpauses a request that was paused in a block hook based request ID

--- a/requestmanager/messages.go
+++ b/requestmanager/messages.go
@@ -40,14 +40,14 @@ func (urm *unpauseRequestMessage) handle(rm *RequestManager) {
 	}
 }
 
-type processResponseMessage struct {
+type processResponsesMessage struct {
 	p         peer.ID
 	responses []gsmsg.GraphSyncResponse
 	blks      []blocks.Block
 }
 
-func (prm *processResponseMessage) handle(rm *RequestManager) {
-	rm.processResponseMessage(prm.p, prm.responses, prm.blks)
+func (prm *processResponsesMessage) handle(rm *RequestManager) {
+	rm.processResponses(prm.p, prm.responses, prm.blks)
 }
 
 type cancelRequestMessage struct {

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -262,13 +262,13 @@ func (rm *RequestManager) cancelOnError(requestID graphsync.RequestID, ipr *inPr
 	}
 }
 
-func (rm *RequestManager) processResponseMessage(p peer.ID, responses []gsmsg.GraphSyncResponse, blks []blocks.Block) {
-	log.Debugf("beging rocessing message for peer %s", p)
+func (rm *RequestManager) processResponses(p peer.ID, responses []gsmsg.GraphSyncResponse, blks []blocks.Block) {
+	log.Debugf("beginning processing responses for peer %s", p)
 	requestIds := make([]int, 0, len(responses))
 	for _, r := range responses {
 		requestIds = append(requestIds, int(r.RequestID()))
 	}
-	ctx, span := otel.Tracer("graphsync").Start(rm.ctx, "responseMessage", trace.WithAttributes(
+	ctx, span := otel.Tracer("graphsync").Start(rm.ctx, "processResponses", trace.WithAttributes(
 		attribute.String("peerID", p.Pretty()),
 		attribute.IntSlice("requestIDs", requestIds),
 	))
@@ -279,7 +279,7 @@ func (rm *RequestManager) processResponseMessage(p peer.ID, responses []gsmsg.Gr
 	responseMetadata := metadataForResponses(filteredResponses)
 	rm.asyncLoader.ProcessResponse(ctx, responseMetadata, blks)
 	rm.processTerminations(filteredResponses)
-	log.Debugf("end processing message for peer %s", p)
+	log.Debugf("end processing responses for peer %s", p)
 }
 
 func (rm *RequestManager) filterResponsesForPeer(responses []gsmsg.GraphSyncResponse, p peer.ID) []gsmsg.GraphSyncResponse {


### PR DESCRIPTION
This is just a consistency thing that I noticed while working on internal docs for the requestmanager code. In all other cases, the name of the public API in client.go matches a private version in server.go, just lower cased, and the message between them just has `Message` appended to the end. In this case, `ProcessResponses` maps to `processResponseMessage` which is also the name of the message that invokes it. So I've made the private `processResponses` and the message `processResponsesMessage`. The tracing span name, and some logging text also changes too to be consistent.