### PR TITLE
Fix potential lock on context cancel

### DIFF
--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -191,6 +191,8 @@ func (rm *RequestManager) NewRequest(ctx context.Context,
 	select {
 	case <-rm.ctx.Done():
 		return rm.emptyResponse()
+	case <-ctx.Done():
+		return rm.emptyResponse()
 	case receivedInProgressRequest = <-inProgressRequestChan:
 	}
 
@@ -284,6 +286,8 @@ func (rm *RequestManager) CancelRequest(ctx context.Context, requestID graphsync
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
+	case <-ctx.Done():
+		return errors.New("context cancelled")
 	case err := <-terminated:
 		return err
 	}
@@ -306,6 +310,8 @@ func (rm *RequestManager) UnpauseRequest(ctx context.Context, requestID graphsyn
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
+	case <-ctx.Done():
+		return errors.New("context cancelled")
 	case err := <-response:
 		return err
 	}
@@ -318,6 +324,8 @@ func (rm *RequestManager) PauseRequest(ctx context.Context, requestID graphsync.
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
+	case <-ctx.Done():
+		return errors.New("context cancelled")
 	case err := <-response:
 		return err
 	}
@@ -329,6 +337,8 @@ func (rm *RequestManager) UpdateRequest(ctx context.Context, requestID graphsync
 	rm.send(&updateRequestMessage{requestID, extensions, response}, ctx.Done())
 	select {
 	case <-rm.ctx.Done():
+		return errors.New("context cancelled")
+	case <-ctx.Done():
 		return errors.New("context cancelled")
 	case err := <-response:
 		return err

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -181,6 +181,21 @@ func TestCancelRequestImperativeNoMoreBlocks(t *testing.T) {
 	require.True(t, ok)
 }
 
+func TestCommandsWithCancelledContext(t *testing.T) {
+	ctx := context.Background()
+	managerCtx, managerCancel := context.WithCancel(ctx)
+	defer managerCancel()
+	td := newTestData(managerCtx, t)
+	peers := testutil.GeneratePeers(1)
+
+	cancelledCtx, cancel := context.WithCancel(ctx)
+	cancel()
+
+	returnedResponseChan, returnedErrorChan := td.requestManager.NewRequest(cancelledCtx, peers[0], td.blockChain.TipLink, td.blockChain.Selector())
+	testutil.VerifyEmptyErrors(managerCtx, t, returnedErrorChan)
+	testutil.VerifyEmptyResponse(managerCtx, t, returnedResponseChan)
+}
+
 func TestCancelManagerExitsGracefully(t *testing.T) {
 	ctx := context.Background()
 	managerCtx, managerCancel := context.WithCancel(ctx)

--- a/responsemanager/client.go
+++ b/responsemanager/client.go
@@ -164,6 +164,8 @@ func (rm *ResponseManager) UnpauseResponse(ctx context.Context, requestID graphs
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
+	case <-ctx.Done():
+		return errors.New("context cancelled")
 	case err := <-response:
 		return err
 	}
@@ -175,6 +177,8 @@ func (rm *ResponseManager) PauseResponse(ctx context.Context, requestID graphsyn
 	rm.send(&pauseRequestMessage{requestID, response}, ctx.Done())
 	select {
 	case <-rm.ctx.Done():
+		return errors.New("context cancelled")
+	case <-ctx.Done():
 		return errors.New("context cancelled")
 	case err := <-response:
 		return err
@@ -188,6 +192,8 @@ func (rm *ResponseManager) CancelResponse(ctx context.Context, requestID graphsy
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
+	case <-ctx.Done():
+		return errors.New("context cancelled")
 	case err := <-response:
 		return err
 	}
@@ -199,6 +205,8 @@ func (rm *ResponseManager) UpdateResponse(ctx context.Context, requestID graphsy
 	rm.send(&updateRequestMessage{requestID, extensions, response}, ctx.Done())
 	select {
 	case <-rm.ctx.Done():
+		return errors.New("context cancelled")
+	case <-ctx.Done():
 		return errors.New("context cancelled")
 	case err := <-response:
 		return err


### PR DESCRIPTION
# Goals

Fix an identified potential lock on imperative public function calls that take a context that can be cancelled.

# Why

The graphsync RequestManager and ResponseManager run an internal run loop in a seperate go-routine. Public function calls access communicate with this run loop via a message queue channel. Sometimes these public function calls wait for a response on a channel, in order to return a value to the caller. When this is done, the message send into the run loop can abort if the calling context passed to the public method is cancelled. However, we were failing to account for this context when reading back out the response, which could cause a hang if the context passed into the public function is already cancelled at the time of calling. We found this did crop up in the wild.

# Implementation

Add a calling context cancel check on the select statements in every place where we read a return value

# For discussion

Contexts and channels suck and boy this code is verbose when can we use generics.

This is PR'd against a 0.13.3 release branch forked from v0.13.2 to avoid 0.14.x changes that are for go-data-transfer v2