### PR TITLE
fix(network): show what causes the test failure

### DIFF
--- a/network/libp2p_impl.go
+++ b/network/libp2p_impl.go
@@ -195,6 +195,8 @@ func (gsnet *libp2pGraphSyncNetwork) SendMessage(
 		return err
 	}
 
+	time.Sleep(100 * time.Millisecond)
+
 	return s.Close()
 }
 


### PR DESCRIPTION
# Goals

Diagnose issue in test failure after upgrading libp2p from 0.16.1 -> 0.20.1. Issue affects 0.19.4 as well.

# Implementation

it appears calling stream.Close() too quickly returns an error? Adding a sleep fixes the problem. However, I don't understand why stream.Close would emit an error if you call it right after sending data.

cc: @marten-seemann @aschmahmann 