### PR TITLE
fix: calling message queue Shutdown twice causes panic

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -68,6 +68,7 @@ type MessageQueue struct {
 
 	outgoingWork chan struct{}
 	done         chan struct{}
+	doneOnce     sync.Once
 
 	// internal do not touch outside go routines
 	sender             gsnet.MessageSender
@@ -144,7 +145,9 @@ func (mq *MessageQueue) Startup() {
 
 // Shutdown stops the processing of messages for a message queue.
 func (mq *MessageQueue) Shutdown() {
-	close(mq.done)
+	mq.doneOnce.Do(func() {
+		close(mq.done)
+	})
 }
 
 func (mq *MessageQueue) runQueue() {


### PR DESCRIPTION
The panic is caused because close is called twice on the `done` channel

This can occur now because a new code path to calling `Shutdown` was introduced in https://github.com/ipfs/go-graphsync/pull/412

An example:
```
panic: close of closed channel

goroutine 9631156 [running]:
github.com/ipfs/go-graphsync/messagequeue.(*MessageQueue).Shutdown(0xc000cc74c8?)
        /home/stuart/go/pkg/mod/github.com/ipfs/go-graphsync@v0.13.3/messagequeue/messagequeue.go:147 +0x1d
github.com/ipfs/go-graphsync/peermanager.(*PeerManager).Disconnected(0xc000cc74c0, {0xc0101003c0, 0x26})
        /home/stuart/go/pkg/mod/github.com/ipfs/go-graphsync@v0.13.3/peermanager/peermanager.go:82 +0xce
github.com/ipfs/go-graphsync/impl.(*graphSyncReceiver).Disconnected(0xc0021e5380?, {0xc0101003c0?, 0x18f2880?})
        /home/stuart/go/pkg/mod/github.com/ipfs/go-graphsync@v0.13.3/impl/graphsync.go:515 +0x28
github.com/ipfs/go-graphsync/network.(*libp2pGraphSyncNotifee).Disconnected(0xc0001ecfb8?, {0x4402b00?, 0xc0001ecf78?}, {0x5a3ca80?, 0xc02621e480?})
        /home/stuart/go/pkg/mod/github.com/ipfs/go-graphsync@v0.13.3/network/libp2p_impl.go:277 +0x58
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).doClose.func1.1({0x5a28810?, 0xc0008290e0?})
        /home/stuart/go/pkg/mod/github.com/libp2p/go-libp2p@v0.23.4/p2p/net/swarm/swarm_conn.go:86 +0x3d
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Swarm).notifyAll(0xc000908340, 0xc01b49bfb8)
        /home/stuart/go/pkg/mod/github.com/libp2p/go-libp2p@v0.23.4/p2p/net/swarm/swarm.go:573 +0xa2
github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).doClose.func1()
        /home/stuart/go/pkg/mod/github.com/libp2p/go-libp2p@v0.23.4/p2p/net/swarm/swarm_conn.go:85 +0xa8
created by github.com/libp2p/go-libp2p/p2p/net/swarm.(*Conn).doClose
        /home/stuart/go/pkg/mod/github.com/libp2p/go-libp2p@v0.23.4/p2p/net/swarm/swarm_conn.go:80 +0x18b
```