### PR TITLE
refactor: apply go fix modernizers from Go 1.26

### DIFF
--- a/allocator/allocator_test.go
+++ b/allocator/allocator_test.go
@@ -441,7 +441,7 @@ type pendingResultWithChan struct {
 }
 
 type allocStep struct {
-	op              interface{}
+	op              any
 	totals          map[peer.ID]uint64
 	expectedPending []pendingResult
 }

--- a/benchmarks/benchmark_test.go
+++ b/benchmarks/benchmark_test.go
@@ -101,7 +101,7 @@ func benchmarkRepeatedDisconnects(ctx context.Context, b *testing.B, numnodes in
 		require.NoError(b, err)
 		start := time.Now()
 		errgrp, grpctx := errgroup.WithContext(ctx)
-		for j := 0; j < numnodes; j++ {
+		for j := range numnodes {
 			instance := instances[j+1]
 			_, errChan := fetcher.Exchange.Request(grpctx, instance.Peer, cidlink.Link{Cid: allCids[i][j]}, allSelector)
 			other := instance.Peer
@@ -152,7 +152,7 @@ func p2pStrestTest(ctx context.Context, b *testing.B, numfiles int, df distFunc,
 	instances, err := ig.Instances(1 + b.N)
 	require.NoError(b, err)
 	var allCids []cid.Cid
-	for i := 0; i < numfiles; i++ {
+	for range numfiles {
 		thisCids := df(ctx, b, instances[:1])
 		allCids = append(allCids, thisCids...)
 	}
@@ -170,7 +170,7 @@ func p2pStrestTest(ctx context.Context, b *testing.B, numfiles int, df distFunc,
 		require.NoError(b, err)
 		start := time.Now()
 		errgrp, grpctx := errgroup.WithContext(ctx)
-		for j := 0; j < numfiles; j++ {
+		for j := range numfiles {
 			responseChan, errChan := fetcher.Exchange.Request(grpctx, instances[0].Peer, cidlink.Link{Cid: allCids[j]}, allSelector)
 			errgrp.Go(func() error {
 				for range responseChan {
@@ -223,7 +223,7 @@ func subtestDistributeAndFetch(ctx context.Context, b *testing.B, numnodes int, 
 		require.NoError(b, err)
 		start := time.Now()
 		errgrp, grpctx := errgroup.WithContext(ctx)
-		for j := 0; j < numnodes; j++ {
+		for j := range numnodes {
 			instance := instances[j]
 			_, errChan := fetcher.Exchange.Request(grpctx, instance.Peer, cidlink.Link{Cid: destCids[j]}, allSelector)
 

--- a/benchmarks/testinstance/testinstance.go
+++ b/benchmarks/testinstance/testinstance.go
@@ -73,7 +73,7 @@ func (g *InstanceGenerator) Next() (Instance, error) {
 // them to each other
 func (g *InstanceGenerator) Instances(n int) ([]Instance, error) {
 	var instances []Instance
-	for j := 0; j < n; j++ {
+	for range n {
 		inst, err := g.Next()
 		if err != nil {
 			return nil, err

--- a/benchmarks/testnet/internet_latency_delay_generator_test.go
+++ b/benchmarks/testnet/internet_latency_delay_generator_test.go
@@ -36,7 +36,7 @@ func TestInternetLatencyDelayNextWaitTimeDistribution(t *testing.T) {
 
 	// strategy here is rather than mock randomness, just use enough samples to
 	// get approximately the distribution you'd expect
-	for i := 0; i < 10000; i++ {
+	for range 10000 {
 		next := internetLatencyDistributionDelay.NextWaitTime(initialValue)
 		if math.Abs((next - initialValue).Seconds()) <= deviation.Seconds() {
 			buckets["fast"]++

--- a/benchmarks/testnet/peernet.go
+++ b/benchmarks/testnet/peernet.go
@@ -2,6 +2,7 @@ package testnet
 
 import (
 	"context"
+	"slices"
 
 	tnet "github.com/libp2p/go-libp2p-testing/net"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -32,12 +33,7 @@ func (pn *peernet) Adapter(p tnet.Identity) gsnet.GraphSyncNetwork {
 }
 
 func (pn *peernet) HasPeer(p peer.ID) bool {
-	for _, member := range pn.Mocknet.Peers() {
-		if p == member {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(pn.Mocknet.Peers(), p)
 }
 
 var _ Network = (*peernet)(nil)

--- a/impl/graphsync_test.go
+++ b/impl/graphsync_test.go
@@ -168,7 +168,6 @@ func TestGraphsyncRoundTripRequestBudgets(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			// create network
 			ctx := context.Background()
@@ -439,7 +438,7 @@ func TestGraphsyncRoundTripHooksOrder(t *testing.T) {
 	require.Len(t, td.blockStore1, blockChainLength, "did not store all blocks")
 
 	var calledHooks []string
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		select {
 		case <-ctx.Done():
 			t.Fatal("did not receive all events")
@@ -1970,8 +1969,8 @@ func TestPanicHandlingInTraversal(t *testing.T) {
 	}
 
 	// initialize graphsync on first node to make requests and set a panic callback
-	var panicObj interface{}
-	requestor := td.GraphSyncHost1(PanicCallback(func(recoverObj interface{}, debugStackTrace string) {
+	var panicObj any
+	requestor := td.GraphSyncHost1(PanicCallback(func(recoverObj any, debugStackTrace string) {
 		panicObj = recoverObj
 	}))
 

--- a/ipldutil/traverser_test.go
+++ b/ipldutil/traverser_test.go
@@ -115,7 +115,7 @@ func TestTraverser(t *testing.T) {
 			},
 		}.Start(ctx)
 		var path ipld.Path
-		for i := 0; i < 6; i++ {
+		for range 6 {
 			path = path.AppendSegment(ipld.PathSegmentOfString("Parents"))
 			path = path.AppendSegment(ipld.PathSegmentOfInt(0))
 		}
@@ -155,7 +155,7 @@ func TestTraverser(t *testing.T) {
 
 		var err error
 		// To ensure the state isn't broken, do multiple calls.
-		for i := 0; i < 3; i++ {
+		for range 3 {
 			err = traverser.Advance(bytes.NewBuffer(nil))
 			require.Error(t, err)
 

--- a/message/message.go
+++ b/message/message.go
@@ -3,6 +3,7 @@ package message
 import (
 	"fmt"
 	"io"
+	"maps"
 	"strings"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -256,17 +257,11 @@ func (gsm GraphSyncMessage) Blocks() []blocks.Block {
 // Clone returns a shallow copy of this GraphSyncMessage
 func (gsm GraphSyncMessage) Clone() GraphSyncMessage {
 	requests := make(map[graphsync.RequestID]GraphSyncRequest, len(gsm.requests))
-	for id, request := range gsm.requests {
-		requests[id] = request
-	}
+	maps.Copy(requests, gsm.requests)
 	responses := make(map[graphsync.RequestID]GraphSyncResponse, len(gsm.responses))
-	for id, response := range gsm.responses {
-		responses[id] = response
-	}
+	maps.Copy(responses, gsm.responses)
 	blocks := make(map[cid.Cid]blocks.Block, len(gsm.blocks))
-	for cid, block := range gsm.blocks {
-		blocks[cid] = block
-	}
+	maps.Copy(blocks, gsm.blocks)
 	return GraphSyncMessage{requests, responses, blocks}
 }
 

--- a/message/v2/message_test.go
+++ b/message/v2/message_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"math/rand"
+	"slices"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -146,12 +147,7 @@ func TestAppendBlock(t *testing.T) {
 }
 
 func contains(strs []string, x string) bool {
-	for _, s := range strs {
-		if s == x {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(strs, x)
 }
 
 func TestRequestCancel(t *testing.T) {

--- a/network/libp2p_impl_test.go
+++ b/network/libp2p_impl_test.go
@@ -124,7 +124,7 @@ func TestMessageSendAndReceive(t *testing.T) {
 	require.True(t, found)
 	require.Equal(t, extension.Data, extensionData)
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		testutil.AssertDoesReceive(ctx, t, r.connectedPeers, "peers were not notified")
 	}
 

--- a/notifications/types.go
+++ b/notifications/types.go
@@ -1,13 +1,13 @@
 package notifications
 
 // Topic is a topic that events appear on
-type Topic interface{}
+type Topic any
 
 // Event is a publishable event
-type Event interface{}
+type Event any
 
 // TopicData is data added to every message broadcast on a topic
-type TopicData interface{}
+type TopicData any
 
 // Subscriber is a subscriber that can receive events
 type Subscriber interface {

--- a/panics/panics.go
+++ b/panics/panics.go
@@ -6,15 +6,15 @@ import (
 )
 
 // CallBackFn is a function that will get called with information about the panic
-type CallBackFn func(recoverObj interface{}, debugStackTrace string)
+type CallBackFn func(recoverObj any, debugStackTrace string)
 
 // PanicHandler is a function that can be called with the result of revover() within a deferred
 // to recover from panics and pass them to a callback it returns an error if a recovery was needed
-type PanicHandler func(interface{}) error
+type PanicHandler func(any) error
 
 // MakeHandler makes a handler that recovers from panics and passes them to the given callback
 func MakeHandler(cb CallBackFn) PanicHandler {
-	return func(obj interface{}) error {
+	return func(obj any) error {
 		if obj == nil {
 			return nil
 		}
@@ -33,7 +33,7 @@ func MakeHandler(cb CallBackFn) PanicHandler {
 // The assumption is we want to make sure all of graphsync doesn't go down cause a single block load
 // or selector execution fails
 type RecoveredPanicErr struct {
-	PanicObj        interface{}
+	PanicObj        any
 	DebugStackTrace string
 }
 

--- a/peermanager/peermanager.go
+++ b/peermanager/peermanager.go
@@ -13,7 +13,7 @@ type PeerProcess interface {
 	Shutdown()
 }
 
-type PeerHandler interface{}
+type PeerHandler any
 
 // PeerProcessFactory provides a function that will create a PeerQueue.
 type PeerProcessFactory func(ctx context.Context, p peer.ID, onShutdown func(peer.ID)) PeerHandler

--- a/peerstate/peerstate_test.go
+++ b/peerstate/peerstate_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestDiagnostics(t *testing.T) {
 	requestIDs := make([]graphsync.RequestID, 0, 5)
-	for i := 0; i < 5; i++ {
+	for range 5 {
 		requestIDs = append(requestIDs, graphsync.NewRequestID())
 	}
 	testCases := map[string]struct {

--- a/requestmanager/executor/executor.go
+++ b/requestmanager/executor/executor.go
@@ -212,10 +212,7 @@ func (e *Executor) processResult(rt RequestTask, link datamodel.Link, result typ
 
 func (e *Executor) startRemoteRequest(rt RequestTask) error {
 	request := rt.Request
-	doNotSendFirstBlocks := rt.DoNotSendFirstBlocks
-	if doNotSendFirstBlocks < int64(rt.Traverser.NBlocksTraversed()) {
-		doNotSendFirstBlocks = int64(rt.Traverser.NBlocksTraversed())
-	}
+	doNotSendFirstBlocks := max(rt.DoNotSendFirstBlocks, int64(rt.Traverser.NBlocksTraversed()))
 	if doNotSendFirstBlocks > 0 {
 		doNotSendFirstBlocksData := donotsendfirstblocks.EncodeDoNotSendFirstBlocks(doNotSendFirstBlocks)
 		request = rt.Request.ReplaceExtensions([]graphsync.ExtensionData{{Name: graphsync.ExtensionsDoNotSendFirstBlocks, Data: doNotSendFirstBlocksData}})

--- a/requestmanager/reconciledloader/remotequeue.go
+++ b/requestmanager/reconciledloader/remotequeue.go
@@ -10,7 +10,7 @@ import (
 )
 
 var linkedRemoteItemPool = sync.Pool{
-	New: func() interface{} {
+	New: func() any {
 		return new(remotedLinkedItem)
 	},
 }

--- a/requestmanager/requestmanager_test.go
+++ b/requestmanager/requestmanager_test.go
@@ -1046,7 +1046,7 @@ func (fph *fakePeerHandler) AllocateAndBuildMessage(p peer.ID, blkSize uint64,
 
 func readNNetworkRequests(ctx context.Context, t *testing.T, td *testData, count int) []requestRecord {
 	requestRecords := make(map[graphsync.RequestID]requestRecord, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		var rr requestRecord
 		testutil.AssertReceive(ctx, t, td.requestRecordChan, &rr, fmt.Sprintf("did not receive request %d", i))
 		requestRecords[rr.gsr.ID()] = rr

--- a/requestmanager/responsecollector_test.go
+++ b/requestmanager/responsecollector_test.go
@@ -54,7 +54,7 @@ func TestBufferingResponseProgress(t *testing.T) {
 		require.Equal(t, block.Cid(), testResponse.LastBlock.Link.(cidlink.Link).Cid, "did not store block correctly")
 	}
 
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		var testErr error
 		testutil.AssertReceive(ctx, t, outgoingErrors, &testErr, "should have read from channel but couldn't")
 		if i == 0 {

--- a/responsemanager/queryexecutor/queryexecutor_test.go
+++ b/responsemanager/queryexecutor/queryexecutor_test.go
@@ -298,7 +298,7 @@ func newTestData(t *testing.T, blockCount int, expectedTraverse int) (*testData,
 
 	td.expectedBlocks = make([]*blockData, 0)
 	links := make([]ipld.Link, 0)
-	for i := 0; i < blockCount; i++ {
+	for i := range blockCount {
 		td.expectedBlocks = append(td.expectedBlocks, newRandomBlock(int64(i)))
 		links = append(links, td.expectedBlocks[i].link)
 	}

--- a/responsemanager/responsemanager_test.go
+++ b/responsemanager/responsemanager_test.go
@@ -86,7 +86,7 @@ func TestIncomingQuery(t *testing.T) {
 	responseManager.Startup()
 
 	responseManager.ProcessRequests(td.ctx, td.p, td.requests)
-	for i := 0; i < len(blks); i++ {
+	for range blks {
 		td.assertSendBlock()
 	}
 	td.assertCompleteRequestWith(graphsync.RequestCompletedFull)
@@ -1379,7 +1379,7 @@ func (td *testData) assertReceiveExtensionResponse() {
 }
 
 func (td *testData) verifyNResponsesOnlyProcessing(blockCount int) {
-	for i := 0; i < blockCount; i++ {
+	for range blockCount {
 		testutil.AssertDoesReceive(td.ctx, td.t, td.sentResponses, "should sent block")
 	}
 	testutil.AssertChannelEmpty(td.t, td.sentResponses, "should not send more blocks")
@@ -1388,7 +1388,7 @@ func (td *testData) verifyNResponsesOnlyProcessing(blockCount int) {
 func (td *testData) verifyNResponses(blockCount int) {
 	td.verifyNResponsesOnlyProcessing(blockCount)
 	td.notifyBlockSendsSent()
-	for i := 0; i < blockCount; i++ {
+	for range blockCount {
 		testutil.AssertDoesReceive(td.ctx, td.t, td.blockSends, "should sent block")
 	}
 	testutil.AssertChannelEmpty(td.t, td.blockSends, "should not send more blocks")
@@ -1460,7 +1460,7 @@ func (td *testData) assertNoCompletedResponseStatuses() {
 }
 
 func (td *testData) assertNetworkErrors(err error, count int) {
-	for i := 0; i < count; i++ {
+	for range count {
 		td.assertHasNetworkErrors(err)
 	}
 	testutil.AssertChannelEmpty(td.t, td.networkErrorChan, "should not send more blocks")

--- a/taskqueue/taskqueue.go
+++ b/taskqueue/taskqueue.go
@@ -93,7 +93,7 @@ func (tq *WorkerTaskQueue) WithPeerTopics(p peer.ID, withPeerTopics func(*peertr
 
 // Startup runs the given number of task workers with the given executor
 func (tq *WorkerTaskQueue) Startup(workerCount uint64, executor Executor) {
-	for i := uint64(0); i < workerCount; i++ {
+	for range workerCount {
 		go tq.worker(executor)
 	}
 }

--- a/testutil/channelassertions.go
+++ b/testutil/channelassertions.go
@@ -10,20 +10,20 @@ import (
 
 // AssertReceive verifies that a channel returns a value before the given context closes, and writes into
 // into out, which should be a pointer to the value type
-func AssertReceive(ctx context.Context, t testing.TB, channel interface{}, out interface{}, errorMessage string) {
+func AssertReceive(ctx context.Context, t testing.TB, channel any, out any, errorMessage string) {
 	t.Helper()
 	AssertReceiveFirst(t, channel, out, errorMessage, ctx.Done())
 }
 
 // AssertReceiveFirst verifies that a channel returns a value on the specified channel before the other channels,
 // and writes the value into out, which should be a pointer to the value type
-func AssertReceiveFirst(t testing.TB, channel interface{}, out interface{}, errorMessage string, incorrectChannels ...interface{}) {
+func AssertReceiveFirst(t testing.TB, channel any, out any, errorMessage string, incorrectChannels ...any) {
 	t.Helper()
 	chanValue := reflect.ValueOf(channel)
 	outValue := reflect.ValueOf(out)
 	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
 	require.Contains(t, []reflect.ChanDir{reflect.BothDir, reflect.RecvDir}, chanValue.Type().ChanDir(), "incorrect argument: should pass a receiving channel")
-	require.Equal(t, reflect.Ptr, outValue.Kind(), "incorrect argument: should pass a pointer for out value")
+	require.Equal(t, reflect.Pointer, outValue.Kind(), "incorrect argument: should pass a pointer for out value")
 	require.True(t, chanValue.Type().Elem().AssignableTo(outValue.Elem().Type()), "incorrect argument: out value is incorrect type")
 	var incorrectSelectCases []reflect.SelectCase
 	for _, incorrectChannel := range incorrectChannels {
@@ -47,13 +47,13 @@ func AssertReceiveFirst(t testing.TB, channel interface{}, out interface{}, erro
 }
 
 // AssertDoesReceive verifies that a channel returns some value before the given context closes
-func AssertDoesReceive(ctx context.Context, t testing.TB, channel interface{}, errorMessage string) {
+func AssertDoesReceive(ctx context.Context, t testing.TB, channel any, errorMessage string) {
 	t.Helper()
 	AssertDoesReceiveFirst(t, channel, errorMessage, ctx.Done())
 }
 
 // AssertDoesReceiveFirst asserts that the given channel receives a value before any of the other channels specified
-func AssertDoesReceiveFirst(t testing.TB, channel interface{}, errorMessage string, incorrectChannels ...interface{}) {
+func AssertDoesReceiveFirst(t testing.TB, channel any, errorMessage string, incorrectChannels ...any) {
 	t.Helper()
 	chanValue := reflect.ValueOf(channel)
 	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
@@ -78,7 +78,7 @@ func AssertDoesReceiveFirst(t testing.TB, channel interface{}, errorMessage stri
 }
 
 // AssertChannelEmpty verifies that a channel has no value currently
-func AssertChannelEmpty(t testing.TB, channel interface{}, errorMessage string) {
+func AssertChannelEmpty(t testing.TB, channel any, errorMessage string) {
 	t.Helper()
 	chanValue := reflect.ValueOf(channel)
 	require.Equal(t, reflect.Chan, chanValue.Kind(), "incorrect argument: should pass channel to read from")
@@ -96,7 +96,7 @@ func AssertChannelEmpty(t testing.TB, channel interface{}, errorMessage string) 
 }
 
 // AssertSends attempts to send the given input value to the given channel before the given context closes
-func AssertSends(ctx context.Context, t testing.TB, channel interface{}, in interface{}, errorMessage string) {
+func AssertSends(ctx context.Context, t testing.TB, channel any, in any, errorMessage string) {
 	t.Helper()
 	chanValue := reflect.ValueOf(channel)
 	inValue := reflect.ValueOf(in)

--- a/testutil/testchain.go
+++ b/testutil/testchain.go
@@ -156,7 +156,7 @@ func (tbc *TestBlockChain) NodeTipIndex(fromTip int) ipld.Node {
 // PathTipIndex returns the path to the block at the given index from the tip
 func (tbc *TestBlockChain) PathTipIndex(fromTip int) ipld.Path {
 	expectedPath := make([]datamodel.PathSegment, 0, 2*fromTip)
-	for i := 0; i < fromTip; i++ {
+	for range fromTip {
 		expectedPath = append(expectedPath, datamodel.PathSegmentOfString("Parents"), datamodel.PathSegmentOfInt(0))
 	}
 	return datamodel.NewPath(expectedPath)

--- a/testutil/testconnmanager.go
+++ b/testutil/testconnmanager.go
@@ -1,6 +1,7 @@
 package testutil
 
 import (
+	"slices"
 	"sync"
 	"testing"
 
@@ -24,10 +25,8 @@ func NewTestConnManager() *TestConnManager {
 func (tcm *TestConnManager) Protect(p peer.ID, tag string) {
 	tcm.protectedConnsLk.Lock()
 	defer tcm.protectedConnsLk.Unlock()
-	for _, tagCmp := range tcm.protectedConns[p] {
-		if tag == tagCmp {
-			return
-		}
+	if slices.Contains(tcm.protectedConns[p], tag) {
+		return
 	}
 	tcm.protectedConns[p] = append(tcm.protectedConns[p], tag)
 }

--- a/testutil/testnotifications.go
+++ b/testutil/testnotifications.go
@@ -72,7 +72,7 @@ func (ts *TestSubscriber) ExpectClosesAnyOrder(ctx context.Context, t *testing.T
 
 func (ts *TestSubscriber) ExpectNCloses(ctx context.Context, t *testing.T, n int) {
 	t.Helper()
-	for i := 0; i < n; i++ {
+	for range n {
 		AssertDoesReceive(ctx, t, ts.closed, "should receive another event")
 	}
 }

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"math/rand"
+	"slices"
 	"testing"
 
 	blocks "github.com/ipfs/go-block-format"
@@ -18,12 +19,7 @@ import (
 
 // ContainsPeer returns true if a peer is found n a list of peers.
 func ContainsPeer(peers []peer.ID, p peer.ID) bool {
-	for _, n := range peers {
-		if p == n {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(peers, p)
 }
 
 // AssertContainsPeer will fail a test if the peer is not in the given peer list
@@ -105,7 +101,7 @@ func CollectErrors(ctx context.Context, t *testing.T, errChan <-chan error) []er
 func ReadNResponses(ctx context.Context, t testing.TB, responseChan <-chan graphsync.ResponseProgress, count int) []graphsync.ResponseProgress {
 	t.Helper()
 	var returnedBlocks []graphsync.ResponseProgress
-	for i := 0; i < count; i++ {
+	for range count {
 		select {
 		case blk, ok := <-responseChan:
 			if !ok {

--- a/testutil/tracing.go
+++ b/testutil/tracing.go
@@ -211,7 +211,7 @@ func EventAsException(t *testing.T, evt trace.Event) ExceptionEvent {
 
 func RepeatTraceStrings(tmpl string, count int) []string {
 	res := make([]string, 0, count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		res = append(res, strings.Replace(tmpl, "{}", fmt.Sprintf("%d", i), 1))
 	}
 	return res


### PR DESCRIPTION
This PR applies automated refactoring from go 1.26 (go fix ./...):

- `interface{}` to `any`, `slices.Contains`, `range` loops, `maps.Copy`, and other idiomatic updates.