### PR TITLE
fix: shutdown queue on publish error if not done

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -245,7 +245,13 @@ func (mq *MessageQueue) sendMessage() {
 		log.Infof("cant open message sender to peer %s: %s", mq.p, err)
 		// TODO: cant connect, what now?
 		mq.publishError(metadata, fmt.Errorf("cant open message sender to peer %s: %w", mq.p, err))
-		return
+		select {
+		case <-mq.done:
+			return
+		default:
+			mq.Shutdown()
+			return
+		}
 	}
 
 	for i := 0; i < mq.maxRetries; i++ { // try to send this message until we fail.
@@ -377,12 +383,4 @@ func (mq *MessageQueue) publishError(metadata internalMetadata, err error) {
 	mq.scrubResponseStreams(metadata.responseStreams)
 	mq.eventPublisher.Publish(metadata.topic, Event{Name: Error, Err: err, Metadata: metadata.public})
 	_ = mq.allocator.ReleaseBlockMemory(mq.p, metadata.msgSize)
-
-	select {
-	case <-mq.done:
-		return
-	default:
-		mq.Shutdown()
-		return
-	}
 }

--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -377,4 +377,12 @@ func (mq *MessageQueue) publishError(metadata internalMetadata, err error) {
 	mq.scrubResponseStreams(metadata.responseStreams)
 	mq.eventPublisher.Publish(metadata.topic, Event{Name: Error, Err: err, Metadata: metadata.public})
 	_ = mq.allocator.ReleaseBlockMemory(mq.p, metadata.msgSize)
+
+	select {
+	case <-mq.done:
+		return
+	default:
+		mq.Shutdown()
+		return
+	}
 }


### PR DESCRIPTION
## Summary
This is a patch on top of 0.13.2. While debugging network disconnect issues in [Boost](https://github.com/filecoin-project/boost) during retrieval we discovered a leak in go-routines for graphsync. The issue is that a hard network disconnect may still result in the MessageQueue being restarted if there are messages the server is still attempting to send.

This change does not fully fix the issue but after multiple runs of force disconnecting 500 retrievals, we saw a 10x reduction in open goroutines. More robust handling for hard network disconnects may be warranted in the 0.14.x line, but that is also likely a non trivial effort. This gets us most of the way.

## Goroutine dumps from boost
_The below were goroutine diffs between startup and after executing 500 forceful disconnects._

**Before**
![image](https://user-images.githubusercontent.com/639834/223524711-97508e00-22d1-4e23-ad4c-422b026a53dd.png)

**After**
![image](https://user-images.githubusercontent.com/639834/223524832-dbaa5920-f854-47b4-9778-d7abe4c6fdca.png)

