### PR TITLE
Handle context cancellation properly

### DIFF
--- a/requestmanager/client.go
+++ b/requestmanager/client.go
@@ -187,12 +187,13 @@ func (rm *RequestManager) NewRequest(ctx context.Context,
 
 	inProgressRequestChan := make(chan inProgressRequest)
 
-	rm.send(&newRequestMessage{requestID, span, p, root, selectorNode, extensions, inProgressRequestChan}, ctx.Done())
+	err := rm.send(&newRequestMessage{requestID, span, p, root, selectorNode, extensions, inProgressRequestChan}, ctx.Done())
+	if err != nil {
+		return rm.emptyResponse()
+	}
 	var receivedInProgressRequest inProgressRequest
 	select {
 	case <-rm.ctx.Done():
-		return rm.emptyResponse()
-	case <-ctx.Done():
 		return rm.emptyResponse()
 	case receivedInProgressRequest = <-inProgressRequestChan:
 	}
@@ -283,12 +284,13 @@ func (rm *RequestManager) cancelRequestAndClose(requestID graphsync.RequestID,
 // CancelRequest cancels the given request ID and waits for the request to terminate
 func (rm *RequestManager) CancelRequest(ctx context.Context, requestID graphsync.RequestID) error {
 	terminated := make(chan error, 1)
-	rm.send(&cancelRequestMessage{requestID, terminated, graphsync.RequestClientCancelledErr{}}, ctx.Done())
+	err := rm.send(&cancelRequestMessage{requestID, terminated, graphsync.RequestClientCancelledErr{}}, ctx.Done())
+	if err != nil {
+		return err
+	}
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
-	case <-ctx.Done():
-		return ctx.Err()
 	case err := <-terminated:
 		return err
 	}
@@ -300,19 +302,20 @@ func (rm *RequestManager) ProcessResponses(p peer.ID,
 	responses []gsmsg.GraphSyncResponse,
 	blks []blocks.Block) {
 
-	rm.send(&processResponsesMessage{p, responses, blks}, nil)
+	_ = rm.send(&processResponsesMessage{p, responses, blks}, nil)
 }
 
 // UnpauseRequest unpauses a request that was paused in a block hook based request ID
 // Can also send extensions with unpause
 func (rm *RequestManager) UnpauseRequest(ctx context.Context, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
 	response := make(chan error, 1)
-	rm.send(&unpauseRequestMessage{requestID, extensions, response}, ctx.Done())
+	err := rm.send(&unpauseRequestMessage{requestID, extensions, response}, ctx.Done())
+	if err != nil {
+		return err
+	}
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
-	case <-ctx.Done():
-		return ctx.Err()
 	case err := <-response:
 		return err
 	}
@@ -321,12 +324,13 @@ func (rm *RequestManager) UnpauseRequest(ctx context.Context, requestID graphsyn
 // PauseRequest pauses an in progress request (may take 1 or more blocks to process)
 func (rm *RequestManager) PauseRequest(ctx context.Context, requestID graphsync.RequestID) error {
 	response := make(chan error, 1)
-	rm.send(&pauseRequestMessage{requestID, response}, ctx.Done())
+	err := rm.send(&pauseRequestMessage{requestID, response}, ctx.Done())
+	if err != nil {
+		return err
+	}
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
-	case <-ctx.Done():
-		return ctx.Err()
 	case err := <-response:
 		return err
 	}
@@ -335,12 +339,13 @@ func (rm *RequestManager) PauseRequest(ctx context.Context, requestID graphsync.
 // UpdateRequest updates an in progress request
 func (rm *RequestManager) UpdateRequest(ctx context.Context, requestID graphsync.RequestID, extensions ...graphsync.ExtensionData) error {
 	response := make(chan error, 1)
-	rm.send(&updateRequestMessage{requestID, extensions, response}, ctx.Done())
+	err := rm.send(&updateRequestMessage{requestID, extensions, response}, ctx.Done())
+	if err != nil {
+		return err
+	}
 	select {
 	case <-rm.ctx.Done():
 		return errors.New("context cancelled")
-	case <-ctx.Done():
-		return ctx.Err()
 	case err := <-response:
 		return err
 	}
@@ -348,13 +353,13 @@ func (rm *RequestManager) UpdateRequest(ctx context.Context, requestID graphsync
 
 // GetRequestTask gets data for the given task in the request queue
 func (rm *RequestManager) GetRequestTask(p peer.ID, task *peertask.Task, requestExecutionChan chan executor.RequestTask) {
-	rm.send(&getRequestTaskMessage{p, task, requestExecutionChan}, nil)
+	_ = rm.send(&getRequestTaskMessage{p, task, requestExecutionChan}, nil)
 }
 
 // ReleaseRequestTask releases a task request the requestQueue
 func (rm *RequestManager) ReleaseRequestTask(p peer.ID, task *peertask.Task, err error) {
 	done := make(chan struct{}, 1)
-	rm.send(&releaseRequestTaskMessage{p, task, err, done}, nil)
+	_ = rm.send(&releaseRequestTaskMessage{p, task, err, done}, nil)
 	select {
 	case <-rm.ctx.Done():
 	case <-done:
@@ -364,7 +369,7 @@ func (rm *RequestManager) ReleaseRequestTask(p peer.ID, task *peertask.Task, err
 // PeerState gets stats on all outgoing requests for a given peer
 func (rm *RequestManager) PeerState(p peer.ID) peerstate.PeerState {
 	response := make(chan peerstate.PeerState)
-	rm.send(&peerStateMessage{p, response}, nil)
+	_ = rm.send(&peerStateMessage{p, response}, nil)
 	select {
 	case <-rm.ctx.Done():
 		return peerstate.PeerState{}
@@ -392,11 +397,20 @@ func (rm *RequestManager) Shutdown() {
 	rm.cancel()
 }
 
-func (rm *RequestManager) send(message requestManagerMessage, done <-chan struct{}) {
+func (rm *RequestManager) send(message requestManagerMessage, done <-chan struct{}) error {
+	// prioritize cancelled context
+	select {
+	case <-done:
+		return errors.New("unable to send message before cancellation")
+	default:
+	}
 	select {
 	case <-rm.ctx.Done():
+		return rm.ctx.Err()
 	case <-done:
+		return errors.New("unable to send message before cancellation")
 	case rm.messages <- message:
+		return nil
 	}
 }
 

--- a/requestmanager/server.go
+++ b/requestmanager/server.go
@@ -47,6 +47,7 @@ func (rm *RequestManager) run() {
 	for {
 		select {
 		case message := <-rm.messages:
+
 			message.handle(rm)
 		case <-rm.ctx.Done():
 			return
@@ -304,13 +305,13 @@ func (rm *RequestManager) processResponses(p peer.ID,
 	for _, blk := range blks {
 		blkMap[blk.Cid()] = blk.RawData()
 	}
+	rm.updateLastResponses(filteredResponses)
 	for _, response := range filteredResponses {
 		reconciledLoader := rm.inProgressRequestStatuses[response.RequestID()].reconciledLoader
 		if reconciledLoader != nil {
 			reconciledLoader.IngestResponse(response.Metadata(), trace.LinkFromContext(ctx), blkMap)
 		}
 	}
-	rm.updateLastResponses(filteredResponses)
 	rm.processTerminations(filteredResponses)
 	log.Debugf("end processing responses for peer %s", p)
 }


### PR DESCRIPTION
A previous fix #391, attempted to address a lock that occurred when a client facing function was called with a context that was cancelled. However in doing so, this PR introduced a new, potentially more critical lock the request manager/response manager message loop.

The original issue is as follows: if a message was not sent to the requestmanager/responsemanager go routine because the calling context is cancelled, then subsequent code waiting for a response to that message being processed could block indefinitely. 

The previous fix therefore stopped waiting for a response when the calling context cancelled. 

However once a message reaches the go routine of the requestmanager/responsemanager, it's important that it's processed to completion, so that the the message loop doesn't lock. If we stop waiting for a response, the message loop itself can lock trying to send a response to the message.

The proper fix is to detect when the message is sent to the message loop successfully vs aborted due to context cancellation. If it is sent successfully before the calling context cancels, then we need to wait for it to be processed, even if the calling context cancels while it's processed (this should be a miniscule amount of time). If it isn't sent before the context cancels, we can safely abort the go routine immediately.