### PR TITLE
Removes `main` branch callout.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,3 @@
-***go-graphsync's default branch is now `main`***
-
-To update your local repository run:
-```
-git branch -m master main
-git fetch origin
-git branch -u origin/main main
-git remote set-head origin -a
-```
-
 # go-graphsync
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)


### PR DESCRIPTION
It's been at least two years since the _checkout to `main`_ instructions were added. I think it's safe to say that folks have switched over their branches by now. It's also commonplace for the primary branch of a repo to be `main` instead of `master`, so calling out this change is likely moot.

Edit: this is the silliest, most nit-picky of PRs, so feel free to ignore and close.