### PR TITLE
Revert "Bring changes from #412"

### DIFF
--- a/messagequeue/messagequeue.go
+++ b/messagequeue/messagequeue.go
@@ -248,11 +248,6 @@ func (mq *MessageQueue) sendMessage() {
 		log.Infof("cant open message sender to peer %s: %s", mq.p, err)
 		// TODO: cant connect, what now?
 		mq.publishError(metadata, fmt.Errorf("cant open message sender to peer %s: %w", mq.p, err))
-		select {
-		case <-mq.done:
-		default:
-			mq.Shutdown()
-		}
 		return
 	}
 


### PR DESCRIPTION
# Goals

This commit is the source of the problems in go-data-transfer tests. ( https://github.com/filecoin-project/go-data-transfer/pull/373, https://github.com/filecoin-project/go-data-transfer/pull/374 )

I'm not sure I want to merge this, as #412 also fixes a memory leak. The short version of the problem is: 412 contains a pretty serious problem where it shuts down the message queue, but fails to tell the peer manager to remove it, so if a reconnect happens, the peer manager may never realize the queue shutdown, and send messages to a shutdown queue. This is bad cause I think theoretically Boost's version can break a node-disconnect-reconnect from ever sending messages.

cc: @jacobheun who wrote original PR.