### PR TITLE
Fix shutdown bug in #412

### DIFF
--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -237,8 +237,8 @@ func New(parent context.Context, network gsnet.GraphSyncNetwork,
 		incomingRequestHooks.Register(selectorvalidator.SelectorValidator(maxRecursionDepth))
 	}
 	responseAllocator := allocator.NewAllocator(gsConfig.totalMaxMemoryResponder, gsConfig.maxMemoryPerPeerResponder)
-	createMessageQueue := func(ctx context.Context, p peer.ID) peermanager.PeerQueue {
-		return messagequeue.New(ctx, p, network, responseAllocator, gsConfig.messageSendRetries, gsConfig.sendMessageTimeout)
+	createMessageQueue := func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) peermanager.PeerQueue {
+		return messagequeue.New(ctx, p, network, responseAllocator, gsConfig.messageSendRetries, gsConfig.sendMessageTimeout, onShutdown)
 	}
 	peerManager := peermanager.NewMessageManager(ctx, createMessageQueue)
 

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -1039,6 +1039,20 @@ func TestNetworkDisconnect(t *testing.T) {
 	drain(requestor)
 	drain(responder)
 
+	// verify we can execute a request after disconnection
+	_, err = td.mn.LinkPeers(td.host1.ID(), td.host2.ID())
+	require.NoError(t, err)
+	_, err = td.mn.ConnectPeers(td.host1.ID(), td.host2.ID())
+	require.NoError(t, err)
+	requestCtx, requestCancel = context.WithTimeout(ctx, 1*time.Second)
+	defer requestCancel()
+	progressChan, errChan = requestor.Request(requestCtx, td.host2.ID(), blockChain.TipLink, blockChain.Selector(), td.extension)
+	blockChain.VerifyWholeChain(ctx, progressChan)
+	testutil.VerifyEmptyErrors(ctx, t, errChan)
+
+	drain(requestor)
+	drain(responder)
+
 	tracing := collectTracing(t)
 
 	traceStrings := tracing.TracesToStrings()

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -523,7 +523,7 @@ func TestGraphsyncRoundTripIgnoreNBlocks(t *testing.T) {
 
 	// create network
 	ctx, collectTracing := testutil.SetupTracing(context.Background())
-	ctx, cancel := context.WithTimeout(ctx, 1*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
 	td := newGsTestData(ctx, t)
 

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -118,10 +118,5 @@ func (pm *PeerManager) getOrCreate(p peer.ID) *peerProcessInstance {
 func (pm *PeerManager) onQueueShutdown(p peer.ID) {
 	pm.peerProcessesLk.Lock()
 	defer pm.peerProcessesLk.Unlock()
-	_, ok := pm.peerProcesses[p]
-	if !ok {
-
-		return
-	}
 	delete(pm.peerProcesses, p)
 }

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -16,7 +16,7 @@ type PeerProcess interface {
 type PeerHandler interface{}
 
 // PeerProcessFactory provides a function that will create a PeerQueue.
-type PeerProcessFactory func(ctx context.Context, p peer.ID) PeerHandler
+type PeerProcessFactory func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerHandler
 
 type peerProcessInstance struct {
 	refcnt  int
@@ -105,7 +105,7 @@ func (pm *PeerManager) GetProcess(
 func (pm *PeerManager) getOrCreate(p peer.ID) *peerProcessInstance {
 	pqi, ok := pm.peerProcesses[p]
 	if !ok {
-		pq := pm.createPeerProcess(pm.ctx, p)
+		pq := pm.createPeerProcess(pm.ctx, p, pm.onQueueShutdown)
 		if pprocess, ok := pq.(PeerProcess); ok {
 			pprocess.Startup()
 		}
@@ -113,4 +113,15 @@ func (pm *PeerManager) getOrCreate(p peer.ID) *peerProcessInstance {
 		pm.peerProcesses[p] = pqi
 	}
 	return pqi
+}
+
+func (pm *PeerManager) onQueueShutdown(p peer.ID) {
+	pm.peerProcessesLk.Lock()
+	defer pm.peerProcessesLk.Unlock()
+	_, ok := pm.peerProcesses[p]
+	if !ok {
+
+		return
+	}
+	delete(pm.peerProcesses, p)
 }

--- a/peermanager/peermanager_test.go
+++ b/peermanager/peermanager_test.go
@@ -17,7 +17,7 @@ func (fp *fakePeerProcess) Shutdown() {}
 
 func TestAddingAndRemovingPeers(t *testing.T) {
 	ctx := context.Background()
-	peerProcessFatory := func(ctx context.Context, p peer.ID) PeerHandler {
+	peerProcessFatory := func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerHandler {
 		return &fakePeerProcess{}
 	}
 

--- a/peermanager/peermessagemanager.go
+++ b/peermanager/peermessagemanager.go
@@ -15,7 +15,7 @@ type PeerQueue interface {
 }
 
 // PeerQueueFactory provides a function that will create a PeerQueue.
-type PeerQueueFactory func(ctx context.Context, p peer.ID) PeerQueue
+type PeerQueueFactory func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerQueue
 
 // PeerMessageManager manages message queues for peers
 type PeerMessageManager struct {
@@ -25,8 +25,8 @@ type PeerMessageManager struct {
 // NewMessageManager generates a new manger for sending messages
 func NewMessageManager(ctx context.Context, createPeerQueue PeerQueueFactory) *PeerMessageManager {
 	return &PeerMessageManager{
-		PeerManager: New(ctx, func(ctx context.Context, p peer.ID) PeerHandler {
-			return createPeerQueue(ctx, p)
+		PeerManager: New(ctx, func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerHandler {
+			return createPeerQueue(ctx, p, onShutdown)
 		}),
 	}
 }

--- a/peermanager/peermessagemanager_test.go
+++ b/peermanager/peermessagemanager_test.go
@@ -27,6 +27,7 @@ var _ PeerQueue = (*fakePeer)(nil)
 type fakePeer struct {
 	p            peer.ID
 	messagesSent chan messageSent
+	onShutdown   func(peer.ID)
 }
 
 func (fp *fakePeer) AllocateAndBuildMessage(blkSize uint64, buildMessage func(b *messagequeue.Builder)) {
@@ -50,10 +51,11 @@ func (fp *fakePeer) Shutdown() {}
 //}
 
 func makePeerQueueFactory(messagesSent chan messageSent) PeerQueueFactory {
-	return func(ctx context.Context, p peer.ID) PeerQueue {
+	return func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerQueue {
 		return &fakePeer{
 			p:            p,
 			messagesSent: messagesSent,
+			onShutdown:   onShutdown,
 		}
 	}
 }

--- a/responsemanager/responseassembler/responseassembler.go
+++ b/responsemanager/responseassembler/responseassembler.go
@@ -69,7 +69,7 @@ type ResponseAssembler struct {
 // New generates a new ResponseAssembler for sending responses
 func New(ctx context.Context, peerHandler PeerMessageHandler) *ResponseAssembler {
 	return &ResponseAssembler{
-		PeerManager: peermanager.New(ctx, func(ctx context.Context, p peer.ID) peermanager.PeerHandler {
+		PeerManager: peermanager.New(ctx, func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) peermanager.PeerHandler {
 			return newTracker()
 		}),
 		peerHandler: peerHandler,


### PR DESCRIPTION
# Goals

This resolves the problem created by #412, without reverting the change that created a memory error.

Essentially the problem is the queue is shut down without being removed from the peer manager, which continues to send it messages, that have no effect. This change adds a hook so that the queue itself can notify the peer manager it's been shutdown.
