### PR TITLE
feat!(messagev2): tweak dag-cbor message schema

### DIFF
--- a/message/ipldbind/message.go
+++ b/message/ipldbind/message.go
@@ -18,8 +18,11 @@ type GraphSyncExtensions struct {
 
 // NewGraphSyncExtensions creates GraphSyncExtensions from either a request or
 // response object
-func NewGraphSyncExtensions(part message.MessagePartWithExtensions) GraphSyncExtensions {
+func NewGraphSyncExtensions(part message.MessagePartWithExtensions) *GraphSyncExtensions {
 	names := part.ExtensionNames()
+	if len(names) == 0 {
+		return nil
+	}
 	keys := make([]string, 0, len(names))
 	values := make(map[string]datamodel.Node, len(names))
 	for _, name := range names {
@@ -27,7 +30,7 @@ func NewGraphSyncExtensions(part message.MessagePartWithExtensions) GraphSyncExt
 		data, _ := part.Extension(graphsync.ExtensionName(name))
 		values[string(name)] = data
 	}
-	return GraphSyncExtensions{keys, values}
+	return &GraphSyncExtensions{keys, values}
 }
 
 // ToExtensionsList creates a list of graphsync.ExtensionData objects from a
@@ -45,10 +48,10 @@ func (gse GraphSyncExtensions) ToExtensionsList() []graphsync.ExtensionData {
 type GraphSyncRequest struct {
 	Id          []byte
 	RequestType graphsync.RequestType
-	Priority    graphsync.Priority
+	Priority    *graphsync.Priority
 	Root        *cid.Cid
 	Selector    *datamodel.Node
-	Extensions  GraphSyncExtensions
+	Extensions  *GraphSyncExtensions
 }
 
 // GraphSyncResponse is an struct to capture data on a response sent back
@@ -56,8 +59,8 @@ type GraphSyncRequest struct {
 type GraphSyncResponse struct {
 	Id         []byte
 	Status     graphsync.ResponseStatusCode
-	Metadata   []message.GraphSyncLinkMetadatum
-	Extensions GraphSyncExtensions
+	Metadata   *[]message.GraphSyncLinkMetadatum
+	Extensions *GraphSyncExtensions
 }
 
 // GraphSyncBlock is a container for representing extension data for bindnode,

--- a/message/ipldbind/message.go
+++ b/message/ipldbind/message.go
@@ -43,20 +43,18 @@ func (gse GraphSyncExtensions) ToExtensionsList() []graphsync.ExtensionData {
 // GraphSyncRequest is a struct to capture data on a request contained in a
 // GraphSyncMessage.
 type GraphSyncRequest struct {
-	Id []byte
-
+	Id          []byte
+	RequestType graphsync.RequestType
+	Priority    graphsync.Priority
 	Root        *cid.Cid
 	Selector    *datamodel.Node
 	Extensions  GraphSyncExtensions
-	Priority    graphsync.Priority
-	RequestType graphsync.RequestType
 }
 
 // GraphSyncResponse is an struct to capture data on a response sent back
 // in a GraphSyncMessage.
 type GraphSyncResponse struct {
-	Id []byte
-
+	Id         []byte
 	Status     graphsync.ResponseStatusCode
 	Metadata   []message.GraphSyncLinkMetadatum
 	Extensions GraphSyncExtensions
@@ -72,9 +70,13 @@ type GraphSyncBlock struct {
 // GraphSyncMessage is a container for representing extension data for bindnode,
 // it's converted to a message.GraphSyncMessage by the message translation layer
 type GraphSyncMessage struct {
-	Requests  []GraphSyncRequest
-	Responses []GraphSyncResponse
-	Blocks    []GraphSyncBlock
+	Requests  *[]GraphSyncRequest
+	Responses *[]GraphSyncResponse
+	Blocks    *[]GraphSyncBlock
+}
+
+type GraphSyncMessageRoot struct {
+	Gs2 *GraphSyncMessage
 }
 
 // NamedExtension exists just for the purpose of the constructors

--- a/message/ipldbind/schema.go
+++ b/message/ipldbind/schema.go
@@ -21,5 +21,5 @@ func init() {
 		panic(err)
 	}
 
-	Prototype.Message = bindnode.Prototype((*GraphSyncMessage)(nil), ts.TypeByName("GraphSyncMessage"))
+	Prototype.Message = bindnode.Prototype((*GraphSyncMessageRoot)(nil), ts.TypeByName("GraphSyncMessageRoot"))
 }

--- a/message/ipldbind/schema.ipldsch
+++ b/message/ipldbind/schema.ipldsch
@@ -63,28 +63,32 @@ type GraphSyncRequestType enum {
 } representation string
 
 type GraphSyncRequest struct {
-  id                GraphSyncRequestID   (rename "ID")   # unique id set on the requester side
-  root     optional Link                 (rename "Root") # a CID for the root node in the query
-  selector optional Any                  (rename "Sel")  # see https://github.com/ipld/specs/blob/master/selectors/selectors.md
-  extensions        GraphSyncExtensions  (rename "Ext")  # side channel information
-  priority          GraphSyncPriority    (rename "Pri")  # the priority (normalized). default to 1
-  requestType       GraphSyncRequestType (rename "Typ")  # the request type
-} representation map
+  id                GraphSyncRequestID   # unique id set on the requester side
+  requestType       GraphSyncRequestType # the request type
+  priority          GraphSyncPriority    # the priority (normalized). default to 1
+  root     nullable Link                 # a CID for the root node in the query
+  selector nullable Any                  # see https://github.com/ipld/specs/blob/master/selectors/selectors.md
+  extensions        GraphSyncExtensions  # side channel information
+} representation tuple
 
 type GraphSyncResponse struct {
-  id          GraphSyncRequestID          (rename "ID")   # the request id we are responding to
-  status      GraphSyncResponseStatusCode (rename "Stat") # a status code.
-  metadata    GraphSyncMetadata           (rename "Meta") # metadata about response
-  extensions  GraphSyncExtensions         (rename "Ext")  # side channel information
-} representation map
+  id          GraphSyncRequestID          # the request id we are responding to
+  status      GraphSyncResponseStatusCode # a status code.
+  metadata    GraphSyncMetadata           # metadata about response
+  extensions  GraphSyncExtensions         # side channel information
+} representation tuple
 
 type GraphSyncBlock struct {
-  prefix  Bytes (rename "Pre") # CID prefix (cid version, multicodec and multihash prefix (type + length)
-  data    Bytes (rename "Data")
-} representation map
+  prefix  Bytes # CID prefix (cid version, multicodec and multihash prefix (type + length)
+  data    Bytes
+} representation tuple
 
 type GraphSyncMessage struct {
-  requests  [GraphSyncRequest]  (rename "Reqs")
-  responses [GraphSyncResponse] (rename "Rsps")
-  blocks    [GraphSyncBlock]    (rename "Blks")
+  requests  optional [GraphSyncRequest]  (rename "req")
+  responses optional [GraphSyncResponse] (rename "rsp")
+  blocks    optional [GraphSyncBlock]    (rename "blk")
 } representation map
+
+type GraphSyncMessageRoot union {
+  | GraphSyncMessage "gs2"
+} representation keyed

--- a/message/ipldbind/schema.ipldsch
+++ b/message/ipldbind/schema.ipldsch
@@ -1,6 +1,14 @@
-type GraphSyncExtensions {String:nullable Any}
+################################################################################
+###                  GraphSync messaging protocol version 2                  ###
+################################################################################
+
+# UUID bytes
 type GraphSyncRequestID bytes
+
 type GraphSyncPriority int
+
+# Extensions as a name:data map where the data is any arbitrary, valid Node
+type GraphSyncExtensions { String : nullable Any }
 
 type GraphSyncLinkAction enum {
    # Present means the linked block was present on this machine, and is included
@@ -18,6 +26,9 @@ type GraphSyncLinkAction enum {
    # TODO: | DuplicateDAGSkipped ("s")
 } representation string
 
+# Metadata for each "link" in the DAG being communicated, each block gets one of
+# these and missing blocks also get one, with an explanation as per
+# GraphSyncLinkAction
 type GraphSyncMetadatum struct {
   link         Link
   action       GraphSyncLinkAction
@@ -57,38 +68,47 @@ type GraphSyncRequestType enum {
    | Cancel  ("c")
    # Update means the extensions contain an update about this request
    | Update  ("u")
-   # Restart means restart this request from the begging, respecting the any DoNotSendCids/DoNotSendBlocks contained
-   # in the extensions -- essentially a cancel followed by a new
+   # Restart means restart this request from the begging, respecting the any
+   # DoNotSendCids/DoNotSendBlocks contained in the extensions--essentially a
+   # cancel followed by a new
    # TODO: | Restart ("r")
 } representation string
 
 type GraphSyncRequest struct {
-  id                GraphSyncRequestID   # unique id set on the requester side
-  requestType       GraphSyncRequestType # the request type
-  priority          GraphSyncPriority    # the priority (normalized). default to 1
-  root     nullable Link                 # a CID for the root node in the query
-  selector nullable Any                  # see https://github.com/ipld/specs/blob/master/selectors/selectors.md
-  extensions        GraphSyncExtensions  # side channel information
-} representation tuple
+  id                  GraphSyncRequestID   (rename "id")   # unique id set on the requester side
+  requestType         GraphSyncRequestType (rename "type") # the request type
+  priority   optional GraphSyncPriority    (rename "pri")  # the priority (normalized). default to 1
+  root       optional Link                 (rename "root") # a CID for the root node in the query
+  selector   optional Any                  (rename "sel")  # see https://github.com/ipld/specs/blob/master/selectors/selectors.md
+  extensions optional GraphSyncExtensions  (rename "ext")  # side channel information
+} representation map
 
 type GraphSyncResponse struct {
-  id          GraphSyncRequestID          # the request id we are responding to
-  status      GraphSyncResponseStatusCode # a status code.
-  metadata    GraphSyncMetadata           # metadata about response
-  extensions  GraphSyncExtensions         # side channel information
-} representation tuple
+  id          GraphSyncRequestID           (rename "reqid") # the request id we are responding to
+  status      GraphSyncResponseStatusCode  (rename "stat")  # a status code.
+  metadata    optional GraphSyncMetadata   (rename "meta")  # metadata about response
+  extensions  optional GraphSyncExtensions (rename "ext")   # side channel information
+} representation map
 
+# Block data and CID prefix that can be used to reconstruct the entire CID from
+# the hash of the bytes
 type GraphSyncBlock struct {
   prefix  Bytes # CID prefix (cid version, multicodec and multihash prefix (type + length)
   data    Bytes
 } representation tuple
 
+# We expect each message to contain at least one of the fields, typically either
+# just requests, or responses and possibly blocks with it
 type GraphSyncMessage struct {
   requests  optional [GraphSyncRequest]  (rename "req")
   responses optional [GraphSyncResponse] (rename "rsp")
   blocks    optional [GraphSyncBlock]    (rename "blk")
 } representation map
 
+# Parent keyed union to hold the message, the root of the structure that can be
+# used to version the messaging format outside of the protocol and makes the
+# data itself more self-descriptive (i.e. `{"gs2":...` will appear at the front
+# of every msg)
 type GraphSyncMessageRoot union {
   | GraphSyncMessage "gs2"
 } representation keyed

--- a/message/v2/ipld_roundtrip_test.go
+++ b/message/v2/ipld_roundtrip_test.go
@@ -74,7 +74,7 @@ func TestIPLDRoundTrip(t *testing.T) {
 	err = dagcbor.Decode(builder, &buf)
 	require.NoError(t, err)
 	rtnode := builder.Build()
-	rtigsm := bindnode.Unwrap(rtnode).(*ipldbind.GraphSyncMessage)
+	rtigsm := bindnode.Unwrap(rtnode).(*ipldbind.GraphSyncMessageRoot)
 
 	// back to message format
 	rtgsm, err := NewMessageHandler().fromIPLD(rtigsm)

--- a/message/v2/message.go
+++ b/message/v2/message.go
@@ -49,61 +49,70 @@ func (mh *MessageHandler) FromMsgReader(_ peer.ID, r msgio.Reader) (message.Grap
 		return message.GraphSyncMessage{}, err
 	}
 	node := builder.Build()
-	ipldGSM := bindnode.Unwrap(node).(*ipldbind.GraphSyncMessage)
+	ipldGSM := bindnode.Unwrap(node).(*ipldbind.GraphSyncMessageRoot)
 	return mh.fromIPLD(ipldGSM)
 }
 
-// ToProto converts a GraphSyncMessage to its ipldbind.GraphSyncMessage equivalent
-func (mh *MessageHandler) toIPLD(gsm message.GraphSyncMessage) (*ipldbind.GraphSyncMessage, error) {
+// ToProto converts a GraphSyncMessage to its ipldbind.GraphSyncMessageRoot equivalent
+func (mh *MessageHandler) toIPLD(gsm message.GraphSyncMessage) (*ipldbind.GraphSyncMessageRoot, error) {
 	ibm := new(ipldbind.GraphSyncMessage)
 	requests := gsm.Requests()
-	ibm.Requests = make([]ipldbind.GraphSyncRequest, 0, len(requests))
-	for _, request := range requests {
-		selector := request.Selector()
-		selPtr := &selector
-		if selector == nil {
-			selPtr = nil
+	if len(requests) > 0 {
+		ibmRequests := make([]ipldbind.GraphSyncRequest, 0, len(requests))
+		for _, request := range requests {
+			selector := request.Selector()
+			selPtr := &selector
+			if selector == nil {
+				selPtr = nil
+			}
+			root := request.Root()
+			rootPtr := &root
+			if root == cid.Undef {
+				rootPtr = nil
+			}
+			ibmRequests = append(ibmRequests, ipldbind.GraphSyncRequest{
+				Id:          request.ID().Bytes(),
+				Root:        rootPtr,
+				Selector:    selPtr,
+				Priority:    request.Priority(),
+				RequestType: request.Type(),
+				Extensions:  ipldbind.NewGraphSyncExtensions(request),
+			})
 		}
-		root := request.Root()
-		rootPtr := &root
-		if root == cid.Undef {
-			rootPtr = nil
-		}
-		ibm.Requests = append(ibm.Requests, ipldbind.GraphSyncRequest{
-			Id:          request.ID().Bytes(),
-			Root:        rootPtr,
-			Selector:    selPtr,
-			Priority:    request.Priority(),
-			RequestType: request.Type(),
-			Extensions:  ipldbind.NewGraphSyncExtensions(request),
-		})
+		ibm.Requests = &ibmRequests
 	}
 
 	responses := gsm.Responses()
-	ibm.Responses = make([]ipldbind.GraphSyncResponse, 0, len(responses))
-	for _, response := range responses {
-		glsm, ok := response.Metadata().(message.GraphSyncLinkMetadata)
-		if !ok {
-			return nil, fmt.Errorf("unexpected metadata type")
+	if len(responses) > 0 {
+		ibmResponses := make([]ipldbind.GraphSyncResponse, 0, len(responses))
+		for _, response := range responses {
+			glsm, ok := response.Metadata().(message.GraphSyncLinkMetadata)
+			if !ok {
+				return nil, fmt.Errorf("unexpected metadata type")
+			}
+			ibmResponses = append(ibmResponses, ipldbind.GraphSyncResponse{
+				Id:         response.RequestID().Bytes(),
+				Status:     response.Status(),
+				Metadata:   glsm.RawMetadata(),
+				Extensions: ipldbind.NewGraphSyncExtensions(response),
+			})
 		}
-		ibm.Responses = append(ibm.Responses, ipldbind.GraphSyncResponse{
-			Id:         response.RequestID().Bytes(),
-			Status:     response.Status(),
-			Metadata:   glsm.RawMetadata(),
-			Extensions: ipldbind.NewGraphSyncExtensions(response),
-		})
+		ibm.Responses = &ibmResponses
 	}
 
 	blocks := gsm.Blocks()
-	ibm.Blocks = make([]ipldbind.GraphSyncBlock, 0, len(blocks))
-	for _, b := range blocks {
-		ibm.Blocks = append(ibm.Blocks, ipldbind.GraphSyncBlock{
-			Data:   b.RawData(),
-			Prefix: b.Cid().Prefix().Bytes(),
-		})
+	if len(blocks) > 0 {
+		ibmBlocks := make([]ipldbind.GraphSyncBlock, 0, len(blocks))
+		for _, b := range blocks {
+			ibmBlocks = append(ibmBlocks, ipldbind.GraphSyncBlock{
+				Data:   b.RawData(),
+				Prefix: b.Cid().Prefix().Bytes(),
+			})
+		}
+		ibm.Blocks = &ibmBlocks
 	}
 
-	return ibm, nil
+	return &ipldbind.GraphSyncMessageRoot{Gs2: ibm}, nil
 }
 
 // ToNet writes a GraphSyncMessage in its DAG-CBOR format to a writer,
@@ -132,68 +141,81 @@ func (mh *MessageHandler) ToNet(_ peer.ID, gsm message.GraphSyncMessage, w io.Wr
 	return err
 }
 
-// Mapping from a ipldbind.GraphSyncMessage object to a GraphSyncMessage object
-func (mh *MessageHandler) fromIPLD(ibm *ipldbind.GraphSyncMessage) (message.GraphSyncMessage, error) {
-	requests := make(map[graphsync.RequestID]message.GraphSyncRequest, len(ibm.Requests))
-	for _, req := range ibm.Requests {
-		id, err := graphsync.ParseRequestID(req.Id)
-		if err != nil {
-			return message.GraphSyncMessage{}, err
-		}
-
-		if req.RequestType == graphsync.RequestTypeCancel {
-			requests[id] = message.NewCancelRequest(id)
-			continue
-		}
-
-		if req.RequestType == graphsync.RequestTypeUpdate {
-			requests[id] = message.NewUpdateRequest(id, req.Extensions.ToExtensionsList()...)
-			continue
-		}
-
-		root := cid.Undef
-		if req.Root != nil {
-			root = *req.Root
-		}
-
-		var selector datamodel.Node
-		if req.Selector != nil {
-			selector = *req.Selector
-		}
-
-		requests[id] = message.NewRequest(id, root, selector, graphsync.Priority(req.Priority), req.Extensions.ToExtensionsList()...)
+// Mapping from a ipldbind.GraphSyncMessageRoot object to a GraphSyncMessage object
+func (mh *MessageHandler) fromIPLD(ibm *ipldbind.GraphSyncMessageRoot) (message.GraphSyncMessage, error) {
+	if ibm.Gs2 == nil {
+		return message.GraphSyncMessage{}, fmt.Errorf("invalid GraphSyncMessageRoot, no inner message")
 	}
 
-	responses := make(map[graphsync.RequestID]message.GraphSyncResponse, len(ibm.Responses))
-	for _, res := range ibm.Responses {
-		id, err := graphsync.ParseRequestID(res.Id)
-		if err != nil {
-			return message.GraphSyncMessage{}, err
+	var requests map[graphsync.RequestID]message.GraphSyncRequest
+	if ibm.Gs2.Requests != nil {
+		requests = make(map[graphsync.RequestID]message.GraphSyncRequest, len(*ibm.Gs2.Requests))
+		for _, req := range *ibm.Gs2.Requests {
+			id, err := graphsync.ParseRequestID(req.Id)
+			if err != nil {
+				return message.GraphSyncMessage{}, err
+			}
+
+			if req.RequestType == graphsync.RequestTypeCancel {
+				requests[id] = message.NewCancelRequest(id)
+				continue
+			}
+
+			if req.RequestType == graphsync.RequestTypeUpdate {
+				requests[id] = message.NewUpdateRequest(id, req.Extensions.ToExtensionsList()...)
+				continue
+			}
+
+			root := cid.Undef
+			if req.Root != nil {
+				root = *req.Root
+			}
+
+			var selector datamodel.Node
+			if req.Selector != nil {
+				selector = *req.Selector
+			}
+
+			requests[id] = message.NewRequest(id, root, selector, graphsync.Priority(req.Priority), req.Extensions.ToExtensionsList()...)
 		}
-		responses[id] = message.NewResponse(id,
-			graphsync.ResponseStatusCode(res.Status),
-			res.Metadata,
-			res.Extensions.ToExtensionsList()...)
 	}
 
-	blks := make(map[cid.Cid]blocks.Block, len(ibm.Blocks))
-	for _, b := range ibm.Blocks {
-		pref, err := cid.PrefixFromBytes(b.Prefix)
-		if err != nil {
-			return message.GraphSyncMessage{}, err
+	var responses map[graphsync.RequestID]message.GraphSyncResponse
+	if ibm.Gs2.Responses != nil {
+		responses = make(map[graphsync.RequestID]message.GraphSyncResponse, len(*ibm.Gs2.Responses))
+		for _, res := range *ibm.Gs2.Responses {
+			id, err := graphsync.ParseRequestID(res.Id)
+			if err != nil {
+				return message.GraphSyncMessage{}, err
+			}
+			responses[id] = message.NewResponse(id,
+				graphsync.ResponseStatusCode(res.Status),
+				res.Metadata,
+				res.Extensions.ToExtensionsList()...)
 		}
+	}
 
-		c, err := pref.Sum(b.Data)
-		if err != nil {
-			return message.GraphSyncMessage{}, err
+	var blks map[cid.Cid]blocks.Block
+	if ibm.Gs2.Blocks != nil {
+		blks = make(map[cid.Cid]blocks.Block, len(*ibm.Gs2.Blocks))
+		for _, b := range *ibm.Gs2.Blocks {
+			pref, err := cid.PrefixFromBytes(b.Prefix)
+			if err != nil {
+				return message.GraphSyncMessage{}, err
+			}
+
+			c, err := pref.Sum(b.Data)
+			if err != nil {
+				return message.GraphSyncMessage{}, err
+			}
+
+			blk, err := blocks.NewBlockWithCid(b.Data, c)
+			if err != nil {
+				return message.GraphSyncMessage{}, err
+			}
+
+			blks[blk.Cid()] = blk
 		}
-
-		blk, err := blocks.NewBlockWithCid(b.Data, c)
-		if err != nil {
-			return message.GraphSyncMessage{}, err
-		}
-
-		blks[blk.Cid()] = blk
 	}
 
 	return message.NewMessage(requests, responses, blks), nil

--- a/message/v2/message_test.go
+++ b/message/v2/message_test.go
@@ -53,7 +53,7 @@ func TestAppendingRequests(t *testing.T) {
 	require.NoError(t, err, "serialize to dag-cbor errored")
 	require.NoError(t, err)
 
-	gsrIpld := gsmIpld.Requests[0]
+	gsrIpld := (*gsmIpld.Gs2.Requests)[0]
 	require.Equal(t, priority, gsrIpld.Priority)
 	require.Equal(t, request.Type(), graphsync.RequestTypeNew)
 	require.Equal(t, root, *gsrIpld.Root)
@@ -105,7 +105,7 @@ func TestAppendingResponses(t *testing.T) {
 
 	gsmIpld, err := mh.toIPLD(gsm)
 	require.NoError(t, err, "serialize to dag-cbor errored")
-	gsr := gsmIpld.Responses[0]
+	gsr := (*gsmIpld.Gs2.Responses)[0]
 	// no longer equal: require.Equal(t, requestID.Bytes(), gsr.Id)
 	require.Equal(t, status, gsr.Status)
 	require.Equal(t, basicnode.NewString("test extension data"), gsr.Extensions.Values["graphsync/awesome"])
@@ -140,7 +140,7 @@ func TestAppendBlock(t *testing.T) {
 	require.NoError(t, err, "serializing to dag-cbor errored")
 
 	// assert strings are in dag-cbor message
-	for _, block := range gsmIpld.Blocks {
+	for _, block := range *gsmIpld.Gs2.Blocks {
 		s := bytes.NewBuffer(block.Data).String()
 		require.True(t, contains(strs, s))
 	}

--- a/message/v2/message_test.go
+++ b/message/v2/message_test.go
@@ -54,7 +54,7 @@ func TestAppendingRequests(t *testing.T) {
 	require.NoError(t, err)
 
 	gsrIpld := (*gsmIpld.Gs2.Requests)[0]
-	require.Equal(t, priority, gsrIpld.Priority)
+	require.Equal(t, priority, *gsrIpld.Priority)
 	require.Equal(t, request.Type(), graphsync.RequestTypeNew)
 	require.Equal(t, root, *gsrIpld.Root)
 	require.Equal(t, selector, *gsrIpld.Selector)


### PR DESCRIPTION
For:

1. Efficiency: compacting the noisy structures into tuples representations and making top-level components of a message optional.
2. Migrations: providing a secondary mechanism to lean on for versioning if we want a gentler upgrade path than libp2p protocol versioning.

Closes: https://github.com/ipfs/go-graphsync/issues/351

In terms of what this looks like, an example of an original message is in https://github.com/ipfs/go-graphsync/issues/351 and with this change the same data would look like (as dag-json):

```json
{
  "gs1": {
    "blk": [
      [
        { "/": { "bytes": "AVUSIA" } },
        { "/": { "bytes": "QgTLmh40xfCOmyCqdgkOcAILtWwMo9OvcpbNEFilESiQ/tIYSI8ITY355INftUrQRf/ZNuO/cmGwQmxRNSoJeBbtdEgruQhLSn7YrcUX8zceDgQ0tRFiXNGkF5IkPczc/ogJSw" } }
      ],
      [
        { "/": { "bytes": "AVUSIA" } },
        { "/": { "bytes": "xfPTKlWZ2kO4US4NsU11HtHWQJ2dy3rtBdbMbAmHxjTufEI28FF8INzGqZ6G5LrcAl5fXoG0WWEoUimfNvEQ6Qa6IW4ByDcDUq0ziUrrH+WNzNCC9FaSKBovz42VowZ4zaRVhw" } }
      ]
    ],
    "req": [
      [
        { "/": { "bytes": "GmIWTBeVSRyOznxIsnBumg" } },
        "n",
        101,
        { "/": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi" },
        {"R":{":>":{"|":[{".":{}},{"a":{">":{"@":{}}}}]},"l":{"none":{}}}},
        {
          "AppleSauce/McGee": "yee haw"
        }
      ],
      [
        { "/": { "bytes": "vd/PRdnYTg27RolghnknVQ" } },
        "n",
        202,
        { "/": "bafyreibdoxfay27gf4ye3t5a7aa5h4z2azw7hhhz36qrbf5qleldj76qfy" },
        {"R":{":>":{"a":{">":{"@":{}}}},"l":{"none":{}}}},
        {}
      ]
    ],
    "rsp": [
      [
        { "/": { "bytes": "GmIWTBeVSRyOznxIsnBumg" } },
        34,
        [
          [
            { "/": "bafyreibdoxfay27gf4ye3t5a7aa5h4z2azw7hhhz36qrbf5qleldj76qfy" },
            "m"
          ]
        ],
        {}
      ],
      [
        { "/": { "bytes": "vd/PRdnYTg27RolghnknVQ" } },
        14,
        [],
        {
          "Hippity+Hoppity": {   "/": {   "bytes": "9V/48SUItj7yv+ynVXrpDfYxGl7BYxtKH6hDMQvZw6cQ6qzlob3XKtC/4El3HBHnVjOL2Thl5kXxreybnJnvQH+9T8aFnnkExa19yb0QpcwWlz1bKOwabdQ9n4L58Yw9A0GONQ"   }   }
        }
      ]
    ]
  }
}
```

In terms of bytes saved, using the randomish data in TestGraphsyncRoundTrip (i.e. it has some variability in output length and these are not using exactly the same data so consider it approximate):

* v1.0 -> v1.0 protobuf original: 213 bytes written by client, 25,361 bytes written by server
* v2.0 -> v2.0 prior to this change: 271 bytes written by requestor, 23,129 bytes written by server
* v2.0 -> v2.0 with this change: 239 bytes written by client, 22,076 bytes written by server

@mvdan @warpfork care to critique my schema?

Aside: it's interesting that we're even saving bytes written by server from protobuf to dag-cbor even without these changes. The majority of the data sent should be blocks and their CIDs and all these maps with string keys should drown out any saving CBOR gets from its compact int & length representation. Plus we have v1.0 doing int request IDs and v2 doing UUID (as bytes) request IDs so they're longer. Nothing in the protobuf spec is `optional`, although I believe `repeated` allows for zero occurrences so in effect the top-level items are `optional` at least. Perhaps it's all to do with moving the metadata into the core message rather than as an extension (so we save writing the string `"graphsync/response-metadata"` on each response). An interesting mystery that might be worth investigating at some point.