### PR TITLE
Use do not send blocks for pause/resume & prevent processing of blocks on cancelled requests

### DIFF
--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/hannahhoward/go-pubsub"
 	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	"github.com/ipld/go-ipld-prime"
@@ -46,23 +45,23 @@ const (
 )
 
 type inProgressRequestStatus struct {
-	ctx              context.Context
-	span             trace.Span
-	startTime        time.Time
-	cancelFn         func()
-	p                peer.ID
-	terminalError    error
-	pauseMessages    chan struct{}
-	state            graphsync.RequestState
-	lastResponse     atomic.Value
-	onTerminated     []chan<- error
-	request          gsmsg.GraphSyncRequest
-	doNotSendCids    *cid.Set
-	nodeStyleChooser traversal.LinkTargetNodePrototypeChooser
-	inProgressChan   chan graphsync.ResponseProgress
-	inProgressErr    chan error
-	traverser        ipldutil.Traverser
-	traverserCancel  context.CancelFunc
+	ctx                  context.Context
+	span                 trace.Span
+	startTime            time.Time
+	cancelFn             func()
+	p                    peer.ID
+	terminalError        error
+	pauseMessages        chan struct{}
+	state                graphsync.RequestState
+	lastResponse         atomic.Value
+	onTerminated         []chan<- error
+	request              gsmsg.GraphSyncRequest
+	doNotSendFirstBlocks int64
+	nodeStyleChooser     traversal.LinkTargetNodePrototypeChooser
+	inProgressChan       chan graphsync.ResponseProgress
+	inProgressErr        chan error
+	traverser            ipldutil.Traverser
+	traverserCancel      context.CancelFunc
 }
 
 // PeerHandler is an interface that can send requests to peers

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -5,11 +5,9 @@ import (
 	"context"
 	"sync/atomic"
 
-	"github.com/ipfs/go-cid"
 	logging "github.com/ipfs/go-log/v2"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	"github.com/ipld/go-ipld-prime"
-	cidlink "github.com/ipld/go-ipld-prime/linking/cid"
 	"github.com/ipld/go-ipld-prime/traversal"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"go.opentelemetry.io/otel"
@@ -17,7 +15,7 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-graphsync/cidset"
+	"github.com/ipfs/go-graphsync/donotsendfirstblocks"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/requestmanager/hooks"
@@ -102,17 +100,17 @@ func (e *Executor) ExecuteTask(ctx context.Context, pid peer.ID, task *peertask.
 
 // RequestTask are parameters for a single request execution
 type RequestTask struct {
-	Ctx            context.Context
-	Span           trace.Span
-	Request        gsmsg.GraphSyncRequest
-	LastResponse   *atomic.Value
-	DoNotSendCids  *cid.Set
-	PauseMessages  <-chan struct{}
-	Traverser      ipldutil.Traverser
-	P              peer.ID
-	InProgressErr  chan error
-	Empty          bool
-	InitialRequest bool
+	Ctx                  context.Context
+	Span                 trace.Span
+	Request              gsmsg.GraphSyncRequest
+	LastResponse         *atomic.Value
+	DoNotSendFirstBlocks int64
+	PauseMessages        <-chan struct{}
+	Traverser            ipldutil.Traverser
+	P                    peer.ID
+	InProgressErr        chan error
+	Empty                bool
+	InitialRequest       bool
 }
 
 func (e *Executor) traverse(rt RequestTask) error {
@@ -152,17 +150,16 @@ func (e *Executor) traverse(rt RequestTask) error {
 			}
 		}
 		log.Debugf("successfully loaded link=%s, nBlocksRead=%d", lnk, rt.Traverser.NBlocksTraversed())
-
-		// check for interrupts and run block hooks
-		processErr := e.processResult(rt, lnk, result)
-
 		// advance the traversal based on results
 		err = e.advanceTraversal(rt, result)
 		if err != nil {
 			return err
 		}
-		if processErr != nil {
-			return processErr
+
+		// check for interrupts and run block hooks
+		err = e.processResult(rt, lnk, result)
+		if err != nil {
+			return err
 		}
 
 	}
@@ -178,7 +175,6 @@ func (e *Executor) processBlockHooks(p peer.ID, response graphsync.ResponseData,
 }
 
 func (e *Executor) onNewBlock(rt RequestTask, block graphsync.BlockData) error {
-	rt.DoNotSendCids.Add(block.Link().(cidlink.Link).Cid)
 	response := rt.LastResponse.Load().(gsmsg.GraphSyncResponse)
 	return e.processBlockHooks(rt.P, response, block)
 }
@@ -205,7 +201,7 @@ func (e *Executor) advanceTraversal(rt RequestTask, result types.AsyncLoadResult
 func (e *Executor) processResult(rt RequestTask, link ipld.Link, result types.AsyncLoadResult) error {
 	var err error
 	if result.Err == nil {
-		err = e.onNewBlock(rt, &blockData{link, result.Local, uint64(len(result.Data)), int64(rt.Traverser.NBlocksTraversed()+1)})
+		err = e.onNewBlock(rt, &blockData{link, result.Local, uint64(len(result.Data)), int64(rt.Traverser.NBlocksTraversed())})
 	}
 	select {
 	case <-rt.PauseMessages:
@@ -219,12 +215,16 @@ func (e *Executor) processResult(rt RequestTask, link ipld.Link, result types.As
 
 func (e *Executor) startRemoteRequest(rt RequestTask) error {
 	request := rt.Request
-	if rt.DoNotSendCids.Len() > 0 {
-		cidsData, err := cidset.EncodeCidSet(rt.DoNotSendCids)
+	doNotSendFirstBlocks := rt.DoNotSendFirstBlocks
+	if doNotSendFirstBlocks < int64(rt.Traverser.NBlocksTraversed()) {
+		doNotSendFirstBlocks = int64(rt.Traverser.NBlocksTraversed())
+	}
+	if doNotSendFirstBlocks > 0 {
+		doNotSendFirstBlocksData, err := donotsendfirstblocks.EncodeDoNotSendFirstBlocks(doNotSendFirstBlocks)
 		if err != nil {
 			return err
 		}
-		request = rt.Request.ReplaceExtensions([]graphsync.ExtensionData{{Name: graphsync.ExtensionDoNotSendCIDs, Data: cidsData}})
+		request = rt.Request.ReplaceExtensions([]graphsync.ExtensionData{{Name: graphsync.ExtensionsDoNotSendFirstBlocks, Data: doNotSendFirstBlocksData}})
 	}
 	log.Debugw("starting remote request", "id", rt.Request.ID(), "peer", rt.P.String(), "root_cid", rt.Request.Root().String())
 	e.manager.SendRequest(rt.P, request)

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/dedupkey"
+	"github.com/ipfs/go-graphsync/donotsendfirstblocks"
 	"github.com/ipfs/go-graphsync/listeners"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/messagequeue"
@@ -877,10 +877,10 @@ func TestPauseResume(t *testing.T) {
 
 	// verify the correct new request with Do-no-send-cids & other extensions
 	resumedRequest := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
-	doNotSendCidsData, has := resumedRequest.gsr.Extension(graphsync.ExtensionDoNotSendCIDs)
-	doNotSendCids, err := cidset.DecodeCidSet(doNotSendCidsData)
+	doNotSendFirstBlocksData, has := resumedRequest.gsr.Extension(graphsync.ExtensionsDoNotSendFirstBlocks)
+	doNotSendFirstBlocks, err := donotsendfirstblocks.DecodeDoNotSendFirstBlocks(doNotSendFirstBlocksData)
 	require.NoError(t, err)
-	require.Equal(t, pauseAt, doNotSendCids.Len())
+	require.Equal(t, pauseAt, int(doNotSendFirstBlocks))
 	require.True(t, has)
 	ext1Data, has := resumedRequest.gsr.Extension(td.extensionName1)
 	require.True(t, has)
@@ -957,10 +957,10 @@ func TestPauseResumeExternal(t *testing.T) {
 
 	// verify the correct new request with Do-no-send-cids & other extensions
 	resumedRequest := readNNetworkRequests(requestCtx, t, td.requestRecordChan, 1)[0]
-	doNotSendCidsData, has := resumedRequest.gsr.Extension(graphsync.ExtensionDoNotSendCIDs)
-	doNotSendCids, err := cidset.DecodeCidSet(doNotSendCidsData)
+	doNotSendFirstBlocksData, has := resumedRequest.gsr.Extension(graphsync.ExtensionsDoNotSendFirstBlocks)
+	doNotSendFirstBlocks, err := donotsendfirstblocks.DecodeDoNotSendFirstBlocks(doNotSendFirstBlocksData)
 	require.NoError(t, err)
-	require.Equal(t, pauseAt, doNotSendCids.Len())
+	require.Equal(t, pauseAt, int(doNotSendFirstBlocks))
 	require.True(t, has)
 	ext1Data, has := resumedRequest.gsr.Extension(td.extensionName1)
 	require.True(t, has)

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -259,6 +259,7 @@ func (rm *RequestManager) cancelOnError(requestID graphsync.RequestID, ipr *inPr
 		rm.terminateRequest(requestID, ipr)
 	} else {
 		ipr.cancelFn()
+		rm.asyncLoader.CompleteResponsesFor(requestID)
 	}
 }
 

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	blocks "github.com/ipfs/go-block-format"
-	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-peertaskqueue/peertask"
 	"github.com/ipfs/go-peertaskqueue/peertracker"
 	"github.com/ipld/go-ipld-prime"
@@ -22,8 +21,8 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	"github.com/ipfs/go-graphsync"
-	"github.com/ipfs/go-graphsync/cidset"
 	"github.com/ipfs/go-graphsync/dedupkey"
+	"github.com/ipfs/go-graphsync/donotsendfirstblocks"
 	"github.com/ipfs/go-graphsync/ipldutil"
 	gsmsg "github.com/ipfs/go-graphsync/message"
 	"github.com/ipfs/go-graphsync/peerstate"
@@ -73,10 +72,10 @@ func (rm *RequestManager) newRequest(parentSpan trace.Span, p peer.ID, root ipld
 		rp, err := rm.singleErrorResponse(err)
 		return request, rp, err
 	}
-	doNotSendCidsData, has := request.Extension(graphsync.ExtensionDoNotSendCIDs)
-	var doNotSendCids *cid.Set
+	doNotSendFirstBlocksData, has := request.Extension(graphsync.ExtensionsDoNotSendFirstBlocks)
+	var doNotSendFirstBlocks int64
 	if has {
-		doNotSendCids, err = cidset.DecodeCidSet(doNotSendCidsData)
+		doNotSendFirstBlocks, err = donotsendfirstblocks.DecodeDoNotSendFirstBlocks(doNotSendFirstBlocksData)
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
@@ -84,23 +83,21 @@ func (rm *RequestManager) newRequest(parentSpan trace.Span, p peer.ID, root ipld
 			rp, err := rm.singleErrorResponse(err)
 			return request, rp, err
 		}
-	} else {
-		doNotSendCids = cid.NewSet()
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	requestStatus := &inProgressRequestStatus{
-		ctx:              ctx,
-		span:             parentSpan,
-		startTime:        time.Now(),
-		cancelFn:         cancel,
-		p:                p,
-		pauseMessages:    make(chan struct{}, 1),
-		doNotSendCids:    doNotSendCids,
-		request:          request,
-		state:            graphsync.Queued,
-		nodeStyleChooser: hooksResult.CustomChooser,
-		inProgressChan:   make(chan graphsync.ResponseProgress),
-		inProgressErr:    make(chan error),
+		ctx:                  ctx,
+		span:                 parentSpan,
+		startTime:            time.Now(),
+		cancelFn:             cancel,
+		p:                    p,
+		pauseMessages:        make(chan struct{}, 1),
+		doNotSendFirstBlocks: doNotSendFirstBlocks,
+		request:              request,
+		state:                graphsync.Queued,
+		nodeStyleChooser:     hooksResult.CustomChooser,
+		inProgressChan:       make(chan graphsync.ResponseProgress),
+		inProgressErr:        make(chan error),
 	}
 	requestStatus.lastResponse.Store(gsmsg.NewResponse(request.ID(), graphsync.RequestAcknowledged))
 	rm.inProgressRequestStatuses[request.ID()] = requestStatus
@@ -157,17 +154,17 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 
 	ipr.state = graphsync.Running
 	return executor.RequestTask{
-		Ctx:            ipr.ctx,
-		Span:           ipr.span,
-		Request:        ipr.request,
-		LastResponse:   &ipr.lastResponse,
-		DoNotSendCids:  ipr.doNotSendCids,
-		PauseMessages:  ipr.pauseMessages,
-		Traverser:      ipr.traverser,
-		P:              ipr.p,
-		InProgressErr:  ipr.inProgressErr,
-		InitialRequest: initialRequest,
-		Empty:          false,
+		Ctx:                  ipr.ctx,
+		Span:                 ipr.span,
+		Request:              ipr.request,
+		LastResponse:         &ipr.lastResponse,
+		DoNotSendFirstBlocks: ipr.doNotSendFirstBlocks,
+		PauseMessages:        ipr.pauseMessages,
+		Traverser:            ipr.traverser,
+		P:                    ipr.p,
+		InProgressErr:        ipr.inProgressErr,
+		InitialRequest:       initialRequest,
+		Empty:                false,
 	}
 }
 


### PR DESCRIPTION
# Goals

This PR has two small changes to remove the usage of do-not-send-cids in go-data-transfer

1. Removes usage of CID lists for graphsync's little known "pause/resume on the requestor side feature" (which works by cancelling and resending requests), moving instead to use do not send first blocks. This is almost surely not being used anyway but now its less unneccesarily memory intensive.
2. In order to be reliable about whether we're seeing blocks for the first time for go-data-transfer, we need to make sure we don't verify blocks after a request is canceled, so that when data transfer restarts, it seems the same results as from where it left off. This is probably what we should have done anyway... but it's a one line change in our cancel method.  See: https://github.com/ipfs/go-graphsync/pull/333/files#diff-71edc89e7b7c1e4f58b00139297dc49e2ddb0671d6adfe0d152d569f6ce8e398L262