### PR TITLE
test: manual ipld garbage fuzzing on messages v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/ipfs/go-unixfs v0.3.1
 	github.com/ipfs/go-unixfsnode v1.2.0
 	github.com/ipld/go-codec-dagpb v1.3.0
-	github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d
+	github.com/ipld/go-ipld-prime v0.14.5-0.20220214151842-d62ec3674f3a
 	github.com/jbenet/go-random v0.0.0-20190219211222-123a90aedc0c
 	github.com/libp2p/go-buffer-pool v0.0.2
 	github.com/libp2p/go-libp2p v0.16.0

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,8 @@ github.com/ipld/go-ipld-prime v0.9.1-0.20210324083106-dc342a9917db/go.mod h1:KvB
 github.com/ipld/go-ipld-prime v0.11.0/go.mod h1:+WIAkokurHmZ/KwzDOMUuoeJgaRQktHtEaLglS3ZeV8=
 github.com/ipld/go-ipld-prime v0.14.0/go.mod h1:9ASQLwUFLptCov6lIYc70GRB4V7UTyLD0IJtrDJe6ZM=
 github.com/ipld/go-ipld-prime v0.14.4/go.mod h1:QcE4Y9n/ZZr8Ijg5bGPT0GqYWgZ1704nH0RDcQtgTP0=
-github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d h1:HMvFmQbipEXniV3cRdqnkrsvAlKYMjEPbvvKN3mWsDE=
-github.com/ipld/go-ipld-prime v0.14.5-0.20220204050122-679d74376a0d/go.mod h1:f5ls+uUY8Slf1NN6YUOeEyYe3TA/J02Rn7zw1NQTeSk=
+github.com/ipld/go-ipld-prime v0.14.5-0.20220214151842-d62ec3674f3a h1:H8VkPzKxtNNBveLtwvgQsCrPRlf32/KmymdeiKz7dHc=
+github.com/ipld/go-ipld-prime v0.14.5-0.20220214151842-d62ec3674f3a/go.mod h1:f5ls+uUY8Slf1NN6YUOeEyYe3TA/J02Rn7zw1NQTeSk=
 github.com/ipld/go-ipld-prime/storage/bsadapter v0.0.0-20211210234204-ce2a1c70cd73/go.mod h1:2PJ0JgxyB08t0b2WKrcuqI3di0V+5n6RS/LTUJhkoxY=
 github.com/jackpal/gateway v1.0.5/go.mod h1:lTpwd4ACLXmpyiCTRtfiNyVnUmqT9RivzCDQetPfnjA=
 github.com/jackpal/go-nat-pmp v1.0.1/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=


### PR DESCRIPTION
This might just be a temporary branch but I wanted to throw some garbage, but valid, dag-cbor at the message decoder to see how easy it was to break; it turns out it's still pretty trivial to break but I don't really understand why. So this one's for @mvdan.

Any time it comes up with a top-level map it'll panic like this:

```
panic: interface conversion: datamodel.NodeAssembler is bindnode._errorAssembler, not *bindnode._assembler [recovered]
        panic: interface conversion: datamodel.NodeAssembler is bindnode._errorAssembler, not *bindnode._assembler

goroutine 19 [running]:
testing.tRunner.func1.2(0x8cdee0, 0xc00039eea0)
        /snap/go/9026/src/testing/testing.go:1143 +0x332
testing.tRunner.func1(0xc000102a80)
        /snap/go/9026/src/testing/testing.go:1146 +0x4b6
panic(0x8cdee0, 0xc00039eea0)
        /snap/go/9026/src/runtime/panic.go:965 +0x1b9
github.com/ipld/go-ipld-prime/node/bindnode.assemblerRepr(...)
        /home/rvagg/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.14.5-0.20220214151842-d62ec3674f3a/node/bindnode/repr.go:541
github.com/ipld/go-ipld-prime/node/bindnode.(*_unionAssemblerRepr).AssembleValue(0xc0003becb0, 0xc00020dfd9, 0x3)
        /home/rvagg/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.14.5-0.20220214151842-d62ec3674f3a/node/bindnode/repr.go:960 +0x27f
github.com/ipld/go-ipld-prime/node/bindnode.(*_unionAssemblerRepr).AssembleEntry(0xc0003becb0, 0xc00020dfd9, 0x3, 0x0, 0x0, 0x0, 0xc0003bec40)
        /home/rvagg/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.14.5-0.20220214151842-d62ec3674f3a/node/bindnode/repr.go:971 +0x93
github.com/ipld/go-ipld-prime/codec/dagcbor.unmarshal2(0x7f12a0433270, 0xc0003a48c0, 0xaf69c0, 0xc0003ae230, 0xc0003bec40, 0xc000131d98, 0xdab701, 0x0, 0xc000131d48)
        /home/rvagg/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.14.5-0.20220214151842-d62ec3674f3a/codec/dagcbor/unmarshal.go:133 +0xbbe
github.com/ipld/go-ipld-prime/codec/dagcbor.unmarshal1(0x7f12a0433270, 0xc0003a48c0, 0xaf69c0, 0xc0003ae230, 0xc000131d98, 0xdab701, 0x0, 0xc000131dc0)
        /home/rvagg/go/pkg/mod/github.com/ipld/go-ipld-prime@v0.14.5-0.20220214151842-d62ec3674f3a/codec/dagcbor/unmarshal.go:85 +0x125
```

I initially started this branch on an version of the code prior to the schema changes in https://github.com/ipfs/go-graphsync/pull/354 with the same error, so it's not just due the top-level keyed union introduced there.

I was also playing around with a variation of the example posted in https://github.com/ipld/go-ipld-prime/issues/342 and was able to easily get `panic: bindnode TODO: invalid key: "J" is not a field in type Foo` if I just fed it a map with a misnamed field.