### PR TITLE
fix(responsemanager): send update while completing

### DIFF
--- a/responsemanager/server.go
+++ b/responsemanager/server.go
@@ -362,7 +362,7 @@ func (rm *ResponseManager) pauseRequest(requestID graphsync.RequestID) error {
 
 func (rm *ResponseManager) updateRequest(requestID graphsync.RequestID, extensions []graphsync.ExtensionData) error {
 	inProgressResponse, ok := rm.inProgressResponses[requestID]
-	if !ok || inProgressResponse.state == graphsync.CompletingSend {
+	if !ok {
 		return graphsync.RequestNotFoundErr{}
 	}
 	_ = inProgressResponse.responseStream.Transaction(func(rb responseassembler.ResponseBuilder) error {


### PR DESCRIPTION
If request has finished selector traversal but is still sending blocks,
I think it should be possible to send updates. As a side effect, this
fixes our test race.

Logically, this makes sense, cause our external indicator that we're
done (completed response listener) has not been called.