### PR TITLE
Restore immediate request sends, make local only fulfillment optional

### DIFF
--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -90,6 +90,9 @@ type RequestManager struct {
 	// maximum number of links to traverse per request. A value of zero = infinity, or no limit
 	maxLinksPerRequest uint64
 
+	// when true,
+	onlySendRemoteRequestWhenNeccesary bool
+
 	// dont touch out side of run loop
 	inProgressRequestStatuses          map[graphsync.RequestID]*inProgressRequestStatus
 	requestHooks                       RequestHooks
@@ -124,6 +127,7 @@ func New(ctx context.Context,
 	requestQueue taskqueue.TaskQueue,
 	connManager network.ConnManager,
 	maxLinksPerRequest uint64,
+	onlySendRemoteRequestWhenNeccesary bool,
 ) *RequestManager {
 	ctx, cancel := context.WithCancel(ctx)
 	return &RequestManager{
@@ -142,6 +146,7 @@ func New(ctx context.Context,
 		requestQueue:                       requestQueue,
 		connManager:                        connManager,
 		maxLinksPerRequest:                 maxLinksPerRequest,
+		onlySendRemoteRequestWhenNeccesary: onlySendRemoteRequestWhenNeccesary,
 	}
 }
 

--- a/requestmanager/executor/executor_test.go
+++ b/requestmanager/executor/executor_test.go
@@ -364,16 +364,17 @@ func (ree *requestExecutionEnv) GetRequestTask(_ peer.ID, _ *peertask.Task, requ
 	lastResponse.Store(gsmsg.NewResponse(ree.request.ID(), graphsync.RequestAcknowledged, nil))
 
 	requestExecution := executor.RequestTask{
-		Ctx:                  ree.ctx,
-		Request:              ree.request,
-		LastResponse:         &lastResponse,
-		DoNotSendFirstBlocks: ree.doNotSendFirstBlocks,
-		PauseMessages:        ree.pauseMessages,
-		Traverser:            ree.traverser,
-		P:                    ree.p,
-		InProgressErr:        ree.inProgressErr,
-		Empty:                false,
-		ReconciledLoader:     ree.reconciledLoader,
+		Ctx:                    ree.ctx,
+		Request:                ree.request,
+		LastResponse:           &lastResponse,
+		DoNotSendFirstBlocks:   ree.doNotSendFirstBlocks,
+		PauseMessages:          ree.pauseMessages,
+		Traverser:              ree.traverser,
+		P:                      ree.p,
+		InProgressErr:          ree.inProgressErr,
+		Empty:                  false,
+		SendRequestImmediately: ree.initialRequest,
+		ReconciledLoader:       ree.reconciledLoader,
 	}
 	go func() {
 		select {

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -120,7 +120,12 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 	}
 	log.Infow("graphsync request processing begins", "request id", requestID.String(), "peer", ipr.p, "total time", time.Since(ipr.startTime))
 
+	var sendRequestImmediately bool
 	if ipr.traverser == nil {
+		if !rm.onlySendRemoteRequestWhenNeccesary {
+			sendRequestImmediately = true
+		}
+
 		var budget *traversal.Budget
 		if rm.maxLinksPerRequest > 0 {
 			budget = &traversal.Budget{
@@ -169,17 +174,18 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 
 	ipr.state = graphsync.Running
 	return executor.RequestTask{
-		Ctx:                  ipr.ctx,
-		Span:                 ipr.span,
-		Request:              ipr.request,
-		LastResponse:         &ipr.lastResponse,
-		DoNotSendFirstBlocks: ipr.doNotSendFirstBlocks,
-		PauseMessages:        ipr.pauseMessages,
-		Traverser:            ipr.traverser,
-		P:                    ipr.p,
-		InProgressErr:        ipr.inProgressErr,
-		ReconciledLoader:     ipr.reconciledLoader,
-		Empty:                false,
+		Ctx:                    ipr.ctx,
+		Span:                   ipr.span,
+		Request:                ipr.request,
+		LastResponse:           &ipr.lastResponse,
+		DoNotSendFirstBlocks:   ipr.doNotSendFirstBlocks,
+		PauseMessages:          ipr.pauseMessages,
+		Traverser:              ipr.traverser,
+		P:                      ipr.p,
+		InProgressErr:          ipr.inProgressErr,
+		ReconciledLoader:       ipr.reconciledLoader,
+		Empty:                  false,
+		SendRequestImmediately: sendRequestImmediately,
 	}
 }
 


### PR DESCRIPTION
# Goals

Upon further inspection, never sending graphsync requests we fulfill entirely locally presents several problems for go-data-transfer, as an entirely locally fulfilled request will never send the messages to initiate data transfer. This PR temporarily puts back in sending an immediate remote request as the default while we consider the implications and ideal approach to supporting local-only fulfilled requests at the data transfer level.

# Implementation

- Restore executor's former "InitialRequest" parameter, now called send request immediately
- Add an optional configuration parameter in initailization to enable local only fulfilled requests
