### PR TITLE
Cleanup README, add prod configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ The above provides both immediate and relevant metadata for matching nodes in a 
 
 ## Production Configuration
 
-go-graphsync supports a number of configuration options. Each configuration option is documented in [the code](./impl/graphsync.go). The default configuration is not well setup for production clients or servers serving high traffic volumes. The following is a sample configuration more appropriate to production environments with heavy load:
+go-graphsync supports a number of configuration options. Each configuration option is documented in [the code](./impl/graphsync.go). The default configuration is not well setup for production clients or servers serving high traffic volumes. We supply a default set of "production defaults" that are more appropriately suited to this use case. You can use them as such:
 
 ```golang
 import (
-  gsimpl "github.com/ipfs/go-graphsync/impl"
+  graphsync "github.com/ipfs/go-graphsync/impl"
   gsnet "github.com/ipfs/go-graphsync/network"
   ipld "github.com/ipld/go-ipld-prime"
 )
@@ -134,18 +134,10 @@ var host libp2p.Host
 var lsys ipld.LinkSystem
 
 network := gsnet.NewFromLibp2pHost(host)
-exchange := gsimpl.New(ctx, network, lsys,
-			gsimpl.MaxInProgressIncomingRequests(200),
-			gsimpl.MaxInProgressOutgoingRequests(200),
-			gsimpl.MaxMemoryResponder(8 << 30),
-			gsimpl.MaxMemoryPerPeerResponder(32 << 20),
-			gsimpl.MaxInProgressIncomingRequestsPerPeer(20),
-			gsimpl.MessageSendRetries(2),
-			gsimpl.SendMessageTimeout(2 * time.Minute),
-			gsimpl.MaxLinksPerIncomingRequests(32 * (1 << 20)),
-			gsimpl.MaxLinksPerOutgoingRequests(32 * (1 << 20)),
-)
+exchange := graphsync.New(ctx, network, lsys, graphsync.ProductionDefaults)
 ```
+
+If you are running GraphSync in a production environment, it is recommended to take time to understand configuration settings and adjust them appropriately for your particular use case.
 
 ## Contribute
 

--- a/impl/graphsync.go
+++ b/impl/graphsync.go
@@ -200,6 +200,20 @@ func PanicCallback(callbackFn panics.CallBackFn) Option {
 	}
 }
 
+// ProductionDefaults are a set of alternate defaults for clients and servers
+// with large resources that want to serve heavy loads
+var ProductionDefaults = func(gs *graphsyncConfigOptions) {
+	MaxInProgressIncomingRequests(200)(gs)
+	MaxInProgressOutgoingRequests(200)(gs)
+	MaxMemoryResponder(8 << 30)(gs)
+	MaxMemoryPerPeerResponder(32 << 20)(gs)
+	MaxInProgressIncomingRequestsPerPeer(20)(gs)
+	MessageSendRetries(2)(gs)
+	SendMessageTimeout(2 * time.Minute)(gs)
+	MaxLinksPerIncomingRequests(32 * (1 << 20))(gs)
+	MaxLinksPerOutgoingRequests(32 * (1 << 20))(gs)
+}
+
 // New creates a new GraphSync Exchange on the given network,
 // and the given link loader+storer.
 func New(parent context.Context, network gsnet.GraphSyncNetwork,


### PR DESCRIPTION
# Goals

This came about cause we found some high volume clients were using the default config and having poor results because of it. 

Felt like we should document this issue and provide some sensible defaults.

# Implementation

- add production config section
- also cleaned up some old references
- added a set of defaults for prod configs
