### PR TITLE
fix: avoid double-encode for extension size estimation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.2.0
 	github.com/ipld/go-codec-dagpb v1.3.0
-	github.com/ipld/go-ipld-prime v0.14.5-0.20220202110753-c322674203f0
+	github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/libp2p/go-libp2p v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvB
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/ipld/go-ipld-prime v0.14.0/go.mod h1:9ASQLwUFLptCov6lIYc70GRB4V7UTyLD0IJtrDJe6ZM=
 github.com/ipld/go-ipld-prime v0.14.4/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704nH0RDcQtgTP0=
-github.com/ipld/go-ipld-prime v0.14.5-0.20220202110753-c322674203f0 h1:7X6qWhXCRVVe+eeL2XZtSgVgqKCQNwuuDAjOTE/97kg=
-github.com/ipld/go-ipld-prime v0.14.5-0.20220202110753-c322674203f0/go.mod h1:f5ls+uUY8Slf1NN6YUOeEyYe3TA/J02Rn7zw1NQTeSk=
+github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d h1:HMvFmQbipEXniV3cRdqnkrsvAlKYMjEPbvvKN3mWsDE=
+github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d/go.mod h1:f5ls+uUY8Slf1NN6YUOeEyYe3TA/J02Rn7zw1NQTeSk=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=

--- a/responsemanager/responseassembler/responseBuilder.go
+++ b/responsemanager/responseassembler/responseBuilder.go
@@ -1,7 +1,6 @@
 package responseassembler
 
 import (
-	"bytes"
 	"context"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -104,14 +103,13 @@ func (eo extensionOperation) build(builder *messagequeue.Builder) {
 }
 
 func (eo extensionOperation) size() uint64 {
-	// TODO: this incurs a double-encode, this first one is just to get the expected length;
-	// can we avoid this?
 	if eo.extension.Data == nil {
 		return 0
 	}
-	var buf bytes.Buffer
-	dagcbor.Encode(eo.extension.Data, &buf)
-	return uint64(buf.Len())
+	// any erorr produced by this call will be picked up during actual encode, so
+	// we can defer handling till then and let it be zero for now
+	len, _ := dagcbor.EncodedLength(eo.extension.Data)
+	return uint64(len)
 }
 
 type blockOperation struct {


### PR DESCRIPTION
This is draft pending merging of https://github.com/ipld/go-ipld-prime/pull/346