### PR TITLE
fix: wire up proper linksystem to traverser

### DIFF
--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -157,7 +157,7 @@ func (rm *RequestManager) requestTask(requestID graphsync.RequestID) executor.Re
 				return nil
 			},
 			Chooser:       ipr.nodeStyleChooser,
-			LinkSystem:    rm.linkSystem,
+			LinkSystem:    *ipr.lsys,
 			Budget:        budget,
 			PanicCallback: rm.panicCallback,
 		}.Start(ctx)


### PR DESCRIPTION
Was missed in https://github.com/ipfs/go-graphsync/pull/356

This doesn't break anything obvious because the loader isn't used from the traverser's linksystem, and the traverser sets up defaults where the provided linksystem is missing them. But, we don't get certain things, like KnownReifiers, which are kind of important.