### PR TITLE
Minimal alternate metadata type support

### DIFF
--- a/graphsync.go
+++ b/graphsync.go
@@ -227,10 +227,24 @@ const (
 	// is included a this message
 	LinkActionPresent = LinkAction("Present")
 
+	// LinkActionDuplicateNotSent means the linked block was present on this machine,
+	// but I am not sending it (most likely duplicate)
+	LinkActionDuplicateNotSent = LinkAction("DuplicateNotSent")
+
 	// LinkActionMissing means I did not have the linked block, so I skipped over
 	// this part of the traversal
 	LinkActionMissing = LinkAction("Missing")
+
+	// LinkActionDuplicateDAGSkipped means the DAG with this link points toward has already
+	// been traversed entirely in the course of this request so I am skipping over it entirely
+	LinkActionDuplicateDAGSkipped = LinkAction("DuplicateDAGSkipped")
 )
+
+// DidFollowLink indicates whether the remote actually loaded the block and
+// followed it in its selector traversal
+func (l LinkAction) DidFollowLink() bool {
+	return l == LinkActionPresent || l == LinkActionDuplicateNotSent
+}
 
 // LinkMetadataIterator is used to access individual link metadata through a
 // LinkMetadata object

--- a/graphsync.go
+++ b/graphsync.go
@@ -236,7 +236,7 @@ const (
 	LinkActionMissing = LinkAction("Missing")
 
 	// LinkActionDuplicateDAGSkipped means the DAG with this link points toward has already
-	// been traversed entirely in the course of this request so I am skipping over it entirely
+	// been traversed entirely in the course of this request so I am skipping over it
 	LinkActionDuplicateDAGSkipped = LinkAction("DuplicateDAGSkipped")
 )
 

--- a/message/builder_test.go
+++ b/message/builder_test.go
@@ -60,7 +60,7 @@ func TestMessageBuilding(t *testing.T) {
 				rb.AddResponseCode(requestID2, graphsync.RequestCompletedFull)
 
 				rb.AddLink(requestID3, links[0], graphsync.LinkActionPresent)
-				rb.AddLink(requestID3, links[1], graphsync.LinkActionPresent)
+				rb.AddLink(requestID3, links[1], graphsync.LinkActionDuplicateNotSent)
 
 				rb.AddResponseCode(requestID4, graphsync.RequestCompletedFull)
 				rb.AddExtensionData(requestID1, extension1)
@@ -101,7 +101,7 @@ func TestMessageBuilding(t *testing.T) {
 				require.Equal(t, graphsync.PartialResponse, response3.Status(), "did not generate partial response")
 				assertMetadata(t, response3, []GraphSyncLinkMetadatum{
 					{Link: links[0].(cidlink.Link).Cid, Action: graphsync.LinkActionPresent},
-					{Link: links[1].(cidlink.Link).Cid, Action: graphsync.LinkActionPresent},
+					{Link: links[1].(cidlink.Link).Cid, Action: graphsync.LinkActionDuplicateNotSent},
 				})
 				assertExtension(t, response3, extension2)
 

--- a/message/ipldbind/schema.ipldsch
+++ b/message/ipldbind/schema.ipldsch
@@ -16,14 +16,14 @@ type GraphSyncLinkAction enum {
    | Present             ("p")
    # DuplicateNotSent means the linked block was present on this machine, but I
    # am not sending it (most likely duplicate)
-   # TODO: | DuplicateNotSent   ("d")
+   | DuplicateNotSent   ("d")
    # Missing means I did not have the linked block, so I skipped over this part
    # of the traversal
    | Missing             ("m")
    # DuplicateDAGSkipped means the DAG with this link points toward has already
    # been traversed entirely in the course of this request
    # so I am skipping over it entirely
-   # TODO: | DuplicateDAGSkipped ("s")
+   | DuplicateDAGSkipped ("s")
 } representation string
 
 # Metadata for each "link" in the DAG being communicated, each block gets one of

--- a/requestmanager/reconciledloader/load.go
+++ b/requestmanager/reconciledloader/load.go
@@ -53,7 +53,7 @@ func (rl *ReconciledLoader) blockReadOpener(lctx linking.LinkContext, link datam
 	}
 
 	// only attempt remote load if after reconciliation we're not on a missing path
-	if !rl.pathTracker.stillOnMissingRemotePath(lctx.LinkPath) {
+	if !rl.pathTracker.stillOnUnfollowedRemotePath(lctx.LinkPath) {
 		data, err := rl.loadRemote(lctx, link)
 		if data != nil {
 			return true, types.AsyncLoadResult{Data: data, Local: false}
@@ -164,7 +164,7 @@ func (rl *ReconciledLoader) waitRemote() (bool, error) {
 			path := rl.verifier.CurrentPath()
 			head := rl.remoteQueue.first()
 			rl.remoteQueue.consume()
-			err := rl.verifier.VerifyNext(head.link, head.action != graphsync.LinkActionMissing)
+			err := rl.verifier.VerifyNext(head.link, head.action.DidFollowLink())
 			if err != nil {
 				return true, err
 			}

--- a/requestmanager/reconciledloader/pathtracker.go
+++ b/requestmanager/reconciledloader/pathtracker.go
@@ -8,22 +8,22 @@ import (
 // pathTracker is just a simple utility to track whether we're on a missing
 // path for the remote
 type pathTracker struct {
-	lastMissingRemotePath datamodel.Path
+	lastUnfollowedRemotePath datamodel.Path
 }
 
-// stillOnMissingRemotePath determines whether the next link load will be from
+// stillOnUnfollowedRemotePath determines whether the next link load will be from
 // a path missing from the remote
 // if it won't be, based on the linear nature of selector traversals, it wipes
 // the last missing state
-func (pt *pathTracker) stillOnMissingRemotePath(newPath datamodel.Path) bool {
+func (pt *pathTracker) stillOnUnfollowedRemotePath(newPath datamodel.Path) bool {
 	// is there a known missing path?
-	if pt.lastMissingRemotePath.Len() == 0 {
+	if pt.lastUnfollowedRemotePath.Len() == 0 {
 		return false
 	}
 	// are we still on it?
-	if newPath.Len() <= pt.lastMissingRemotePath.Len() {
+	if newPath.Len() <= pt.lastUnfollowedRemotePath.Len() {
 		// if not, reset to no known missing remote path
-		pt.lastMissingRemotePath = datamodel.NewPath(nil)
+		pt.lastUnfollowedRemotePath = datamodel.NewPath(nil)
 		return false
 	}
 	// otherwise we're on a missing path
@@ -34,8 +34,8 @@ func (pt *pathTracker) stillOnMissingRemotePath(newPath datamodel.Path) bool {
 // at the given path
 func (pt *pathTracker) recordRemoteLoadAttempt(currentPath datamodel.Path, action graphsync.LinkAction) {
 	// if the last remote link was missing
-	if action == graphsync.LinkActionMissing {
+	if !action.DidFollowLink() {
 		// record the last known missing path
-		pt.lastMissingRemotePath = currentPath
+		pt.lastUnfollowedRemotePath = currentPath
 	}
 }

--- a/requestmanager/reconciledloader/reconciledloader_test.go
+++ b/requestmanager/reconciledloader/reconciledloader_test.go
@@ -382,7 +382,7 @@ func TestReconciledLoader(t *testing.T) {
 				syncLoad{loadSeq: 7, expectedResult: types.AsyncLoadResult{Local: true, Data: testTree.LeafAlphaBlock.RawData()}},
 			},
 		},
-		"remote duplicate not sentblocks can load from local": {
+		"remote duplicate not sent, blocks can load from local": {
 			root:      testTree.RootBlock.Cid(),
 			baseStore: testTree.Storage,
 			presentRemoteBlocks: []blocks.Block{


### PR DESCRIPTION
# Goals

Avoid a future upgrade to metadata types by supporting simple handling in the client

# Implementation

- Uncomment remaining types on metadata
- Add simple handling in the client for DuplicateNotSent and DuplicateDAGSkipped -- while these two things very different things than Present/Missing:
   - DuplicateDAGSkipped can essentially be treated with the new ReconciledLoader like a Missing -- just switch to a local loading only mode till you exit this branch.
   - DuplicateNotSent can be treated exactly like Present with no block contained in the message, with one caveat: it treats the block as a duplicate even if it is contained in the message. There are certain scenarios (using ExtensionDeDupByKey for example) where this may be useful information that helps us avoid holding a received block in memory longer than needed. (I am still open to the idea though that we should merge this w/o DuplicateNotSent and not add this until there's a super clear use case why we actually need this an not just imply it via the presence of a block in the message)
- By only doing this super minimal client implementation:
   - We avoid downgrading compatibility issues with the v1 protocol till its deprecated
   - We can implement a server version and possibly upgrade the client in the future (for a client that also skips duplicate DAGs), but continue to talk to old clients with no change.