### PR TITLE
feat: SendUpdates() API to send only extension data to via existing requests

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -496,6 +496,9 @@ type GraphExchange interface {
 	// Cancel cancels an in progress request or response
 	Cancel(context.Context, RequestID) error
 
+	// SendUpdate sends an update for an in progress request or response
+	SendUpdate(context.Context, RequestID, ...ExtensionData) error
+
 	// Stats produces insight on the current state of a graphsync exchange
 	Stats() Stats
 }

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -432,6 +432,16 @@ func (gs *GraphSync) Cancel(ctx context.Context, requestID graphsync.RequestID) 
 	return gs.responseManager.CancelResponse(ctx, requestID)
 }
 
+// SendUpdate sends an update for an in progress request or response
+func (gs *GraphSync) SendUpdate(ctx context.Context, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
+	// TODO: error if len(extensions)==0?
+	var reqNotFound graphsync.RequestNotFoundErr
+	if err := gs.requestManager.UpdateRequest(ctx, requestID, extensions...); !errors.As(err, &reqNotFound) {
+		return err
+	}
+	return gs.responseManager.UpdateResponse(ctx, requestID, extensions...)
+}
+
 // Stats produces insight on the current state of a graphsync exchange
 func (gs *GraphSync) Stats() graphsync.Stats {
 	outgoingRequestStats := gs.requestQueue.Stats()

--- a/requestmanager/messages.go
+++ b/requestmanager/messages.go
@@ -13,6 +13,20 @@ import (
 	"github.com/ipfs/go-graphsync/requestmanager/executor"
 )
 
+type updateRequestMessage struct {
+	id         graphsync.RequestID
+	extensions []graphsync.ExtensionData
+	response   chan<- error
+}
+
+func (urm *updateRequestMessage) handle(rm *RequestManager) {
+	err := rm.update(urm.id, urm.extensions)
+	select {
+	case <-rm.ctx.Done():
+	case urm.response <- err:
+	}
+}
+
 type pauseRequestMessage struct {
 	id       graphsync.RequestID
 	response chan<- error

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -406,6 +406,16 @@ func (rm *RequestManager) pause(id graphsync.RequestID) error {
 	return nil
 }
 
+func (rm *RequestManager) update(id graphsync.RequestID, extensions []graphsync.ExtensionData) error {
+	inProgressRequestStatus, ok := rm.inProgressRequestStatuses[id]
+	if !ok {
+		return graphsync.RequestNotFoundErr{}
+	}
+	updateRequest := gsmsg.NewUpdateRequest(id, extensions...)
+	rm.SendRequest(inProgressRequestStatus.p, updateRequest)
+	return nil
+}
+
 func (rm *RequestManager) peerStats(p peer.ID) peerstate.PeerState {
 	var peerState peerstate.PeerState
 	rm.requestQueue.WithPeerTopics(p, func(peerTopics *peertracker.PeerTrackerTopics) {

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -189,6 +189,18 @@ func (rm *ResponseManager) CancelResponse(ctx context.Context, requestID graphsy
 	}
 }
 
+// UpdateRequest updates an in progress response
+func (rm *ResponseManager) UpdateResponse(ctx context.Context, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
+	response := make(chan error, 1)
+	rm.send(&updateRequestMessage{requestID, extensions, response}, ctx.Done())
+	select {
+	case <-rm.ctx.Done():
+		return errors.New("context cancelled")
+	case err := <-response:
+		return err
+	}
+}
+
 // Synchronize is a utility method that blocks until all current messages are processed
 func (rm *ResponseManager) synchronize() {
 	sync := make(chan error)

--- a/responsemanager/messages.go
+++ b/responsemanager/messages.go
@@ -19,6 +19,20 @@ func (prm *processRequestsMessage) handle(rm *ResponseManager) {
 	rm.processRequests(prm.p, prm.requests)
 }
 
+type updateRequestMessage struct {
+	requestID  graphsync.RequestID
+	extensions []graphsync.ExtensionData
+	response   chan error
+}
+
+func (urm *updateRequestMessage) handle(rm *ResponseManager) {
+	err := rm.updateRequest(urm.requestID, urm.extensions)
+	select {
+	case <-rm.ctx.Done():
+	case urm.response <- err:
+	}
+}
+
 type pauseRequestMessage struct {
 	requestID graphsync.RequestID
 	response  chan error

--- a/responsemanager/queryexecutor/queryexecutor_test.go
+++ b/responsemanager/queryexecutor/queryexecutor_test.go
@@ -427,6 +427,9 @@ func (rb fauxResponseBuilder) SendResponse(link ipld.Link, data []byte) graphsyn
 func (rb fauxResponseBuilder) SendExtensionData(ed graphsync.ExtensionData) {
 }
 
+func (rb fauxResponseBuilder) SendUpdates(ed []graphsync.ExtensionData) {
+}
+
 func (rb fauxResponseBuilder) FinishRequest() graphsync.ResponseStatusCode {
 	return rb.finishRequest
 }

--- a/responsemanager/responseassembler/responseBuilder.go
+++ b/responsemanager/responseassembler/responseBuilder.go
@@ -51,6 +51,14 @@ func (rb *responseBuilder) PauseRequest() {
 	rb.operations = append(rb.operations, statusOperation{rb.requestID, graphsync.RequestPaused})
 }
 
+// SendUpdates sets up a PartialResponse with just the extension data provided
+func (rb *responseBuilder) SendUpdates(extensions []graphsync.ExtensionData) {
+	for _, extension := range extensions {
+		rb.SendExtensionData(extension)
+	}
+	rb.operations = append(rb.operations, statusOperation{rb.requestID, graphsync.PartialResponse})
+}
+
 func (rb *responseBuilder) Context() context.Context {
 	return rb.ctx
 }

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -37,6 +37,9 @@ type ResponseBuilder interface {
 	// SendExtensionData adds extension data to the transaction.
 	SendExtensionData(graphsync.ExtensionData)
 
+	// SendUpdates sets up a PartialResponse with just the extension data provided
+	SendUpdates([]graphsync.ExtensionData)
+
 	// FinishRequest completes the response to a request.
 	FinishRequest() graphsync.ResponseStatusCode
 

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -362,7 +362,7 @@ func (rm *ResponseManager) pauseRequest(requestID graphsync.RequestID) error {
 
 func (rm *ResponseManager) updateRequest(requestID graphsync.RequestID, extensions []graphsync.ExtensionData) error {
 	inProgressResponse, ok := rm.inProgressResponses[requestID]
-	if !ok || inProgressResponse.state == graphsync.CompletingSend {
+	if !ok {
 		return graphsync.RequestNotFoundErr{}
 	}
 	_ = inProgressResponse.responseStream.Transaction(func(rb responseassembler.ResponseBuilder) error {

--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -360,6 +360,19 @@ func (rm *ResponseManager) pauseRequest(requestID graphsync.RequestID) error {
 	return nil
 }
 
+func (rm *ResponseManager) updateRequest(requestID graphsync.RequestID, extensions []graphsync.ExtensionData) error {
+	inProgressResponse, ok := rm.inProgressResponses[requestID]
+	if !ok || inProgressResponse.state == graphsync.CompletingSend {
+		return graphsync.RequestNotFoundErr{}
+	}
+	_ = inProgressResponse.responseStream.Transaction(func(rb responseassembler.ResponseBuilder) error {
+		rb.SendUpdates(extensions)
+		return nil
+	})
+
+	return nil
+}
+
 func (rm *ResponseManager) peerState(p peer.ID) peerstate.PeerState {
 	var peerState peerstate.PeerState
 	rm.responseQueue.WithPeerTopics(p, func(peerTopics *peertracker.PeerTrackerTopics) {


### PR DESCRIPTION
Closes: https://github.com/ipfs/go-graphsync/issues/348

WIP, figuring out the testing parts of this currently